### PR TITLE
Make the Attack paths graph interactive and educational

### DIFF
--- a/internal/report/glossary.go
+++ b/internal/report/glossary.go
@@ -1,0 +1,399 @@
+// Package report — glossary and explainer copy used by the interactive attack-graph in the HTML
+// report. This is presentation-layer content: it deliberately does not live on models.Finding so
+// it stays out of JSON/CSV/SARIF outputs, and lets us iterate on copy without re-running scans.
+//
+// All HTML strings are rendered into a self-contained report — no remote assets, no <script>
+// content, only inline markup for typography (<code>, <strong>, <em>, <p>).
+package report
+
+import (
+	"html/template"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+// GlossaryEntry teaches one Kubernetes concept that appears as an entry-point or capability node
+// in the attack graph. Short feeds tooltips; Long renders into the side-panel detail view.
+type GlossaryEntry struct {
+	Title  string        `json:"Title"`
+	Short  string        `json:"Short"`
+	Long   template.HTML `json:"Long"`
+	DocURL string        `json:"DocURL,omitempty"`
+}
+
+// TechniqueExplainer describes one attacker technique in plain language. Plain renders as HTML
+// in the side-panel; AttackerSteps is rendered as an ordered list ("here is what an attacker
+// would actually run, in order").
+type TechniqueExplainer struct {
+	Title         string        `json:"Title"`
+	Plain         template.HTML `json:"Plain"`
+	Mitre         string        `json:"Mitre,omitempty"`
+	AttackerSteps []string      `json:"AttackerSteps,omitempty"`
+}
+
+// CategoryExplainer is the impact-lane copy. Plain explains what the category means in
+// concrete terms; Examples lists real-world manifestations a reader can picture.
+type CategoryExplainer struct {
+	Title    string        `json:"Title"`
+	Plain    template.HTML `json:"Plain"`
+	Examples []string      `json:"Examples,omitempty"`
+}
+
+// Glossary maps a stable key (subject Kind, resource Kind, or k8s concept name) to its
+// teaching entry. Keys must match the GlossaryKey set on GraphNodeDetail at build time.
+var Glossary = map[string]GlossaryEntry{
+	"ServiceAccount": {
+		Title:  "ServiceAccount",
+		Short:  "An identity used by pods (not humans) to call the Kubernetes API.",
+		Long:   template.HTML(`<p>A <strong>ServiceAccount</strong> is an in-cluster identity assigned to pods. Every pod gets a token mounted at <code>/var/run/secrets/kubernetes.io/serviceaccount/token</code> — that token <em>is</em> the credential. If an attacker reads that file from inside a compromised container (or creates a pod that mounts the token), they can call the API <em>as</em> the ServiceAccount, with whatever permissions the SA has been granted.</p><p>This is the most common pivot in real-world Kubernetes attacks: compromise one pod, steal its token, ride the token to wherever its RBAC allows.</p>`),
+		DocURL: "https://kubernetes.io/docs/concepts/security/service-accounts/",
+	},
+	"Group": {
+		Title:  "Group",
+		Short:  "A label attached to authenticated identities — e.g. system:masters acts as cluster-admin.",
+		Long:   template.HTML(`<p>A <strong>Group</strong> is a string label associated with users or ServiceAccounts at authentication time. RoleBindings can target groups, so <em>everyone</em> in the group inherits the bound permissions. Two groups deserve special care:</p><ul><li><code>system:masters</code> — hardcoded as cluster-admin. Membership is permanent (you cannot un-grant it via RBAC).</li><li><code>system:authenticated</code> — every authenticated identity. Bind anything sensitive to this and you grant it to the world.</li></ul><p>Groups are assigned by the authenticator (OIDC claims, certificate organization fields, etc.), not stored in the API server, which means they don't appear in <code>kubectl get</code>.</p>`),
+		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings",
+	},
+	"User": {
+		Title:  "User",
+		Short:  "A human (or external automation) authenticated by certs, OIDC, or static tokens.",
+		Long:   template.HTML(`<p>A <strong>User</strong> in Kubernetes is whoever the authenticator says they are — there is no User object in the API. Identity comes from a client certificate's CN, an OIDC <code>sub</code> claim, a webhook, or a static token. RBAC then targets that identity by name. If you see "User foo" in a finding, foo is whatever string the authentication layer produced.</p>`),
+		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/authentication/",
+	},
+	"Pod": {
+		Title:  "Pod",
+		Short:  "The smallest schedulable unit — one or more containers sharing a network and storage namespace.",
+		Long:   template.HTML(`<p>A <strong>Pod</strong> wraps one or more containers that share an IP, hostname, and volumes. From an attacker's perspective, a pod is a foothold: the API token mounted into it grants the pod's ServiceAccount permissions; if the pod is privileged or mounts the host filesystem, it's also a path to escape onto the node.</p>`),
+		DocURL: "https://kubernetes.io/docs/concepts/workloads/pods/",
+	},
+	"Deployment": {
+		Title:  "Deployment",
+		Short:  "A controller that keeps N copies of a pod running, with rolling updates.",
+		Long:   template.HTML(`<p>A <strong>Deployment</strong> manages a ReplicaSet which manages Pods. The dangerous attribute lives on the pod template: every replica inherits the same ServiceAccount, the same securityContext, and the same volume mounts. A risky pod template multiplies into N risky pods.</p>`),
+		DocURL: "https://kubernetes.io/docs/concepts/workloads/controllers/deployment/",
+	},
+	"DaemonSet": {
+		Title: "DaemonSet",
+		Short: "Runs a copy of a pod on every node (often privileged — log collectors, CNI agents).",
+		Long:  template.HTML(`<p>A <strong>DaemonSet</strong> schedules one pod per node, typically for cluster infrastructure (CNI, log shipping, node monitoring). DaemonSets are frequent targets because they often need <code>hostNetwork</code>, <code>hostPath</code>, or <code>privileged</code> to do their job — which makes them ideal for attackers if compromised.</p>`),
+	},
+	"StatefulSet": {
+		Title: "StatefulSet",
+		Short: "Pods with stable identities and persistent storage — databases, queues.",
+		Long:  template.HTML(`<p>A <strong>StatefulSet</strong> gives each pod a stable DNS name and dedicated PersistentVolume. Compromise here often means access to durable application data — databases, message queues, caches.</p>`),
+	},
+	"ReplicaSet": {
+		Title: "ReplicaSet",
+		Short: "Maintains a stable set of pod replicas. Usually managed by a Deployment.",
+		Long:  template.HTML(`<p>A <strong>ReplicaSet</strong> keeps a target number of identical pods running. You normally don't manage these directly — a Deployment owns them.</p>`),
+	},
+	"Job": {
+		Title: "Job",
+		Short: "Runs a pod (or pods) to completion — batch tasks, migrations.",
+		Long:  template.HTML(`<p>A <strong>Job</strong> executes one or more pods that must complete successfully. Jobs are a common attacker mechanism for one-shot privilege use ("create a Job that mounts the host filesystem, do the thing, exit").</p>`),
+	},
+	"Secret": {
+		Title:  "Secret",
+		Short:  "Stores credentials — TLS keys, registry creds, API tokens, ServiceAccount tokens.",
+		Long:   template.HTML(`<p>A <strong>Secret</strong> holds sensitive data: registry pull credentials, TLS private keys, ServiceAccount tokens. Secrets are base64-encoded, <em>not</em> encrypted by default — anyone with <code>get</code> on the Secret resource can read the contents in cleartext. <code>get</code>/<code>list</code>/<code>watch</code> on Secrets in <code>kube-system</code> is effectively cluster-admin: that namespace holds the controller-manager and kube-scheduler tokens.</p>`),
+		DocURL: "https://kubernetes.io/docs/concepts/configuration/secret/",
+	},
+	"ConfigMap": {
+		Title: "ConfigMap",
+		Short: "Non-sensitive key/value config data injected into pods. Often misused for credentials.",
+		Long:  template.HTML(`<p>A <strong>ConfigMap</strong> stores plain-text configuration that pods read at startup. They are <em>not</em> meant to hold secrets, but in practice teams put database URLs (with passwords), API keys, and tokens in ConfigMaps. Kubesplaining flags credential-shaped keys for that reason.</p>`),
+	},
+	"ClusterRole": {
+		Title:  "ClusterRole",
+		Short:  "A cluster-wide bag of (verbs × resources) permissions — granted via a binding.",
+		Long:   template.HTML(`<p>A <strong>ClusterRole</strong> is a named set of permissions ("can <code>get</code>/<code>list</code> on <code>pods</code> across the cluster"). It does nothing on its own — it must be granted to a subject through a ClusterRoleBinding (cluster-wide) or RoleBinding (one namespace).</p><p>The infamous <code>cluster-admin</code> ClusterRole grants <code>verbs: ["*"]</code> on <code>resources: ["*"]</code> in <code>apiGroups: ["*"]</code> — total control.</p>`),
+		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
+	},
+	"ClusterRoleBinding": {
+		Title:  "ClusterRoleBinding",
+		Short:  "Grants a ClusterRole's permissions to a subject across the entire cluster.",
+		Long:   template.HTML(`<p>A <strong>ClusterRoleBinding</strong> assigns a ClusterRole to subjects (Users, Groups, ServiceAccounts) at cluster scope — not just one namespace. A binding to <code>cluster-admin</code> here means the subject can do anything anywhere. Always look at <em>both</em> what role is bound <em>and</em> who it is bound to.</p>`),
+		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
+	},
+	"Role": {
+		Title: "Role",
+		Short: "Like a ClusterRole, but scoped to a single namespace.",
+		Long:  template.HTML(`<p>A <strong>Role</strong> is a permission set that only applies inside one namespace. Roles cannot reference cluster-scoped resources (like Nodes or PersistentVolumes).</p>`),
+	},
+	"RoleBinding": {
+		Title: "RoleBinding",
+		Short: "Grants a Role (or ClusterRole) to a subject, scoped to one namespace.",
+		Long:  template.HTML(`<p>A <strong>RoleBinding</strong> assigns permissions inside a single namespace. It can reference a Role from the same namespace or a ClusterRole — when it references a ClusterRole, the permissions still only apply inside the binding's namespace.</p>`),
+	},
+	"Namespace": {
+		Title: "Namespace",
+		Short: "A logical partition for resources — most policies, quotas, and RBAC scope to one.",
+		Long:  template.HTML(`<p>A <strong>Namespace</strong> divides cluster resources by team, environment, or application. RoleBindings, NetworkPolicies, ResourceQuotas, and most admission rules apply at namespace scope. Compromising one workload in a namespace often gives lateral access to the rest of that namespace's resources.</p>`),
+	},
+	"hostPath": {
+		Title:  "hostPath volume",
+		Short:  "Mounts a directory from the underlying node into the pod — a classic container-escape vector.",
+		Long:   template.HTML(`<p>A <strong>hostPath</strong> volume bind-mounts a path from the host node into the container. Sensitive paths like <code>/</code>, <code>/etc</code>, <code>/var/run/docker.sock</code>, or <code>/var/lib/kubelet</code> turn the pod into a node-takeover primitive: an attacker inside the pod can write systemd units, read the kubelet's credentials, or directly invoke the container runtime to start privileged containers on the host.</p>`),
+		DocURL: "https://kubernetes.io/docs/concepts/storage/volumes/#hostpath",
+	},
+	"PrivilegedContainer": {
+		Title:  "Privileged container",
+		Short:  "Runs with kernel-level access to the host — equivalent to root on the node.",
+		Long:   template.HTML(`<p>Setting <code>securityContext.privileged: true</code> disables most container isolation: the container gets every Linux capability, can access all host devices, and can mount host filesystems. From a privileged container an attacker can escape to the node trivially (<code>nsenter</code>, mount the host's <code>/</code>, write a SUID binary, etc.).</p>`),
+		DocURL: "https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+	},
+	"hostNetwork": {
+		Title: "hostNetwork",
+		Short: "Pod shares the node's network namespace — sees and binds host ports.",
+		Long:  template.HTML(`<p>With <code>hostNetwork: true</code>, the pod sees the host's network interfaces directly. It can reach the kubelet on <code>localhost:10250</code>, sniff or spoof traffic between other workloads on that node, and bind privileged ports without going through the CNI.</p>`),
+	},
+	"hostPID": {
+		Title: "hostPID",
+		Short: "Pod sees and can signal every process on the node — including the kubelet.",
+		Long:  template.HTML(`<p>With <code>hostPID: true</code>, the pod's PID namespace is the host's. It can <code>ps</code> all processes (including the kubelet), read <code>/proc/&lt;pid&gt;/environ</code> for credentials, and join other processes' namespaces with <code>nsenter</code>.</p>`),
+	},
+	"RunAsRoot": {
+		Title: "Container runs as root (UID 0)",
+		Short: "No runAsNonRoot constraint — kernel exploits and breakout primitives apply.",
+		Long:  template.HTML(`<p>Containers that run as UID 0 are not automatically dangerous, but they remove a layer of defence. Combined with capabilities or hostPath, root-in-container becomes root-on-node much more easily.</p>`),
+	},
+	"Capabilities": {
+		Title: "Linux capabilities",
+		Short: "Fine-grained kernel privileges — SYS_ADMIN, NET_ADMIN, etc. are container-escape primitives.",
+		Long:  template.HTML(`<p>Linux <strong>capabilities</strong> split root's powers into ~40 buckets. <code>SYS_ADMIN</code> alone is enough to mount filesystems and break out of most container runtimes. <code>NET_ADMIN</code> allows traffic redirection. <code>SYS_PTRACE</code> lets a container read other processes' memory. The principle is: drop everything, add only what is needed.</p>`),
+	},
+	"NetworkPolicy": {
+		Title: "NetworkPolicy",
+		Short: "Cluster-internal firewall — without one, every pod can talk to every other pod.",
+		Long:  template.HTML(`<p>A <strong>NetworkPolicy</strong> restricts which pods can talk to which. The default in Kubernetes is <em>allow-all</em>: a pod with no NetworkPolicies covering it can reach every pod in the cluster, including the API server, etcd via metrics endpoints, and internal services. Lateral movement after pod compromise depends on whether NetworkPolicies are enforced.</p>`),
+	},
+	"AdmissionWebhook": {
+		Title: "Admission webhook",
+		Short: "A pluggable validator/mutator for API requests — failurePolicy: Ignore is a security gap.",
+		Long:  template.HTML(`<p>An <strong>admission webhook</strong> intercepts API requests before they are persisted, allowing custom policy. If a security-critical webhook has <code>failurePolicy: Ignore</code>, an outage of the webhook backend silently disables enforcement — attackers can race a webhook restart and slip through.</p>`),
+	},
+	"kube-system": {
+		Title: "kube-system namespace",
+		Short: "Holds the control plane's ServiceAccounts and tokens — read-access here is cluster-admin.",
+		Long:  template.HTML(`<p>The <strong>kube-system</strong> namespace contains tokens for the controller-manager, kube-scheduler, and other privileged controllers. Anyone who can <code>get</code>/<code>list</code>/<code>watch</code> Secrets in kube-system can read those tokens and act as those controllers — which is effectively cluster-admin.</p>`),
+	},
+	"system:masters": {
+		Title: "system:masters group",
+		Short: "Hardcoded as cluster-admin. Membership cannot be revoked through RBAC.",
+		Long:  template.HTML(`<p>The <strong>system:masters</strong> group is special-cased in the API server: members bypass RBAC and act as cluster-admin. The membership comes from the authenticator (typically certificate <code>O=system:masters</code>) and <em>cannot</em> be removed by deleting bindings — it is wired in below the RBAC layer.</p>`),
+	},
+}
+
+// Techniques maps a privesc-action key (matching the Action strings in
+// internal/analyzer/privesc/graph.go) to its educational content.
+var Techniques = map[string]TechniqueExplainer{
+	"impersonate": {
+		Title: "RBAC impersonation",
+		Plain: template.HTML(`<p>Kubernetes has a built-in "act as another user" feature — the <code>impersonate</code> verb on <code>users</code>, <code>groups</code>, or <code>serviceaccounts</code>. Anyone with that verb can submit requests as <em>any</em> identity, bypassing whatever permissions they don't have themselves.</p><p>Granting <code>impersonate</code> on <code>groups</code> = <code>["*"]</code> is equivalent to cluster-admin: the holder can impersonate <code>system:masters</code>.</p>`),
+		Mitre: "T1078.004 — Cloud Accounts",
+		AttackerSteps: []string{
+			"kubectl auth can-i --list --as=system:masters — confirm impersonation works",
+			"kubectl --as=system:masters get secrets -A — exfiltrate every secret",
+			"kubectl --as=system:masters create clusterrolebinding pwn --clusterrole=cluster-admin --user=attacker",
+		},
+	},
+	"bind_or_escalate": {
+		Title: "RBAC bind/escalate bypass",
+		Plain: template.HTML(`<p>RBAC has a guardrail: you can only grant permissions you yourself hold. Two verbs override that guardrail — <code>bind</code> (on a Role/ClusterRole) and <code>escalate</code> (also on Roles). Holding either lets the attacker create a binding to a Role they don't have themselves — including <code>cluster-admin</code>.</p>`),
+		Mitre: "T1098.003 — Account Manipulation: Additional Cloud Roles",
+		AttackerSteps: []string{
+			"kubectl create clusterrolebinding pwn --clusterrole=cluster-admin --serviceaccount=ns:me",
+			"kubectl get secrets -A — verify cluster-admin reach",
+		},
+	},
+	"pod_create_token_theft": {
+		Title: "Pod creation → ServiceAccount token theft",
+		Plain: template.HTML(`<p>Anyone who can create pods in a namespace can mount any ServiceAccount in that namespace into the pod. Cluster-scoped pod-create lets you mount any ServiceAccount in <em>any</em> namespace. Once the pod is running, the attacker reads <code>/var/run/secrets/kubernetes.io/serviceaccount/token</code> from inside it — and now holds a token for that SA.</p><p>This is the single most common privilege-escalation pattern in production Kubernetes.</p>`),
+		Mitre: "T1528 — Steal Application Access Token",
+		AttackerSteps: []string{
+			"kubectl run thief --image=alpine --serviceaccount=privileged-sa --command -- sleep infinity",
+			"kubectl exec thief -- cat /var/run/secrets/kubernetes.io/serviceaccount/token",
+			"Use the token: curl --header 'Authorization: Bearer <token>' https://kubernetes.default.svc/api/...",
+		},
+	},
+	"pod_exec": {
+		Title: "Pod exec → container takeover",
+		Plain: template.HTML(`<p>The <code>pods/exec</code> subresource opens a shell inside a running container. If the container's pod uses a privileged ServiceAccount, the attacker inherits that SA's reach. If the container is itself privileged or mounts the host, this is also a node-escape primitive.</p>`),
+		Mitre: "T1611 — Escape to Host",
+		AttackerSteps: []string{
+			"kubectl exec -it <pod-with-privileged-sa> -- /bin/sh",
+			"cat /var/run/secrets/kubernetes.io/serviceaccount/token",
+		},
+	},
+	"token_request": {
+		Title: "TokenRequest minting",
+		Plain: template.HTML(`<p>The <code>create</code> verb on <code>serviceaccounts/token</code> mints a fresh, valid token for any ServiceAccount in scope — no pod required. Cleaner than the pod-creation route and harder to spot in audit logs.</p>`),
+		Mitre: "T1528 — Steal Application Access Token",
+		AttackerSteps: []string{
+			"kubectl create token <sa> --duration=24h --bound-object-kind=Pod --bound-object-name=irrelevant",
+			"Use the token to call the API as <sa>",
+		},
+	},
+	"bound_to_cluster_admin": {
+		Title: "Direct cluster-admin binding",
+		Plain: template.HTML(`<p>The subject is bound directly to the <code>cluster-admin</code> ClusterRole through a ClusterRoleBinding. No chain needed — they are already cluster-admin. The only question is whether the subject itself can be compromised.</p>`),
+		Mitre: "T1078 — Valid Accounts",
+		AttackerSteps: []string{
+			"kubectl get clusterrolebinding -o json | jq '.items[] | select(.roleRef.name==\"cluster-admin\") | .subjects'",
+			"Compromise any subject in that list — done.",
+		},
+	},
+	"wildcard_permission": {
+		Title: "Wildcard verbs × wildcard resources",
+		Plain: template.HTML(`<p>An RBAC rule with <code>verbs: ["*"]</code>, <code>resources: ["*"]</code>, and <code>apiGroups: ["*"]</code> is functionally identical to cluster-admin, even if it isn't called that. Often introduced by careless Helm charts or "give it permission to everything until it works" debugging.</p>`),
+		Mitre: "T1078 — Valid Accounts",
+	},
+	"modify_role_binding": {
+		Title: "RoleBinding write access",
+		Plain: template.HTML(`<p><code>create</code>/<code>update</code>/<code>patch</code> on <code>rolebindings</code> or <code>clusterrolebindings</code> lets the attacker bind themselves to any role — typically cluster-admin. They don't need the role's permissions today, only the ability to change bindings.</p>`),
+		Mitre: "T1098 — Account Manipulation",
+		AttackerSteps: []string{
+			"kubectl patch clusterrolebinding existing-binding --type=json -p='[{\"op\":\"add\",\"path\":\"/subjects/-\",\"value\":{\"kind\":\"ServiceAccount\",\"name\":\"me\",\"namespace\":\"ns\"}}]'",
+		},
+	},
+	"read_secrets": {
+		Title: "Secrets read access",
+		Plain: template.HTML(`<p><code>get</code>/<code>list</code>/<code>watch</code> on Secrets in kube-system or cluster-wide reads the controller-manager, scheduler, and node-bootstrap tokens — every credential needed to act as the control plane.</p>`),
+		Mitre: "T1552 — Unsecured Credentials",
+		AttackerSteps: []string{
+			"kubectl get secret -n kube-system -o json | jq -r '.items[] | select(.type==\"kubernetes.io/service-account-token\") | .data.token' | base64 -d",
+		},
+	},
+	"nodes_proxy": {
+		Title: "nodes/proxy → kubelet API",
+		Plain: template.HTML(`<p>The <code>nodes/proxy</code> subresource forwards requests to the kubelet on each node. Combined with kubelet's <code>/exec</code> endpoint and a WebSocket verb mismatch, this becomes a primitive for executing commands inside any pod the kubelet can reach.</p>`),
+		Mitre: "T1611 — Escape to Host",
+	},
+	"pod_host_escape": {
+		Title: "Container escape to host",
+		Plain: template.HTML(`<p>The pod is configured in a way that makes escaping to the underlying node trivial: <code>privileged: true</code>, <code>hostPID</code>, <code>hostNetwork</code>, or a sensitive <code>hostPath</code> mount (root, docker.sock, etc.). An attacker who controls the container reaches root on the node, then has access to every pod and kubelet credential on that node.</p>`),
+		Mitre: "T1611 — Escape to Host",
+		AttackerSteps: []string{
+			"From inside the privileged pod: nsenter -t 1 -m -u -i -n -p — drop into PID 1's namespaces",
+			"Read /var/lib/kubelet/pki/kubelet-client-current.pem — node identity",
+			"Pivot to other pods on the same node via the container runtime socket",
+		},
+	},
+}
+
+// Categories maps a RiskCategory to plain-language explainer copy used on the impact-lane nodes.
+var Categories = map[string]CategoryExplainer{
+	string(models.CategoryPrivilegeEscalation): {
+		Title: "Privilege Escalation",
+		Plain: template.HTML(`<p>An identity that started with limited permissions ends up acting as cluster-admin (or <code>system:masters</code>, or the kubelet on a node). Privilege escalation is the gateway impact — every other category becomes possible once an attacker has it.</p>`),
+		Examples: []string{
+			"A compromised application pod's ServiceAccount mints a cluster-admin token via TokenRequest.",
+			"A namespace-admin abuses bind/escalate to grant themselves cluster-admin.",
+			"A privileged DaemonSet's pod is exec'd into and the attacker pivots to the node, then to the kubelet's credentials.",
+		},
+	},
+	string(models.CategoryLateralMovement): {
+		Title: "Lateral Reach",
+		Plain: template.HTML(`<p>The attacker spreads sideways — across namespaces, across nodes, or out of the pod onto cluster-internal services. NetworkPolicy gaps, default-allow service meshes, and over-broad ServiceAccounts in shared namespaces all enable this.</p>`),
+		Examples: []string{
+			"From a compromised pod, reach the API server, etcd metrics endpoints, or internal databases that have no NetworkPolicy.",
+			"hostNetwork pods can sniff or spoof traffic for every other pod on the same node.",
+		},
+	},
+	string(models.CategoryDataExfiltration): {
+		Title: "Data Exfiltration",
+		Plain: template.HTML(`<p>Reading data the attacker should not see — Secrets, ConfigMap-stored credentials, application data in PersistentVolumes, or audit logs that reveal internal structure.</p>`),
+		Examples: []string{
+			"Reading every Secret in kube-system to harvest controller credentials.",
+			"Mounting a PersistentVolume from a database StatefulSet.",
+			"Pulling registry pull-secrets and using them to clone private images.",
+		},
+	},
+	string(models.CategoryInfrastructureModification): {
+		Title: "Control Bypass",
+		Plain: template.HTML(`<p>The attacker turns off, weakens, or works around the cluster's policy enforcement — admission webhooks, Pod Security admission, OPA/Gatekeeper, or audit configuration. After this, follow-on actions become invisible to defenders.</p>`),
+		Examples: []string{
+			"Patching a ValidatingWebhookConfiguration to <code>failurePolicy: Ignore</code>, then deleting the backing service.",
+			"Removing a Pod Security label from a namespace to allow privileged pods.",
+		},
+	},
+	string(models.CategoryDefenseEvasion): {
+		Title: "Detection Evasion",
+		Plain: template.HTML(`<p>The attacker hides their tracks — disabling audit logging, deleting events, rolling back resource versions, or abusing legitimate-looking patterns (impersonation, service accounts) so the activity blends in.</p>`),
+		Examples: []string{
+			"Using <code>--as=system:serviceaccount:kube-system:replicaset-controller</code> to impersonate a high-volume controller and disappear in audit log noise.",
+			"Deleting Events that record the privileged pod's creation.",
+		},
+	},
+}
+
+// TechniqueKeyForFinding picks the right Techniques key for a Finding.
+// Preference: the first hop's Action (privesc-PATH findings carry these); otherwise we map by RuleID prefix.
+// Returns "" if no entry applies — the JS layer treats that as "no technique explainer".
+func TechniqueKeyForFinding(f models.Finding) string {
+	if len(f.EscalationPath) > 0 && f.EscalationPath[0].Action != "" {
+		if _, ok := Techniques[f.EscalationPath[0].Action]; ok {
+			return f.EscalationPath[0].Action
+		}
+	}
+	switch {
+	case strings.HasPrefix(f.RuleID, "KUBE-ESCAPE"):
+		return "pod_host_escape"
+	case f.RuleID == "KUBE-PRIVESC-001":
+		return "pod_create_token_theft"
+	case f.RuleID == "KUBE-PRIVESC-004":
+		return "pod_exec"
+	case f.RuleID == "KUBE-PRIVESC-005":
+		return "read_secrets"
+	case f.RuleID == "KUBE-PRIVESC-008":
+		return "impersonate"
+	case f.RuleID == "KUBE-PRIVESC-009":
+		return "bind_or_escalate"
+	case f.RuleID == "KUBE-PRIVESC-010":
+		return "modify_role_binding"
+	case f.RuleID == "KUBE-PRIVESC-012":
+		return "nodes_proxy"
+	case f.RuleID == "KUBE-PRIVESC-014":
+		return "token_request"
+	case f.RuleID == "KUBE-PRIVESC-017":
+		return "wildcard_permission"
+	case f.RuleID == "KUBE-RBAC-OVERBROAD-001":
+		return "bound_to_cluster_admin"
+	case strings.HasPrefix(f.RuleID, "KUBE-PRIVESC-PATH-"):
+		// Fall back to the chain's first hop, already handled above; if no hops, leave empty.
+		return ""
+	}
+	return ""
+}
+
+// GlossaryKeyForSubject picks the right Glossary key for a SubjectRef. Returns "" when there's no
+// specific entry — the JS uses the entry-node Title in that case.
+func GlossaryKeyForSubject(ref *models.SubjectRef) string {
+	if ref == nil {
+		return ""
+	}
+	switch ref.Kind {
+	case "ServiceAccount", "User", "Group":
+		// system:masters has its own dedicated entry; check by name.
+		if ref.Kind == "Group" && ref.Name == "system:masters" {
+			return "system:masters"
+		}
+		return ref.Kind
+	}
+	return ""
+}
+
+// GlossaryKeyForResource picks the right Glossary key for a ResourceRef.
+func GlossaryKeyForResource(ref *models.ResourceRef) string {
+	if ref == nil {
+		return ""
+	}
+	switch ref.Kind {
+	case "Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "Job",
+		"Secret", "ConfigMap", "Namespace",
+		"ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+		return ref.Kind
+	}
+	return ""
+}

--- a/internal/report/graph_script.go
+++ b/internal/report/graph_script.go
@@ -1,0 +1,387 @@
+// Package report — kpGraphScript is the inline JavaScript that powers the interactive attack
+// graph in the HTML report. It's kept here as a Go const so the report stays self-contained
+// (no external assets) and so the JS source remains readable without fighting Go template
+// escaping inside the htmlTemplate. The string is injected via template.JS in BuildHTMLData.
+//
+// Design notes:
+//   - Vanilla JS, no library dependencies, runs on DOMContentLoaded.
+//   - Reads the GraphPayload from <script type="application/json" id="kp-graph-data">.
+//   - Hover / click / keyboard handlers on every <g data-node-id> and <path data-edge-id>.
+//   - Side panel ("kp-detail") slides in with glossary + technique + remediation copy.
+//   - Filter chips toggle classes on the <svg>; CSS does the actual dimming.
+//   - innerHTML is used only for HTML already vetted by Go (Glossary.Long / Techniques.Plain
+//     are template.HTML emitted from a hardcoded glossary). All Finding-derived strings (Title,
+//     Description, Remediation, References) go through textContent / safe-attribute setters.
+package report
+
+const kpGraphScript = `
+(function() {
+  var dataEl = document.getElementById('kp-graph-data');
+  if (!dataEl) return;
+  var payload;
+  try { payload = JSON.parse(dataEl.textContent); } catch (e) { return; }
+  if (!payload || !payload.Nodes) return;
+
+  var svg = document.querySelector('.attack-svg');
+  var panel = document.querySelector('.kp-detail');
+  var panelTitle = document.getElementById('kp-detail-title');
+  var panelBody = document.getElementById('kp-detail-body');
+  var panelClose = panel && panel.querySelector('.kp-detail-close');
+  var tooltip = document.querySelector('.kp-tooltip');
+  if (!svg || !panel || !tooltip) return;
+
+  var nodeIndex = {};
+  (payload.Nodes || []).forEach(function(n) { nodeIndex[n.ID] = n; });
+  var edgeIndex = {};
+  (payload.Edges || []).forEach(function(e) { edgeIndex[e.ID] = e; });
+
+  var lastFocused = null;
+  var walkState = null;
+
+  function $$(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
+
+  function clearHighlights() {
+    $$('.kp-hot, .kp-dim', svg).forEach(function(el) {
+      el.classList.remove('kp-hot');
+      el.classList.remove('kp-dim');
+    });
+    svg.classList.remove('kp-active');
+  }
+
+  function highlightNode(node) {
+    if (!node) return;
+    svg.classList.add('kp-active');
+    var hotIDs = {};
+    hotIDs[node.ID] = true;
+    (node.EdgeIDs || []).forEach(function(eid) {
+      hotIDs[eid] = true;
+      var edge = edgeIndex[eid];
+      if (!edge) return;
+      hotIDs[edge.From] = true;
+      hotIDs[edge.To] = true;
+    });
+    $$('[data-node-id]', svg).forEach(function(el) {
+      var id = el.getAttribute('data-node-id');
+      if (hotIDs[id]) { el.classList.add('kp-hot'); el.classList.remove('kp-dim'); }
+      else { el.classList.add('kp-dim'); el.classList.remove('kp-hot'); }
+    });
+    $$('[data-edge-id]', svg).forEach(function(el) {
+      var id = el.getAttribute('data-edge-id');
+      if (hotIDs[id]) { el.classList.add('kp-hot'); el.classList.remove('kp-dim'); }
+      else { el.classList.add('kp-dim'); el.classList.remove('kp-hot'); }
+    });
+  }
+
+  function highlightEdge(edge) {
+    if (!edge) return;
+    svg.classList.add('kp-active');
+    var hotIDs = {};
+    hotIDs[edge.ID] = true;
+    hotIDs[edge.From] = true;
+    hotIDs[edge.To] = true;
+    $$('[data-node-id]', svg).forEach(function(el) {
+      var id = el.getAttribute('data-node-id');
+      if (hotIDs[id]) { el.classList.add('kp-hot'); el.classList.remove('kp-dim'); }
+      else { el.classList.add('kp-dim'); el.classList.remove('kp-hot'); }
+    });
+    $$('[data-edge-id]', svg).forEach(function(el) {
+      var id = el.getAttribute('data-edge-id');
+      if (hotIDs[id]) { el.classList.add('kp-hot'); el.classList.remove('kp-dim'); }
+      else { el.classList.add('kp-dim'); el.classList.remove('kp-hot'); }
+    });
+  }
+
+  function showTooltip(targetEl, title, htmlBody) {
+    var rect = targetEl.getBoundingClientRect();
+    tooltip.style.left = (rect.left + window.pageXOffset + Math.min(rect.width / 2, 220)) + 'px';
+    tooltip.style.top = (rect.top + window.pageYOffset - 12) + 'px';
+    var t = tooltip.querySelector('.kp-tt-title');
+    var b = tooltip.querySelector('.kp-tt-body');
+    t.textContent = title || '';
+    if (htmlBody) { b.innerHTML = htmlBody; b.hidden = false; }
+    else { b.innerHTML = ''; b.hidden = true; }
+    tooltip.hidden = false;
+  }
+
+  function hideTooltip() { tooltip.hidden = true; }
+
+  function el(tag, attrs, children) {
+    var n = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function(k) {
+        if (k === 'class') n.className = attrs[k];
+        else if (k === 'html') n.innerHTML = attrs[k];
+        else if (k === 'text') n.textContent = attrs[k];
+        else if (k === 'attrs') {
+          Object.keys(attrs.attrs).forEach(function(ak) { n.setAttribute(ak, attrs.attrs[ak]); });
+        } else n.setAttribute(k, attrs[k]);
+      });
+    }
+    (children || []).forEach(function(c) {
+      if (c == null) return;
+      if (typeof c === 'string') n.appendChild(document.createTextNode(c));
+      else n.appendChild(c);
+    });
+    return n;
+  }
+
+  function severityLabel(s) {
+    switch (s) {
+      case 'crit': return 'CRITICAL';
+      case 'high': return 'HIGH';
+      case 'med': return 'MEDIUM';
+      case 'low': return 'LOW';
+      default: return (s || '').toUpperCase();
+    }
+  }
+
+  // renderPanel composes the side-panel content for one node. All Finding-derived strings go
+  // through textContent (via the el() helper) so untrusted content never reaches innerHTML.
+  // Glossary/technique/category prose is HTML pre-vetted by Go and is allowed via 'html'.
+  function renderPanel(node) {
+    panelBody.innerHTML = '';
+    panelTitle.textContent = node.Title || 'Detail';
+
+    var hd = el('div', { class: 'kp-panel-meta' });
+    if (node.Severity) hd.appendChild(el('span', { class: 'kp-sev-badge kp-sev-' + node.Severity, text: severityLabel(node.Severity) }));
+    if (node.Kind === 'capability') hd.appendChild(el('span', { class: 'kp-kind-badge', text: 'Abused capability' }));
+    else if (node.Kind === 'entry') hd.appendChild(el('span', { class: 'kp-kind-badge', text: 'Entry point' }));
+    else if (node.Kind === 'impact') hd.appendChild(el('span', { class: 'kp-kind-badge', text: 'Impact' }));
+    if (node.RuleID) hd.appendChild(el('span', { class: 'kp-rule mono', text: node.RuleID }));
+    panelBody.appendChild(hd);
+    if (node.Subtitle) panelBody.appendChild(el('div', { class: 'kp-panel-sub mono', text: node.Subtitle }));
+
+    var glossary = node.GlossaryKey && payload.Glossary ? payload.Glossary[node.GlossaryKey] : null;
+    if (glossary) {
+      var sec = el('section', { class: 'kp-section' }, [
+        el('h4', { text: 'What is this?' }),
+        el('div', { class: 'kp-prose', html: glossary.Long || ('<p>' + (glossary.Short || '') + '</p>') })
+      ]);
+      if (glossary.DocURL) {
+        var doc = el('a', { href: glossary.DocURL, target: '_blank', rel: 'noopener noreferrer', text: 'Kubernetes docs ↗' });
+        sec.appendChild(el('div', { class: 'kp-doc-link' }, [doc]));
+      }
+      panelBody.appendChild(sec);
+    }
+
+    var category = node.RiskCategory && payload.Categories ? payload.Categories[node.RiskCategory] : null;
+    if (category && node.Kind === 'impact') {
+      var csec = el('section', { class: 'kp-section' }, [
+        el('h4', { text: 'What this category means' }),
+        el('div', { class: 'kp-prose', html: category.Plain || '' })
+      ]);
+      if (category.Examples && category.Examples.length) {
+        var ul = el('ul', { class: 'kp-examples' });
+        category.Examples.forEach(function(ex) { ul.appendChild(el('li', { text: ex })); });
+        csec.appendChild(ul);
+      }
+      panelBody.appendChild(csec);
+    }
+
+    if (node.Description) {
+      panelBody.appendChild(el('section', { class: 'kp-section' }, [
+        el('h4', { text: 'Why this finding fires' }),
+        el('p', { class: 'kp-prose', text: node.Description })
+      ]));
+    }
+
+    var techKey = node.TechniqueKey;
+    var tech = techKey && payload.Techniques ? payload.Techniques[techKey] : null;
+    if (tech) {
+      var ts = el('section', { class: 'kp-section kp-tech' }, [
+        el('h4', { text: 'What an attacker does: ' + (tech.Title || techKey) }),
+        el('div', { class: 'kp-prose', html: tech.Plain || '' })
+      ]);
+      if (tech.Mitre) ts.appendChild(el('div', { class: 'kp-mitre', text: 'MITRE ATT&CK · ' + tech.Mitre }));
+      if (tech.AttackerSteps && tech.AttackerSteps.length) {
+        var ol = el('ol', { class: 'kp-steps' });
+        tech.AttackerSteps.forEach(function(s) { ol.appendChild(el('li', { text: s })); });
+        ts.appendChild(el('div', { class: 'kp-steps-hd', text: "What they'd actually run" }));
+        ts.appendChild(ol);
+      }
+      panelBody.appendChild(ts);
+    }
+
+    if (node.Hops && node.Hops.length) {
+      var walkBtn = el('button', { type: 'button', class: 'kp-walk-btn', text: 'Walk the chain step-by-step (' + node.Hops.length + ' hops)' });
+      walkBtn.addEventListener('click', function() { startWalkthrough(node); });
+      panelBody.appendChild(el('section', { class: 'kp-section' }, [
+        el('h4', { text: 'Step-by-step' }),
+        el('p', { class: 'kp-prose', text: 'See exactly how a starting identity reaches the target, hop by hop.' }),
+        walkBtn
+      ]));
+    }
+
+    if (node.Remediation) {
+      panelBody.appendChild(el('section', { class: 'kp-section kp-fix' }, [
+        el('h4', { text: 'How to fix' }),
+        el('p', { class: 'kp-prose', text: node.Remediation })
+      ]));
+    }
+
+    if (node.References && node.References.length) {
+      var refsSec = el('section', { class: 'kp-section' }, [el('h4', { text: 'References' })]);
+      var refUl = el('ul', { class: 'kp-refs' });
+      node.References.forEach(function(href) {
+        if (!href) return;
+        var safeHref = (typeof href === 'string' && /^https?:/i.test(href)) ? href : '#';
+        refUl.appendChild(el('li', {}, [el('a', { href: safeHref, target: '_blank', rel: 'noopener noreferrer', text: href })]));
+      });
+      refsSec.appendChild(refUl);
+      panelBody.appendChild(refsSec);
+    }
+  }
+
+  function startWalkthrough(node) {
+    walkState = { node: node, step: 0 };
+    renderWalkStep();
+  }
+
+  function renderWalkStep() {
+    if (!walkState) return;
+    var node = walkState.node;
+    var i = walkState.step;
+    var hop = node.Hops[i];
+    panelBody.innerHTML = '';
+    panelTitle.textContent = 'Walkthrough · step ' + (i + 1) + ' of ' + node.Hops.length;
+
+    var nav = el('div', { class: 'kp-walk-nav' });
+    var prev = el('button', { type: 'button', class: 'kp-walk-prev', text: '← Prev' });
+    var next = el('button', { type: 'button', class: 'kp-walk-next', text: 'Next →' });
+    var exit = el('button', { type: 'button', class: 'kp-walk-exit', text: 'Exit walkthrough' });
+    if (i === 0) prev.disabled = true;
+    if (i === node.Hops.length - 1) next.disabled = true;
+    prev.addEventListener('click', function() { if (walkState.step > 0) { walkState.step--; renderWalkStep(); } });
+    next.addEventListener('click', function() { if (walkState.step < node.Hops.length - 1) { walkState.step++; renderWalkStep(); } });
+    exit.addEventListener('click', function() { walkState = null; renderPanel(node); });
+    nav.appendChild(prev); nav.appendChild(next); nav.appendChild(exit);
+    panelBody.appendChild(nav);
+
+    panelBody.appendChild(el('div', { class: 'kp-walk-progress', text: 'Step ' + (i + 1) + ' / ' + node.Hops.length + ' · target: ' + (node.Title || '') }));
+
+    var fromBox = el('div', { class: 'kp-walk-card kp-walk-from' }, [
+      el('div', { class: 'kp-walk-label', text: 'Starting identity' }),
+      el('div', { class: 'kp-walk-id mono', text: hop.From || '(initial subject)' })
+    ]);
+    var arrow = el('div', { class: 'kp-walk-arrow', text: '↓' });
+    var actionBox = el('div', { class: 'kp-walk-card kp-walk-action' }, [
+      el('div', { class: 'kp-walk-label', text: 'Technique' }),
+      el('div', { class: 'kp-walk-id', text: (hop.Action || '').replace(/_/g, ' ') }),
+    ]);
+    if (hop.Permission) actionBox.appendChild(el('div', { class: 'kp-walk-perm mono', text: hop.Permission }));
+    var tech = hop.TechniqueKey && payload.Techniques ? payload.Techniques[hop.TechniqueKey] : null;
+    if (tech) {
+      actionBox.appendChild(el('div', { class: 'kp-prose kp-walk-explainer', html: tech.Plain || '' }));
+      if (tech.Mitre) actionBox.appendChild(el('div', { class: 'kp-mitre', text: 'MITRE ATT&CK · ' + tech.Mitre }));
+    }
+    var arrow2 = el('div', { class: 'kp-walk-arrow', text: '↓' });
+    var toBox = el('div', { class: 'kp-walk-card kp-walk-to' }, [
+      el('div', { class: 'kp-walk-label', text: 'Now controls' }),
+      el('div', { class: 'kp-walk-id mono', text: hop.To || '(target)' })
+    ]);
+    if (hop.Gains) toBox.appendChild(el('div', { class: 'kp-walk-gain', text: hop.Gains }));
+
+    panelBody.appendChild(fromBox);
+    panelBody.appendChild(arrow);
+    panelBody.appendChild(actionBox);
+    panelBody.appendChild(arrow2);
+    panelBody.appendChild(toBox);
+  }
+
+  function openPanel(node, originEl) {
+    walkState = null;
+    renderPanel(node);
+    panel.hidden = false;
+    panel.classList.add('kp-open');
+    highlightNode(node);
+    if (originEl) lastFocused = originEl;
+    if (panelClose) panelClose.focus();
+  }
+
+  function closePanel() {
+    panel.hidden = true;
+    panel.classList.remove('kp-open');
+    walkState = null;
+    clearHighlights();
+    if (lastFocused) { try { lastFocused.focus(); } catch (e) {} }
+  }
+
+  $$('[data-node-id]', svg).forEach(function(g) {
+    var id = g.getAttribute('data-node-id');
+    var node = nodeIndex[id];
+    if (!node) return;
+    g.addEventListener('mouseenter', function() {
+      highlightNode(node);
+      var glossary = node.GlossaryKey && payload.Glossary ? payload.Glossary[node.GlossaryKey] : null;
+      var tip = glossary ? glossary.Short : (node.Subtitle || '');
+      showTooltip(g, node.Title || '', tip ? '<div>' + escapeHtml(tip) + '</div>' : '');
+    });
+    g.addEventListener('mouseleave', function() {
+      if (!panel.classList.contains('kp-open')) clearHighlights();
+      hideTooltip();
+    });
+    g.addEventListener('click', function() { openPanel(node, g); });
+    g.addEventListener('keydown', function(ev) {
+      if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); openPanel(node, g); }
+    });
+  });
+
+  $$('[data-edge-id]', svg).forEach(function(p) {
+    var id = p.getAttribute('data-edge-id');
+    var edge = edgeIndex[id];
+    if (!edge) return;
+    p.addEventListener('mouseenter', function() {
+      highlightEdge(edge);
+      var tech = edge.TechniqueKey && payload.Techniques ? payload.Techniques[edge.TechniqueKey] : null;
+      var title = (edge.ActionLabel || '');
+      var body = tech ? (tech.Title || '') + (tech.Plain ? '<div class="kp-tt-prose">' + tech.Plain + '</div>' : '') : '';
+      showTooltip(p, title, body);
+    });
+    p.addEventListener('mouseleave', function() {
+      if (!panel.classList.contains('kp-open')) clearHighlights();
+      hideTooltip();
+    });
+  });
+
+  if (panelClose) panelClose.addEventListener('click', closePanel);
+  document.addEventListener('keydown', function(ev) {
+    if (ev.key === 'Escape' && panel.classList.contains('kp-open')) closePanel();
+  });
+
+  // Filter chips: toggle aria-pressed and a class on the SVG for CSS-only dimming.
+  $$('.kp-chip', document).forEach(function(chip) {
+    chip.addEventListener('click', function() {
+      if (chip.getAttribute('data-action') === 'reset') {
+        $$('.kp-chip', document).forEach(function(c) {
+          if (c.getAttribute('data-action') === 'reset') return;
+          c.setAttribute('aria-pressed', 'true');
+        });
+        applyFilters();
+        return;
+      }
+      var pressed = chip.getAttribute('aria-pressed') === 'true';
+      chip.setAttribute('aria-pressed', pressed ? 'false' : 'true');
+      applyFilters();
+    });
+  });
+
+  function applyFilters() {
+    var hidden = { sev: {}, kind: {} };
+    $$('.kp-chip[data-filter]', document).forEach(function(c) {
+      if (c.getAttribute('aria-pressed') === 'false') {
+        hidden[c.getAttribute('data-filter')][c.getAttribute('data-value')] = true;
+      }
+    });
+    var classes = svg.className.baseVal.split(/\s+/).filter(function(c) { return !/^kp-hide-/.test(c); });
+    Object.keys(hidden.sev).forEach(function(v) { classes.push('kp-hide-sev-' + v); });
+    Object.keys(hidden.kind).forEach(function(v) { classes.push('kp-hide-kind-' + v); });
+    svg.className.baseVal = classes.filter(Boolean).join(' ');
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+})();
+`

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -67,11 +67,11 @@ type HeatmapCell struct {
 
 // HeatmapRow is one row of the Resource × Category heatmap.
 type HeatmapRow struct {
-	Label     string
-	SevClass  string // crit | high | med  — derived from the highest-severity finding on this resource
-	SevLabel  string // CRIT | HIGH | MED
-	Total     int
-	Cells     []HeatmapCell
+	Label    string
+	SevClass string // crit | high | med  — derived from the highest-severity finding on this resource
+	SevLabel string // CRIT | HIGH | MED
+	Total    int
+	Cells    []HeatmapCell
 }
 
 // HeatmapCategory is a column header in the heatmap.
@@ -120,8 +120,64 @@ type GraphTextLine struct {
 
 // GraphEdge is a rendered bezier path in the attack graph.
 type GraphEdge struct {
+	ID    string // stable ID of the form "edge-<fromNodeID>-<toNodeID>" — used by the JS layer.
 	Class string // crit | high | med
 	D     string
+}
+
+// GraphPayload is the parallel detail-only payload that the inline JSON block embeds for the
+// JS interactivity layer. It is kept separate from AttackGraph (which stays cosmetic — only
+// what the SVG template needs) so multi-paragraph educational HTML doesn't bloat per-element
+// attributes.
+type GraphPayload struct {
+	Nodes      []GraphNodeDetail             `json:"Nodes"`
+	Edges      []GraphEdgeDetail             `json:"Edges"`
+	Glossary   map[string]GlossaryEntry      `json:"Glossary"`
+	Techniques map[string]TechniqueExplainer `json:"Techniques"`
+	Categories map[string]CategoryExplainer  `json:"Categories"`
+}
+
+// GraphNodeDetail is the per-node detail payload — title, severity, glossary key, rule
+// description, remediation, references, hop chain, and the IDs of edges this node connects
+// to. Wired up to the SVG <g data-node-id> elements client-side.
+type GraphNodeDetail struct {
+	ID           string    `json:"ID"`
+	Kind         string    `json:"Kind"`     // entry | capability | impact
+	Severity     string    `json:"Severity"` // crit | high | med
+	Title        string    `json:"Title"`
+	Subtitle     string    `json:"Subtitle,omitempty"`
+	GlossaryKey  string    `json:"GlossaryKey,omitempty"`  // entry nodes
+	RuleID       string    `json:"RuleID,omitempty"`       // capability nodes
+	TechniqueKey string    `json:"TechniqueKey,omitempty"` // capability nodes
+	Description  string    `json:"Description,omitempty"`  // capability nodes
+	Remediation  string    `json:"Remediation,omitempty"`  // capability nodes
+	References   []string  `json:"References,omitempty"`   // capability nodes
+	Hops         []HopView `json:"Hops,omitempty"`         // privesc-PATH capability nodes
+	EdgeIDs      []string  `json:"EdgeIDs,omitempty"`      // edges incident on this node
+	EntryKind    string    `json:"EntryKind,omitempty"`    // Subject | Resource (entry filter)
+	RiskCategory string    `json:"RiskCategory,omitempty"` // impact nodes
+}
+
+// GraphEdgeDetail describes one bezier edge for the JS layer.
+type GraphEdgeDetail struct {
+	ID           string `json:"ID"`
+	From         string `json:"From"`
+	To           string `json:"To"`
+	Class        string `json:"Class"` // crit | high | med
+	TechniqueKey string `json:"TechniqueKey,omitempty"`
+	ActionLabel  string `json:"ActionLabel,omitempty"` // human-readable verb (e.g., "abuses", "leads to")
+}
+
+// HopView is one walkthrough step for a privesc-PATH finding — pre-rendered so the JS does
+// no derivation. Step is 1-indexed for display.
+type HopView struct {
+	Step         int    `json:"Step"`
+	From         string `json:"From"`
+	To           string `json:"To"`
+	Action       string `json:"Action"`
+	TechniqueKey string `json:"TechniqueKey"`
+	Permission   string `json:"Permission,omitempty"`
+	Gains        string `json:"Gains,omitempty"`
 }
 
 // htmlReportData is the template input for the HTML dashboard; assembled by BuildHTMLData.
@@ -137,16 +193,18 @@ type htmlReportData struct {
 	TopFindings   []models.Finding
 
 	// Modern-dashboard fields — all derived from Findings so any cluster renders.
-	RiskIndex    int
-	RiskLevel    string // LOW | MODERATE | HIGH | CRITICAL
-	GaugeDash    string // "arcLen gapLen" for stroke-dasharray (circumference = 2π·56 ≈ 351.86)
-	GaugeColor   string // hex for gauge stroke, severity-tinted
-	Headline     string        // data-driven h1 ("2 independent paths to full cluster takeover", etc.)
-	Summaries    template.HTML // short prose under the h1; pre-escaped by buildHeadline so template renders markup
-	Narratives   []NarrativeCard
-	HeatCats     []HeatmapCategory
-	HeatRows     []HeatmapRow
-	Graph        AttackGraph
+	RiskIndex   int
+	RiskLevel   string        // LOW | MODERATE | HIGH | CRITICAL
+	GaugeDash   string        // "arcLen gapLen" for stroke-dasharray (circumference = 2π·56 ≈ 351.86)
+	GaugeColor  string        // hex for gauge stroke, severity-tinted
+	Headline    string        // data-driven h1 ("2 independent paths to full cluster takeover", etc.)
+	Summaries   template.HTML // short prose under the h1; pre-escaped by buildHeadline so template renders markup
+	Narratives  []NarrativeCard
+	HeatCats    []HeatmapCategory
+	HeatRows    []HeatmapRow
+	Graph       AttackGraph
+	GraphJSON   template.JS // JSON-marshaled GraphPayload, rendered into <script type="application/json">
+	GraphScript template.JS // Inline JS that powers the interactive graph (loaded from kpGraphScript const)
 }
 
 // Write emits the requested formats (html, json, csv, sarif) to outputDir along with the snapshot metadata side-file.
@@ -278,6 +336,7 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 
 	summary := BuildSummary(findings)
 	risk, level, gaugeColor := computeRiskIndex(summary)
+	graph, graphPayload := buildAttackGraph(findings, resourceMap, subjectMap)
 
 	data := htmlReportData{
 		Snapshot:      snapshot,
@@ -295,7 +354,9 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 		HeatCats:      heatmapCategories(),
 		HeatRows:      buildHeatmap(findings, resourceMap),
 		Narratives:    buildNarratives(findings),
-		Graph:         buildAttackGraph(findings, resourceMap, subjectMap),
+		Graph:         graph,
+		GraphJSON:     marshalGraphPayload(graphPayload),
+		GraphScript:   template.JS(kpGraphScript),
 	}
 	if len(findings) > 5 {
 		data.TopFindings = append([]models.Finding(nil), findings[:5]...)
@@ -304,6 +365,19 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 	}
 	data.Headline, data.Summaries = buildHeadline(summary, data.Narratives, topNamespaces)
 	return data
+}
+
+// marshalGraphPayload serializes the GraphPayload for inline embedding in a
+// <script type="application/json"> block. encoding/json escapes <, >, & to \uXXXX by default,
+// which prevents the JSON from breaking out of the script tag. On the (essentially impossible)
+// case of a marshal failure we degrade to "{}" so the page still loads — interactivity is off,
+// but the static SVG continues to render.
+func marshalGraphPayload(p GraphPayload) template.JS {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return template.JS("{}")
+	}
+	return template.JS(b)
 }
 
 // writeJSON writes findings as an indented JSON array at path.
@@ -458,9 +532,9 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding)
 		"score": func(v float64) string {
 			return fmt.Sprintf("%.1f", v)
 		},
-		"add": func(a, b int) int { return a + b },
-		"sub": func(a, b int) int { return a - b },
-		"midY": func(n GraphNode) int { return n.Y + n.Height/2 },
+		"add":    func(a, b int) int { return a + b },
+		"sub":    func(a, b int) int { return a - b },
+		"midY":   func(n GraphNode) int { return n.Y + n.Height/2 },
 		"rightX": func(n GraphNode) int { return n.X + n.Width },
 		"catKey": func(c models.RiskCategory) string { return categoryCSSKey(c) },
 		"pluralize": func(n int, singular, plural string) string {
@@ -953,11 +1027,12 @@ func buildHeadline(s Summary, narratives []NarrativeCard, ns []Hotspot) (string,
 
 // buildAttackGraph composes a 3-column flow diagram (entries → capabilities → impacts) from findings.
 // Coordinates are deterministic so the template only emits SVG, no layout computation.
-func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[string][]models.Finding) AttackGraph {
+// Returns the cosmetic AttackGraph (for the SVG template) and a detail GraphPayload (for the
+// inline JSON block that drives the interactive side panel).
+func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[string][]models.Finding) (AttackGraph, GraphPayload) {
+	emptyPayload := GraphPayload{Glossary: Glossary, Techniques: Techniques, Categories: Categories}
+
 	// Select capabilities: critical + high findings, deduplicated by rule_id (keep highest-scoring), top 10 by score.
-	type capCandidate struct {
-		f models.Finding
-	}
 	byRule := map[string]models.Finding{}
 	for _, f := range findings {
 		if f.Severity != models.SeverityCritical && f.Severity != models.SeverityHigh {
@@ -987,18 +1062,23 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 		return AttackGraph{
 			Width: 980, Height: 120,
 			Lanes: [3]GraphLane{{X: 20, Label: "Entry point"}, {X: 360, Label: "Abused capability"}, {X: 720, Label: "Impact"}},
-		}
+		}, emptyPayload
 	}
 
 	// Select entry points: the resource/subject each capability is about, deduplicated.
 	// Entry key = subject.Key() when present, else resource.Key(). Label reflects source.
+	// representative remembers a sample finding so we can later resolve a GlossaryKey from
+	// its Subject/Resource without re-walking findings.
 	type entryInfo struct {
-		Key      string
-		Title    string
-		Subtitle string
-		Meta     string
-		SevClass string
-		topScore float64
+		Key            string
+		Title          string
+		Subtitle       string
+		Meta           string
+		SevClass       string
+		topScore       float64
+		representative models.Finding
+		hasRep         bool
+		entryKind      string // "Subject" | "Resource" — used by the JS filter chips.
 	}
 	entries := map[string]*entryInfo{}
 	entryForCap := make([]string, len(caps))
@@ -1010,8 +1090,19 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 		entryForCap[i] = key
 		e, ok := entries[key]
 		if !ok {
-			e = &entryInfo{Key: key, Title: title, Subtitle: subtitle, SevClass: severityClass(f.Severity)}
+			kind := ""
+			switch {
+			case f.Subject != nil:
+				kind = "Subject"
+			case f.Resource != nil:
+				kind = "Resource"
+			}
+			e = &entryInfo{Key: key, Title: title, Subtitle: subtitle, SevClass: severityClass(f.Severity), entryKind: kind}
 			entries[key] = e
+		}
+		if !e.hasRep {
+			e.representative = f
+			e.hasRep = true
 		}
 		if f.Score > e.topScore {
 			e.topScore = f.Score
@@ -1098,9 +1189,9 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 	for _, k := range entryKeys {
 		e := entries[k]
 		// Per-class avg-glyph widths (px) calibrated to the CSS in the template.
-		titleLines := wrapForWidth(e.Title, entryTextPx, 7.2)    // node-title:  13px sans 600
-		subLines := wrapForWidth(e.Subtitle, entryTextPx, 6.6)   // node-sub:    11px monospace
-		metaLines := wrapForWidth(e.Meta, entryTextPx, 5.7)      // node-meta:   10.5px sans
+		titleLines := wrapForWidth(e.Title, entryTextPx, 7.2)  // node-title:  13px sans 600
+		subLines := wrapForWidth(e.Subtitle, entryTextPx, 6.6) // node-sub:    11px monospace
+		metaLines := wrapForWidth(e.Meta, entryTextPx, 5.7)    // node-meta:   10.5px sans
 		lines, height := composeLines(16, []textCluster{
 			{class: "node-title", lineHeight: 17, leadIn: 22, lines: titleLines},
 			{class: "node-sub", lineHeight: 14, leadIn: 18, lines: subLines},
@@ -1141,7 +1232,7 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 	// Build impact nodes.
 	impactNodeList := make([]GraphNode, 0, len(impactKeys))
 	for _, c := range impactKeys {
-		titleLines := wrapForWidth(impactLabel(c), impactTextPx, 8.5)  // impact-title: 13px bold uppercase
+		titleLines := wrapForWidth(impactLabel(c), impactTextPx, 8.5)   // impact-title: 13px bold uppercase
 		metaLines := wrapForWidth(impactSubtitle(c), impactTextPx, 5.7) // node-meta:    10.5px sans
 		lines, height := composeLines(16, []textCluster{
 			{class: "impact-title", lineHeight: 18, leadIn: 26, lines: titleLines},
@@ -1212,26 +1303,124 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 		g.Nodes = append(g.Nodes, impactNodeList[i])
 	}
 
-	// Edges: entry → capability (per finding), capability → impact (by category).
+	// Edges: entry → capability (per finding), capability → impact (by category). Each edge gets
+	// a stable ID derived from the node IDs so the JS layer can highlight by lookup.
+	// edgesByNode tracks which edge IDs touch each node so the side panel can dim everything else
+	// when the user hovers/clicks one node.
+	edgesByNode := map[string][]string{}
+	payload := GraphPayload{Glossary: Glossary, Techniques: Techniques, Categories: Categories}
 	for i, f := range caps {
 		entryNode, okE := entryNodePos[entryForCap[i]]
 		capNode := capNodes[i]
 		impNode, okI := impactNodePos[f.Category]
 		class := severityClass(f.Severity)
+		techKey := TechniqueKeyForFinding(f)
 		if okE {
+			edgeID := "edge-" + entryNode.ID + "-" + capNode.ID
 			g.Edges = append(g.Edges, GraphEdge{
+				ID:    edgeID,
 				Class: class,
 				D:     bezier(entryNode.X+entryNode.Width, entryNode.Y+entryNode.Height/2, capNode.X, capNode.Y+capNode.Height/2),
 			})
+			payload.Edges = append(payload.Edges, GraphEdgeDetail{
+				ID:           edgeID,
+				From:         entryNode.ID,
+				To:           capNode.ID,
+				Class:        class,
+				TechniqueKey: techKey,
+				ActionLabel:  "abuses",
+			})
+			edgesByNode[entryNode.ID] = append(edgesByNode[entryNode.ID], edgeID)
+			edgesByNode[capNode.ID] = append(edgesByNode[capNode.ID], edgeID)
 		}
 		if okI {
+			edgeID := "edge-" + capNode.ID + "-" + impNode.ID
 			g.Edges = append(g.Edges, GraphEdge{
+				ID:    edgeID,
 				Class: class,
 				D:     bezier(capNode.X+capNode.Width, capNode.Y+capNode.Height/2, impNode.X, impNode.Y+impNode.Height/2),
 			})
+			payload.Edges = append(payload.Edges, GraphEdgeDetail{
+				ID:          edgeID,
+				From:        capNode.ID,
+				To:          impNode.ID,
+				Class:       class,
+				ActionLabel: "leads to",
+			})
+			edgesByNode[capNode.ID] = append(edgesByNode[capNode.ID], edgeID)
+			edgesByNode[impNode.ID] = append(edgesByNode[impNode.ID], edgeID)
 		}
 	}
-	return g
+
+	// Build the per-node detail payload now that edge IDs are known. Glossary keys are derived
+	// from the representative finding's Subject/Resource (for entries) or the rule's technique
+	// (for capabilities). Categories carry their own explainer copy.
+	for _, k := range entryKeys {
+		e := entries[k]
+		node := entryNodePos[k]
+		gloss := ""
+		if e.hasRep {
+			if key := GlossaryKeyForSubject(e.representative.Subject); key != "" {
+				gloss = key
+			} else if key := GlossaryKeyForResource(e.representative.Resource); key != "" {
+				gloss = key
+			}
+		}
+		payload.Nodes = append(payload.Nodes, GraphNodeDetail{
+			ID:          node.ID,
+			Kind:        "entry",
+			Severity:    e.SevClass,
+			Title:       e.Title,
+			Subtitle:    e.Subtitle,
+			GlossaryKey: gloss,
+			EntryKind:   e.entryKind,
+			EdgeIDs:     edgesByNode[node.ID],
+		})
+	}
+	for i, f := range caps {
+		node := capNodes[i]
+		hops := make([]HopView, 0, len(f.EscalationPath))
+		for _, h := range f.EscalationPath {
+			hops = append(hops, HopView{
+				Step:         h.Step,
+				From:         h.FromSubject.Key(),
+				To:           h.ToSubject.Key(),
+				Action:       h.Action,
+				TechniqueKey: h.Action, // Techniques map is keyed by the same string
+				Permission:   h.Permission,
+				Gains:        h.Gains,
+			})
+		}
+		payload.Nodes = append(payload.Nodes, GraphNodeDetail{
+			ID:           node.ID,
+			Kind:         "capability",
+			Severity:     severityClass(f.Severity),
+			Title:        f.Title,
+			Subtitle:     fmt.Sprintf("score %.1f · %s", f.Score, categoryLabel(f.Category)),
+			RuleID:       f.RuleID,
+			TechniqueKey: TechniqueKeyForFinding(f),
+			Description:  f.Description,
+			Remediation:  f.Remediation,
+			References:   append([]string(nil), f.References...),
+			Hops:         hops,
+			RiskCategory: string(f.Category),
+			EdgeIDs:      edgesByNode[node.ID],
+		})
+	}
+	for _, c := range impactKeys {
+		node := impactNodePos[c]
+		payload.Nodes = append(payload.Nodes, GraphNodeDetail{
+			ID:           node.ID,
+			Kind:         "impact",
+			Severity:     "crit",
+			Title:        impactLabel(c),
+			Subtitle:     impactSubtitle(c),
+			RiskCategory: string(c),
+			EdgeIDs:      edgesByNode[node.ID],
+		})
+	}
+
+	return g, payload
 }
 
 // entryIdentity returns a stable key + display strings for the entity an attacker would target to exercise this finding.
@@ -1482,7 +1671,7 @@ const htmlTemplate = `<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Kubesplaining Report{{ if .Snapshot.Metadata.ClusterName }} — {{ .Snapshot.Metadata.ClusterName }}{{ end }}</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
   <style>
     :root {
       --bg-0: #0a0d16; --bg-1: #0f1422;
@@ -1581,18 +1770,130 @@ const htmlTemplate = `<!doctype html>
 
     .graph-intro { color: var(--text-mut); font-size: 14px; max-width: 820px; margin: 0 0 4px; }
     .graph-intro strong { color: var(--text); }
+    .graph-intro .kp-hint { display: inline-block; margin-left: 4px; color: var(--accent); font-size: 12.5px; }
     .graph-wrap { margin-top: 10px; overflow-x: auto; }
+    .kp-graph-card { position: relative; }
     .attack-svg { width: 100%; min-width: 980px; height: auto; display: block; }
+    .attack-svg text { pointer-events: none; user-select: none; }
+    .attack-svg rect.lane-pill { fill: rgba(255,255,255,0.025); stroke: var(--border-soft); stroke-width: 0.6; }
     .attack-svg text.lane-hd { font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; fill: #8d99b1; }
     .attack-svg text.node-title { font-size: 13px; font-weight: 600; fill: #e6eaf3; }
     .attack-svg text.node-sub { font-size: 11px; fill: #bdc9df; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
     .attack-svg text.node-meta { font-size: 10.5px; fill: #8d99b1; }
     .attack-svg text.rule-id { font-size: 10px; fill: #ff9a3c; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; letter-spacing: 0.03em; }
     .attack-svg text.impact-title { font-size: 13px; font-weight: 700; fill: #ffdbe0; letter-spacing: 0.01em; }
-    .attack-svg .edge { stroke-width: 1.4; fill: none; opacity: 0.85; }
-    .attack-svg .edge.crit { stroke: #ff5568; }
-    .attack-svg .edge.high { stroke: #ff9a3c; }
+    .attack-svg .edge { stroke-width: 1.4; fill: none; opacity: 0.85; transition: opacity 0.18s ease, stroke-width 0.18s ease; }
+    .attack-svg .edge.crit { stroke: #ff5568; stroke-dasharray: 6 8; animation: kp-flow 1.6s linear infinite; stroke-linecap: round; }
+    .attack-svg .edge.high { stroke: #ff9a3c; stroke-dasharray: 6 8; animation: kp-flow 2.2s linear infinite; stroke-linecap: round; }
     .attack-svg .edge.med  { stroke: #6ab7ff; stroke-dasharray: 3 3; opacity: 0.7; }
+    @keyframes kp-flow { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -28; } }
+    @keyframes kp-pulse { 0%,100% { filter: drop-shadow(0 0 4px rgba(255,85,104,0.35)); } 50% { filter: drop-shadow(0 0 12px rgba(255,85,104,0.6)); } }
+
+    .attack-svg .kp-node { cursor: pointer; outline: none; transition: opacity 0.2s ease; }
+    .attack-svg .kp-node rect.kp-node-rect { transition: stroke-width 0.18s ease, stroke-opacity 0.18s ease, filter 0.18s ease; }
+    .attack-svg .kp-node:hover rect.kp-node-rect,
+    .attack-svg .kp-node:focus-visible rect.kp-node-rect { stroke-width: 1.8; stroke-opacity: 0.95; filter: drop-shadow(0 0 8px rgba(255,255,255,0.06)); }
+    .attack-svg .kp-node:focus-visible rect.kp-node-rect { stroke-dasharray: 4 3; }
+    .attack-svg .kp-sev-dot { r: 4.5; }
+    .attack-svg .kp-sev-crit { fill: #ff5568; filter: drop-shadow(0 0 4px rgba(255,85,104,0.55)); }
+    .attack-svg .kp-sev-high { fill: #ff9a3c; filter: drop-shadow(0 0 4px rgba(255,154,60,0.55)); }
+    .attack-svg .kp-sev-med  { fill: #6ab7ff; filter: drop-shadow(0 0 4px rgba(106,183,255,0.55)); }
+    .attack-svg .kp-node-impact rect.kp-node-rect { animation: kp-pulse 3.4s ease-in-out infinite; }
+
+    /* Hover/click highlight: dim non-related, hot-glow related. */
+    .attack-svg.kp-active .kp-node.kp-dim { opacity: 0.18; }
+    .attack-svg.kp-active [data-edge-id].kp-dim { opacity: 0.12; }
+    .attack-svg.kp-active .kp-node.kp-hot rect.kp-node-rect { stroke-width: 2.2; stroke-opacity: 1; filter: drop-shadow(0 0 14px rgba(255,154,60,0.45)); }
+    .attack-svg.kp-active [data-edge-id].kp-hot { opacity: 1; stroke-width: 2.4; }
+
+    /* Filter chips */
+    .kp-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 14px 0 6px; }
+    .kp-filters-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em; color: var(--text-mut); padding-right: 6px; }
+    .kp-filters-sep { width: 1px; height: 16px; background: var(--border-soft); margin: 0 6px; }
+    .kp-chip { display: inline-flex; align-items: center; gap: 6px; font: inherit; font-size: 12px; font-weight: 600; padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: rgba(255,255,255,0.02); color: var(--text); cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease; }
+    .kp-chip:hover { border-color: var(--border-strong); background: var(--surface-hover); }
+    .kp-chip[aria-pressed="false"] { color: var(--text-dim); background: transparent; border-style: dashed; }
+    .kp-chip[aria-pressed="false"] .kp-chip-dot { opacity: 0.3; }
+    .kp-chip-dot { width: 8px; height: 8px; border-radius: 999px; display: inline-block; }
+    .kp-chip-dot.crit { background: var(--critical); }
+    .kp-chip-dot.high { background: var(--high); }
+    .kp-chip-dot.med  { background: var(--medium); }
+    .kp-chip-reset { color: var(--accent); border-color: rgba(106,183,255,0.35); }
+
+    /* Filter dim rules: pure CSS so toggling is reflow-free. */
+    .attack-svg.kp-hide-sev-crit [data-sev="crit"]   { opacity: 0.10; pointer-events: none; }
+    .attack-svg.kp-hide-sev-high [data-sev="high"]   { opacity: 0.10; pointer-events: none; }
+    .attack-svg.kp-hide-sev-med  [data-sev="med"]    { opacity: 0.10; pointer-events: none; }
+    .attack-svg.kp-hide-sev-crit .edge.crit { opacity: 0.08; }
+    .attack-svg.kp-hide-sev-high .edge.high { opacity: 0.08; }
+    .attack-svg.kp-hide-sev-med  .edge.med  { opacity: 0.08; }
+
+    /* Side detail panel */
+    .kp-detail { position: fixed; top: 80px; right: 24px; width: 380px; max-width: calc(100vw - 48px); max-height: calc(100vh - 110px); overflow-y: auto; background: var(--surface); border: 1px solid var(--border-strong); border-radius: 14px; padding: 18px 20px 22px; z-index: 50; box-shadow: 0 18px 60px rgba(0,0,0,0.55); transform: translateX(20px); opacity: 0; transition: transform 0.22s ease, opacity 0.18s ease; }
+    .kp-detail.kp-open { transform: translateX(0); opacity: 1; }
+    .kp-detail-hd { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+    .kp-detail-hd h3 { font-size: 16px; line-height: 1.3; flex: 1; }
+    .kp-detail-close { background: transparent; border: 1px solid var(--border); color: var(--text-mut); width: 28px; height: 28px; border-radius: 8px; font-size: 18px; cursor: pointer; line-height: 1; padding: 0; }
+    .kp-detail-close:hover { color: var(--text); border-color: var(--border-strong); }
+    .kp-panel-meta { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-bottom: 6px; }
+    .kp-panel-sub { color: var(--text-mut); font-size: 12px; word-break: break-all; margin-bottom: 12px; }
+    .kp-sev-badge { font-size: 10.5px; font-weight: 700; padding: 3px 8px; border-radius: 999px; letter-spacing: 0.06em; }
+    .kp-sev-badge.kp-sev-crit { background: var(--critical-soft); color: #ffb4be; border: 1px solid var(--critical-edge); }
+    .kp-sev-badge.kp-sev-high { background: var(--high-soft); color: #ffc89a; border: 1px solid var(--high-edge); }
+    .kp-sev-badge.kp-sev-med  { background: var(--medium-soft); color: #ffe9a1; border: 1px solid var(--medium-edge); }
+    .kp-kind-badge { font-size: 10.5px; padding: 3px 8px; border-radius: 999px; background: rgba(106,183,255,0.10); color: #bedbff; border: 1px solid rgba(106,183,255,0.28); letter-spacing: 0.04em; }
+    .kp-rule { font-size: 11px; padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; color: var(--text-mut); background: rgba(255,255,255,0.02); }
+    .kp-section { margin-top: 16px; }
+    .kp-section h4 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-mut); font-weight: 700; margin-bottom: 6px; }
+    .kp-prose { color: var(--text); font-size: 13.5px; line-height: 1.6; margin: 0; }
+    .kp-prose p { margin: 0 0 8px; }
+    .kp-prose p:last-child { margin-bottom: 0; }
+    .kp-prose code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+    .kp-prose strong { color: var(--text); }
+    .kp-prose em { color: #ffdbe0; font-style: normal; }
+    .kp-prose ul, .kp-prose ol { margin: 6px 0 0; padding-left: 20px; }
+    .kp-prose li { margin: 3px 0; }
+    .kp-doc-link { margin-top: 8px; font-size: 12.5px; }
+    .kp-tech .kp-mitre { display: inline-block; margin-top: 8px; padding: 2px 8px; font-size: 11px; font-family: "JetBrains Mono", monospace; color: #ffc89a; background: var(--high-soft); border: 1px solid var(--high-edge); border-radius: 6px; letter-spacing: 0.02em; }
+    .kp-steps-hd { font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-mut); font-weight: 700; margin: 12px 0 4px; }
+    .kp-steps { margin: 0; padding-left: 20px; font-size: 12.5px; line-height: 1.6; color: var(--text); }
+    .kp-steps li { margin: 4px 0; font-family: "JetBrains Mono", monospace; word-break: break-word; }
+    .kp-fix { background: rgba(106,183,255,0.05); border: 1px solid rgba(106,183,255,0.18); border-radius: 10px; padding: 10px 12px; margin-top: 16px; }
+    .kp-fix h4 { color: var(--accent); margin-bottom: 4px; }
+    .kp-refs { margin: 0; padding-left: 18px; font-size: 12.5px; color: var(--text-mut); }
+    .kp-refs li { margin: 3px 0; }
+    .kp-refs a { word-break: break-all; }
+    .kp-examples { margin: 6px 0 0; padding-left: 18px; color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
+    .kp-walk-btn { display: inline-flex; align-items: center; gap: 8px; font: inherit; font-weight: 600; font-size: 13px; padding: 8px 14px; border-radius: 10px; border: 1px solid var(--high-edge); background: var(--high-soft); color: #ffc89a; cursor: pointer; margin-top: 4px; }
+    .kp-walk-btn:hover { background: rgba(255,154,60,0.2); }
+    .kp-walk-nav { display: flex; gap: 8px; margin-bottom: 12px; }
+    .kp-walk-nav button { font: inherit; font-size: 12px; padding: 5px 12px; border-radius: 999px; border: 1px solid var(--border); background: rgba(255,255,255,0.02); color: var(--text); cursor: pointer; }
+    .kp-walk-nav button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .kp-walk-exit { color: var(--text-mut) !important; border-style: dashed !important; }
+    .kp-walk-progress { color: var(--text-mut); font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; font-weight: 700; margin-bottom: 10px; }
+    .kp-walk-card { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.02); }
+    .kp-walk-from { border-color: rgba(106,183,255,0.3); background: rgba(106,183,255,0.06); }
+    .kp-walk-action { border-color: var(--high-edge); background: rgba(255,154,60,0.06); margin-top: 0; }
+    .kp-walk-to { border-color: var(--critical-edge); background: rgba(255,85,104,0.06); }
+    .kp-walk-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--text-mut); font-weight: 700; margin-bottom: 4px; }
+    .kp-walk-id { font-size: 13px; color: var(--text); word-break: break-all; }
+    .kp-walk-perm { color: var(--text-mut); font-size: 11.5px; margin-top: 4px; word-break: break-word; }
+    .kp-walk-explainer { margin-top: 8px; }
+    .kp-walk-gain { color: var(--text-mut); font-size: 12.5px; margin-top: 4px; }
+    .kp-walk-arrow { text-align: center; color: var(--high); font-size: 18px; line-height: 1; margin: 6px 0; }
+
+    /* Floating tooltip */
+    .kp-tooltip { position: absolute; transform: translate(-50%, -100%); background: var(--surface); border: 1px solid var(--border-strong); border-radius: 10px; padding: 8px 12px; max-width: 320px; z-index: 60; box-shadow: 0 12px 32px rgba(0,0,0,0.5); pointer-events: none; }
+    .kp-tt-title { font-size: 12.5px; font-weight: 600; color: var(--text); }
+    .kp-tt-body { font-size: 12px; color: var(--text-mut); margin-top: 4px; line-height: 1.5; }
+    .kp-tt-prose { margin-top: 4px; }
+    .kp-tt-prose p { margin: 0 0 4px; }
+    .kp-tt-prose code { background: rgba(255,255,255,0.05); padding: 1px 4px; border-radius: 4px; }
+
+    @media (max-width: 980px) {
+      .kp-detail { position: relative; top: auto; right: auto; width: 100%; max-width: 100%; margin-top: 12px; transform: translateY(8px); }
+      .kp-detail.kp-open { transform: translateY(0); }
+    }
 
     .narratives { display: grid; grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); gap: 16px; }
     .narrative { border: 1px solid var(--border); border-radius: 16px; padding: 18px 20px; background: var(--surface); position: relative; overflow: hidden; }
@@ -1796,7 +2097,7 @@ const htmlTemplate = `<!doctype html>
 
     {{ if .Graph.Nodes }}
     <section>
-      <div class="card">
+      <div class="card kp-graph-card">
         <div class="card-hd">
           <div>
             <div class="kicker">Think in graphs</div>
@@ -1807,49 +2108,78 @@ const htmlTemplate = `<!doctype html>
             <span class="legend-item"><span class="legend-dot high"></span>high edge</span>
           </div>
         </div>
-        <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves — so a finding's real danger is the <em>path</em> it joins, not its individual score.</p>
+        <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves — so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
+        <div class="kp-filters" role="toolbar" aria-label="Filter the attack graph">
+          <span class="kp-filters-label">Show</span>
+          <button type="button" class="kp-chip" data-filter="sev" data-value="crit" aria-pressed="true"><span class="kp-chip-dot crit"></span>Critical</button>
+          <button type="button" class="kp-chip" data-filter="sev" data-value="high" aria-pressed="true"><span class="kp-chip-dot high"></span>High</button>
+          <button type="button" class="kp-chip" data-filter="sev" data-value="med" aria-pressed="true"><span class="kp-chip-dot med"></span>Medium</button>
+          <span class="kp-filters-sep" aria-hidden="true"></span>
+          <button type="button" class="kp-chip" data-filter="kind" data-value="Subject" aria-pressed="true">Subjects</button>
+          <button type="button" class="kp-chip" data-filter="kind" data-value="Resource" aria-pressed="true">Resources</button>
+          <span class="kp-filters-sep" aria-hidden="true"></span>
+          <button type="button" class="kp-chip kp-chip-reset" data-action="reset">Reset</button>
+        </div>
         <div class="graph-wrap">
-          <svg class="attack-svg" viewBox="0 0 {{ .Graph.Width }} {{ .Graph.Height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Attack path graph">
+          <svg class="attack-svg" viewBox="0 0 {{ .Graph.Width }} {{ .Graph.Height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Attack path graph — interactive">
             <defs>
               <linearGradient id="impact-crit" x1="0" x2="1" y1="0" y2="0">
                 <stop offset="0%" stop-color="#3a1018"/><stop offset="100%" stop-color="#1d0b10"/>
               </linearGradient>
+              <symbol id="kp-icon-sa" viewBox="0 0 16 16">
+                <circle cx="8" cy="6" r="3" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                <path d="M2.5 14c0-2.8 2.5-4.5 5.5-4.5s5.5 1.7 5.5 4.5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+              </symbol>
+              <symbol id="kp-icon-group" viewBox="0 0 16 16">
+                <circle cx="5" cy="6" r="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                <circle cx="11" cy="6" r="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                <path d="M1.5 13.5c0-2 1.7-3.4 3.5-3.4s3.5 1.4 3.5 3.4M7.5 13.5c0-2 1.7-3.4 3.5-3.4s3.5 1.4 3.5 3.4" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+              </symbol>
+              <symbol id="kp-icon-resource" viewBox="0 0 16 16">
+                <path d="M8 1.5l5.5 3v7L8 14.5 2.5 11.5v-7z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+                <path d="M2.5 4.5L8 7.5l5.5-3M8 7.5v7" fill="none" stroke="currentColor" stroke-width="1.4"/>
+              </symbol>
+              <symbol id="kp-icon-key" viewBox="0 0 16 16">
+                <circle cx="5" cy="11" r="2.6" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                <path d="M6.8 9.2L13.5 2.5M11 5l1.5 1.5M9 7l1.5 1.5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+              </symbol>
             </defs>
             {{ range $i, $lane := .Graph.Lanes }}
+              <rect class="lane-pill" x="{{ sub $lane.X 6 }}" y="6" width="120" height="22" rx="11"/>
               <text class="lane-hd" x="{{ $lane.X }}" y="22">{{ $lane.Label }}</text>
             {{ end }}
             <line x1="340" y1="36" x2="340" y2="{{ sub .Graph.Height 10 }}" stroke="#1a2134" stroke-dasharray="2 4"/>
             <line x1="700" y1="36" x2="700" y2="{{ sub .Graph.Height 10 }}" stroke="#1a2134" stroke-dasharray="2 4"/>
             {{ range .Graph.Edges }}
-              <path class="edge {{ .Class }}" d="{{ .D }}"/>
+              <path class="edge {{ .Class }}" data-edge-id="{{ .ID }}" d="{{ .D }}"/>
             {{ end }}
             {{ range .Graph.Nodes }}
               {{ $node := . }}
               {{ if eq .Kind "entry" }}
-                <g>
-                  <rect x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="10"
+                <g class="kp-node kp-node-entry" data-node-id="{{ .ID }}" data-kind="entry" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="Entry point">
+                  <rect class="kp-node-rect" x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="10"
                         fill="#151c2c"
                         stroke="{{ if eq .SevClass "crit" }}#ff5568{{ else if eq .SevClass "high" }}#ff9a3c{{ else }}#6ab7ff{{ end }}"
                         stroke-opacity="0.55"/>
-                  <rect x="{{ .X }}" y="{{ .Y }}" width="4" height="{{ .Height }}" rx="2"
-                        fill="{{ if eq .SevClass "crit" }}#ff5568{{ else if eq .SevClass "high" }}#ff9a3c{{ else }}#6ab7ff{{ end }}"/>
+                  <circle class="kp-sev-dot kp-sev-{{ .SevClass }}" cx="{{ add .X 12 }}" cy="{{ add .Y 14 }}" r="4"/>
                   {{ range .Lines }}
                     <text class="{{ .Class }}" x="{{ add $node.X .OffsetX }}" y="{{ add $node.Y .OffsetY }}">{{ .Text }}</text>
                   {{ end }}
                 </g>
               {{ else if eq .Kind "capability" }}
-                <g>
-                  <rect x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="8"
+                <g class="kp-node kp-node-cap" data-node-id="{{ .ID }}" data-kind="capability" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="Abused capability">
+                  <rect class="kp-node-rect" x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="8"
                         fill="#1a2338"
                         stroke="{{ if eq .SevClass "crit" }}#ff5568{{ else }}#ff9a3c{{ end }}"
                         stroke-opacity="0.55"/>
+                  <circle class="kp-sev-dot kp-sev-{{ .SevClass }}" cx="{{ add .X 11 }}" cy="{{ add .Y 13 }}" r="4"/>
                   {{ range .Lines }}
                     <text class="{{ .Class }}" x="{{ add $node.X .OffsetX }}" y="{{ add $node.Y .OffsetY }}">{{ .Text }}</text>
                   {{ end }}
                 </g>
               {{ else if eq .Kind "impact" }}
-                <g>
-                  <rect x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="10"
+                <g class="kp-node kp-node-impact" data-node-id="{{ .ID }}" data-kind="impact" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="Impact">
+                  <rect class="kp-node-rect" x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="10"
                         fill="url(#impact-crit)" stroke="#ff5568" stroke-width="1.2"/>
                   {{ range .Lines }}
                     <text class="{{ .Class }}" x="{{ add $node.X .OffsetX }}" y="{{ add $node.Y .OffsetY }}">{{ .Text }}</text>
@@ -1860,6 +2190,22 @@ const htmlTemplate = `<!doctype html>
           </svg>
         </div>
       </div>
+
+      <aside class="kp-detail" hidden role="dialog" aria-modal="false" aria-labelledby="kp-detail-title">
+        <header class="kp-detail-hd">
+          <h3 id="kp-detail-title">Click a node</h3>
+          <button type="button" class="kp-detail-close" aria-label="Close">×</button>
+        </header>
+        <div class="kp-detail-body" id="kp-detail-body"></div>
+      </aside>
+
+      <div class="kp-tooltip" hidden role="tooltip">
+        <div class="kp-tt-title"></div>
+        <div class="kp-tt-body" hidden></div>
+      </div>
+
+      <script type="application/json" id="kp-graph-data">{{ .GraphJSON }}</script>
+      <script>{{ .GraphScript }}</script>
     </section>
     {{ end }}
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -3,6 +3,7 @@ package report
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hardik/kubesplaining/internal/models"
@@ -125,5 +126,53 @@ func TestBuildHTMLDataGroupsFindings(t *testing.T) {
 	}
 	if len(data.TopNamespaces) == 0 || data.TopNamespaces[0].Label != "default" {
 		t.Fatalf("unexpected top namespaces: %#v", data.TopNamespaces)
+	}
+}
+
+// TestHTMLReportInteractiveGraph verifies the rendered HTML carries the markup the JS layer
+// requires (CSP allows scripts, JSON payload is embedded, nodes/edges have data IDs). It is a
+// smoke test for the contract between Go and the embedded interactivity, not a behaviour test.
+func TestHTMLReportInteractiveGraph(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	snapshot := models.NewSnapshot()
+	findings := []models.Finding{
+		{
+			ID:       "f-cap",
+			RuleID:   "KUBE-PRIVESC-009",
+			Severity: models.SeverityCritical,
+			Score:    9.5,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "RBAC bind/escalate permission",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "risky", Namespace: "default"},
+			Tags:     []string{"module:rbac"},
+		},
+	}
+
+	if _, err := Write(tmpDir, []string{"html"}, snapshot, findings); err != nil {
+		t.Fatalf("Write html: %v", err)
+	}
+
+	htmlBytes, err := os.ReadFile(filepath.Join(tmpDir, "report.html"))
+	if err != nil {
+		t.Fatalf("read report.html: %v", err)
+	}
+	html := string(htmlBytes)
+
+	mustContain := []string{
+		`script-src 'unsafe-inline'`,
+		`<script type="application/json" id="kp-graph-data">`,
+		`data-node-id=`,
+		`data-edge-id=`,
+		`class="kp-filters"`,
+		`class="kp-detail"`,
+		`class="kp-tooltip"`,
+		`KUBE-PRIVESC-009`,
+	}
+	for _, needle := range mustContain {
+		if !strings.Contains(html, needle) {
+			t.Errorf("rendered HTML missing %q", needle)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- The "Attack paths" graph in the HTML report was static SVG — useful as a structural diagram, useless as a teaching artifact. A reader who didn't already know what a `ServiceAccount`, `bind/escalate`, or `system:masters` was had no way to learn from it.
- Now: hover any node to highlight its connected path with a tooltip, click for a slide-in side panel with a plain-language explainer, MITRE ATT&CK mapping, concrete attacker commands, and remediation. Privesc-PATH findings expose a "Walk the chain step-by-step" mode that paginates through each hop.
- Filter chips above the graph dim by severity and entry kind without reflowing layout.
- Stays single-file self-contained: no external assets, no library, vanilla JS as a Go const, JSON payload inlined. CSP gains `script-src 'unsafe-inline'` (the only addition).

## What changed

- New `internal/report/glossary.go` — ~25 K8s glossary entries, 11 attacker-technique explainers (one per privesc action), 5 risk-category explainers. Educational copy lives in the report package, not on `models.Finding`, so it stays out of JSON/CSV/SARIF.
- New `internal/report/graph_script.go` — vanilla JS that reads the JSON payload, wires hover/click/keyboard handlers, drives the side panel, and powers the walkthrough.
- `internal/report/report.go` — new `GraphPayload`/`GraphNodeDetail`/`GraphEdgeDetail`/`HopView` structs alongside the existing `AttackGraph`; `buildAttackGraph` now returns both. Template gains `data-node-id`/`data-edge-id`/`data-sev`/`data-kind` attributes, type-icon `<symbol>` defs, severity dots, lane-header pills, filter chips, slide-in side panel, floating tooltip, and the inline JSON + JS scripts. ~150 lines of new CSS for dim/hot states, animated edge flow, focus rings, walkthrough cards, and a responsive panel that docks below the graph under 980px.
- `internal/report/report_test.go` — `TestHTMLReportInteractiveGraph` smoke-tests the contract: CSP, JSON block, data attributes, panel/tooltip markup all present.

## Test plan

- [x] `make build` — clean.
- [x] `make test` — all packages green, including the new `TestHTMLReportInteractiveGraph`.
- [x] `make lint` — gofmt + vet clean.
- [x] `make e2e` — kind cluster boots, CLI runs, report at `.tmp/e2e-report/report.html` carries the new markup (7 entries, 10 capabilities, 2 impacts, 83 occurrences of the interactive markers).
- [ ] **Manual browser verification** — open `.tmp/e2e-report/report.html`:
  - DevTools console: zero CSP violations, zero network requests.
  - Hover a `ServiceAccount` entry → connected edges + downstream cap light up, others dim, tooltip explains what a ServiceAccount is.
  - Click `KUBE-PRIVESC-009` → side panel shows rule ID, `bind_or_escalate` plain-English explainer, MITRE ATT&CK ref, attacker commands, remediation, references.
  - Click a privesc-PATH finding → "Walk the chain step-by-step" button paginates the hop chain.
  - Filter chip "Hide Medium" dims medium edges/nodes; layout stable.
  - Tab cycles through nodes, Enter opens panel, Esc closes.
  - Resize to 800px → graph scrolls horizontally; panel re-docks below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)