### PR TITLE
Humanize Evidence rendering in finding cards

### DIFF
--- a/internal/report/evidence_glossary.go
+++ b/internal/report/evidence_glossary.go
@@ -1,0 +1,247 @@
+// Package report — evidence glossary. Static lookup tables that turn opaque cluster
+// observations (verb names, host paths, CIDRs, secret types, …) into one-sentence
+// "what does this mean and why does it matter" hints rendered next to the raw value
+// in the Findings tab. Keep entries terse: the surrounding finding card already carries
+// Description / Impact / AttackScenario prose, so this is annotation, not exposition.
+package report
+
+import (
+	"net"
+	"strings"
+)
+
+// dangerousVerbs maps RBAC verbs that carry outsized blast radius to a one-line hint.
+// Used by the verb chip renderer to flag verbs that aren't merely "broad" but actively
+// dangerous. Lowercase keys; verb input is lowercased before lookup.
+var dangerousVerbs = map[string]string{
+	"impersonate":      "Act as any user, group, or ServiceAccount",
+	"escalate":         "Grant rules beyond the caller's own permissions",
+	"bind":             "Bind any role to any subject",
+	"approve":          "Approve CertificateSigningRequests (issue cluster certs)",
+	"sign":             "Sign CertificateSigningRequests (issue cluster certs)",
+	"create":           "Create new objects of this resource",
+	"delete":           "Permanently remove objects",
+	"deletecollection": "Bulk-delete every object of this resource",
+	"patch":            "Mutate existing objects in place",
+	"update":           "Replace existing objects",
+	"*":                "Wildcard — every verb (get, list, create, update, delete, …)",
+}
+
+// sensitiveResources flags Kubernetes resources whose access is itself a high-impact
+// capability (secrets read = credential theft, pods/exec = remote shell, etc.). Lowercase.
+var sensitiveResources = map[string]string{
+	"secrets":                         "Holds credentials, tokens, TLS keys",
+	"pods/exec":                       "Remote shell into any pod",
+	"pods/attach":                     "Attach to a running container's stdio",
+	"pods/portforward":                "Tunnel arbitrary TCP into the cluster network",
+	"pods":                            "Workload primitive — create = run code on the cluster",
+	"nodes/proxy":                     "Direct kubelet access — bypasses API server authz",
+	"clusterroles":                    "Cluster-scoped RBAC rules",
+	"clusterrolebindings":             "Cluster-scoped RBAC grants",
+	"roles":                           "Namespace-scoped RBAC rules",
+	"rolebindings":                    "Namespace-scoped RBAC grants",
+	"serviceaccounts":                 "Pod identities (and their tokens)",
+	"serviceaccounts/token":           "Mint short-lived ServiceAccount tokens",
+	"certificatesigningrequests":      "Issue X.509 certs honored by the API server",
+	"validatingwebhookconfigurations": "Admission policy — bypassing it disables enforcement",
+	"mutatingwebhookconfigurations":   "Admission policy — controls what enters the cluster",
+	"persistentvolumes":               "Cluster-scoped storage that can mount host paths",
+	"*":                               "Wildcard — every resource",
+}
+
+// sensitiveAPIGroups annotates well-known API groups that carry RBAC-relevant power.
+// Empty group ("") is the core API; we render that as "core/v1" and skip the hint.
+var sensitiveAPIGroups = map[string]string{
+	"rbac.authorization.k8s.io":    "RBAC objects — write access ≈ cluster takeover",
+	"admissionregistration.k8s.io": "Admission webhooks — controls policy enforcement",
+	"certificates.k8s.io":          "Issues cluster-trusted certificates",
+	"policy":                       "PodSecurityPolicy / PodDisruptionBudget",
+	"*":                            "Wildcard — every API group",
+}
+
+// sensitiveHostPathHints annotates host paths whose mount into a container is a
+// well-known escape primitive. The lookup tries an exact match first, then walks
+// up the path segments so e.g. "/var/run/docker.sock" matches even if scanned
+// against "/var/run/docker.sock/". Keys are lowercased and trimmed of trailing slashes.
+var sensitiveHostPathHints = map[string]string{
+	"/":                                   "Node root filesystem — full host takeover",
+	"/etc":                                "Node config — kubelet/CNI/auth files",
+	"/etc/kubernetes":                     "Kubelet kubeconfig & PKI material",
+	"/etc/kubernetes/pki":                 "Cluster PKI — root CA private keys",
+	"/var":                                "Node persistent state",
+	"/var/lib":                            "Persistent state for system daemons",
+	"/var/lib/kubelet":                    "Kubelet credentials & pod tokens for every pod on the node",
+	"/var/lib/docker":                     "Container engine state — image & layer access",
+	"/var/lib/containerd":                 "Container engine state — image & layer access",
+	"/var/log":                            "Node logs — symlinks let you read other pods' logs",
+	"/var/run":                            "Container runtime sockets live here",
+	"/var/run/docker.sock":                "Docker socket — container engine takeover",
+	"/var/run/containerd/containerd.sock": "containerd socket — container engine takeover",
+	"/var/run/crio/crio.sock":             "CRI-O socket — container engine takeover",
+	"/run":                                "Runtime sockets & state",
+	"/run/containerd/containerd.sock":     "containerd socket — container engine takeover",
+	"/proc":                               "Host process tree — read /proc/1/root for full FS access",
+	"/sys":                                "Kernel interfaces — cgroup/namespace abuse",
+	"/dev":                                "Host devices — direct disk / kmem access",
+	"/root":                               "Root user home directory",
+	"/home":                               "User home directories",
+}
+
+// sensitiveCIDRs is checked in order; the first match wins. We keep it ordered so
+// the broadest "internet" entries are tried first and noisy private-range hints
+// don't shadow more meaningful annotations.
+var sensitiveCIDRs = []struct {
+	CIDR string
+	Note string
+}{
+	{"0.0.0.0/0", "Entire IPv4 internet — egress here can exfiltrate to any host"},
+	{"::/0", "Entire IPv6 internet — egress here can exfiltrate to any host"},
+	{"169.254.169.254/32", "Cloud instance metadata service — can mint cloud credentials"},
+	{"169.254.0.0/16", "Link-local range (incl. cloud metadata service)"},
+	{"10.0.0.0/8", "RFC1918 private range"},
+	{"172.16.0.0/12", "RFC1918 private range"},
+	{"192.168.0.0/16", "RFC1918 private range"},
+	{"127.0.0.0/8", "Loopback"},
+}
+
+// secretTypeLabels maps Kubernetes built-in Secret types to a one-line label that
+// explains what the secret holds and why it matters. Strings — analyzers emit the
+// raw type string, we don't import corev1 just for this.
+var secretTypeLabels = map[string]string{
+	"Opaque":                              "Generic key/value secret",
+	"kubernetes.io/service-account-token": "Long-lived ServiceAccount token — holding it = acting as the SA",
+	"kubernetes.io/dockercfg":             "Docker registry credentials (legacy format)",
+	"kubernetes.io/dockerconfigjson":      "Docker registry credentials",
+	"kubernetes.io/basic-auth":            "Basic-auth username + password",
+	"kubernetes.io/ssh-auth":              "SSH private key",
+	"kubernetes.io/tls":                   "TLS certificate + private key",
+	"bootstrap.kubernetes.io/token":       "Bootstrap token — joins new nodes to the cluster",
+}
+
+// hostNamespaceHints explains what each pod-level "host*" boolean grants when set.
+var hostNamespaceHints = map[string]string{
+	"hostNetwork":              "Shares the node's network namespace — sees every pod's traffic, binds to node IPs",
+	"hostPID":                  "Shares the node's process namespace — can ptrace/kill node processes",
+	"hostIPC":                  "Shares the node's IPC namespace — reads other processes' shared memory",
+	"privileged":               "Disables nearly all container isolation — effective root on the node",
+	"allowPrivilegeEscalation": "Lets a child process gain more privileges than its parent",
+	"runAsNonRoot":             "When false, the container can run as UID 0",
+}
+
+// dangerousImagePatterns describes container image references that warrant a hint —
+// mutable tags that defeat reproducibility / supply-chain integrity.
+func mutableImageHint(image string) string {
+	if image == "" {
+		return ""
+	}
+	// No tag at all → defaults to :latest
+	if !strings.Contains(image[strings.LastIndex(image, "/")+1:], ":") {
+		return "No tag — pulls :latest, which is mutable"
+	}
+	if strings.HasSuffix(image, ":latest") {
+		return ":latest is mutable — same tag can resolve to different images over time"
+	}
+	return ""
+}
+
+// hostPathHint returns the explanatory note for a host path, or "" if none.
+// Tries an exact match, then walks parent directories upward.
+func hostPathHint(path string) string {
+	if path == "" {
+		return ""
+	}
+	clean := strings.TrimRight(strings.ToLower(strings.TrimSpace(path)), "/")
+	if clean == "" {
+		clean = "/"
+	}
+	if note, ok := sensitiveHostPathHints[clean]; ok {
+		return note
+	}
+	// Walk parent directories: /var/run/docker.sock/foo → /var/run/docker.sock → /var/run → ...
+	for {
+		idx := strings.LastIndex(clean, "/")
+		if idx < 0 {
+			return ""
+		}
+		if idx == 0 {
+			if note, ok := sensitiveHostPathHints["/"]; ok {
+				return note
+			}
+			return ""
+		}
+		clean = clean[:idx]
+		if note, ok := sensitiveHostPathHints[clean]; ok {
+			return note
+		}
+	}
+}
+
+// cidrHint returns the explanatory note for a CIDR block, or "" if none.
+// Matches the input CIDR exactly first, then checks containment for non-universal
+// well-known ranges (so 10.5.0.0/16 still hits the 10.0.0.0/8 hint, but 0.0.0.0/0
+// only matches an exact 0.0.0.0/0 input).
+func cidrHint(cidr string) string {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return ""
+	}
+	for _, entry := range sensitiveCIDRs {
+		if entry.CIDR == cidr {
+			return entry.Note
+		}
+	}
+	_, target, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range sensitiveCIDRs {
+		// Skip universal-internet entries — they "contain" every IPv4/IPv6 address,
+		// so they'd shadow more specific ranges and produce false positives for
+		// any non-matching CIDR.
+		if entry.CIDR == "0.0.0.0/0" || entry.CIDR == "::/0" {
+			continue
+		}
+		_, well, err := net.ParseCIDR(entry.CIDR)
+		if err != nil {
+			continue
+		}
+		if well.Contains(target.IP) {
+			targetOnes, _ := target.Mask.Size()
+			wellOnes, _ := well.Mask.Size()
+			if targetOnes >= wellOnes {
+				return entry.Note
+			}
+		}
+	}
+	return ""
+}
+
+// verbHint returns a one-line meaning for a known dangerous verb (case-insensitive).
+func verbHint(verb string) string {
+	return dangerousVerbs[strings.ToLower(strings.TrimSpace(verb))]
+}
+
+// resourceHint returns a one-line meaning for a known sensitive resource (case-insensitive).
+func resourceHint(resource string) string {
+	return sensitiveResources[strings.ToLower(strings.TrimSpace(resource))]
+}
+
+// apiGroupHint returns the meaning of a known sensitive API group; "" core group is
+// labelled separately by the renderer.
+func apiGroupHint(group string) string {
+	return sensitiveAPIGroups[strings.TrimSpace(group)]
+}
+
+// secretTypeLabel returns the friendly label for a Kubernetes Secret type, or the
+// raw type if unknown.
+func secretTypeLabel(t string) string {
+	if label, ok := secretTypeLabels[t]; ok {
+		return label
+	}
+	return t
+}
+
+// hostNamespaceHint returns the explanatory note for a pod-level host* boolean field.
+func hostNamespaceHint(key string) string {
+	return hostNamespaceHints[key]
+}

--- a/internal/report/evidence_render.go
+++ b/internal/report/evidence_render.go
@@ -1,0 +1,814 @@
+// Package report — humanized rendering of Finding.Evidence and Finding.EscalationPath
+// for the static Findings tab. The analyzer-emitted Evidence payload is a small
+// `map[string]any` per rule; rather than show it as raw JSON (opaque to a Kubernetes
+// newcomer), we walk the known keys and render them as labeled rows with chips and
+// glossary hints. Unknown keys fall back to inline JSON, so future analyzers degrade
+// gracefully without code changes here.
+//
+// All HTML is built via html/template's HTMLEscapeString — no template.HTML is ever
+// constructed from analyzer-supplied content. This matches the safety pattern in
+// renderInlineCode / renderParagraphs.
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"sort"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+// renderEvidence parses Evidence (an analyzer-emitted JSON object) and renders a
+// labeled grid with semantic formatting per known key. Returns "" when the payload
+// is empty or not a JSON object — the caller still emits a "Show raw JSON" details
+// element below this, so structural surprises are still inspectable.
+func renderEvidence(raw json.RawMessage) template.HTML {
+	if len(raw) == 0 {
+		return ""
+	}
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	obj, ok := payload.(map[string]any)
+	if !ok || len(obj) == 0 {
+		return ""
+	}
+
+	var rows strings.Builder
+	for _, key := range orderedEvidenceKeys(obj) {
+		val := obj[key]
+		row := renderEvidenceRow(key, val, obj)
+		if row != "" {
+			rows.WriteString(row)
+		}
+	}
+	if rows.Len() == 0 {
+		return ""
+	}
+	return template.HTML(`<div class="ev-grid">` + rows.String() + `</div>`)
+}
+
+// orderedEvidenceKeys returns the keys of obj in a stable, semantically meaningful
+// order. Known keys come first in a curated sequence (so the most informative fields
+// lead), followed by any unknown keys sorted alphabetically.
+func orderedEvidenceKeys(obj map[string]any) []string {
+	priority := []string{
+		// Subject identity & scope
+		"scope", "namespace",
+		// RBAC permission shape
+		"api_groups", "resources", "verbs",
+		// Where the permission came from
+		"source_role", "source_binding",
+		// Pod-security observations
+		"container", "image", "service_account",
+		"hostNetwork", "hostPID", "hostIPC", "privileged", "allowPrivilegeEscalation", "runAsNonRoot",
+		"volume", "path",
+		// Network policy
+		"policy", "cidr", "labels",
+		// Admission
+		"failurePolicy", "objectSelector", "namespaceSelector", "rules",
+		// Secrets / configmap
+		"type", "matched_keys", "name",
+		// ServiceAccount aggregations
+		"workloads", "dangerous_permissions",
+	}
+	// privesc summary keys are deliberately suppressed here — the EscalationPath
+	// renderer below is more readable and carries the same information.
+	suppressed := map[string]bool{
+		"target":        true,
+		"hop_count":     true,
+		"techniques":    true,
+		"first_action":  true,
+		"chain_summary": true,
+	}
+
+	seen := map[string]bool{}
+	var out []string
+	for _, k := range priority {
+		if _, ok := obj[k]; ok && !suppressed[k] {
+			out = append(out, k)
+			seen[k] = true
+		}
+	}
+	var rest []string
+	for k := range obj {
+		if seen[k] || suppressed[k] {
+			continue
+		}
+		rest = append(rest, k)
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
+}
+
+// renderEvidenceRow dispatches on key to a per-key renderer. The full obj is passed
+// because some renderers (hostPath / volume) want sibling fields for context.
+func renderEvidenceRow(key string, val any, obj map[string]any) string {
+	switch key {
+	case "verbs":
+		return chipRow("Verbs", toStringSlice(val), verbHint, true)
+	case "resources":
+		return chipRow("Resources", toStringSlice(val), resourceHint, true)
+	case "api_groups":
+		return apiGroupRow(toStringSlice(val))
+	case "source_role":
+		return kubectlRow("Source role", asString(val), sourceRoleCmd(asString(val), obj))
+	case "source_binding":
+		return kubectlRow("Source binding", asString(val), sourceBindingCmd(asString(val), obj))
+	case "scope":
+		return plainRow("Scope", strings.Title(asString(val)), "")
+	case "namespace":
+		return codeRow("Namespace", asString(val))
+	case "container":
+		return codeRow("Container", asString(val))
+	case "image":
+		img := asString(val)
+		return plainRow("Image", img, mutableImageHint(img))
+	case "service_account":
+		return codeRow("ServiceAccount", asString(val))
+	case "hostNetwork", "hostPID", "hostIPC", "privileged",
+		"allowPrivilegeEscalation", "runAsNonRoot":
+		return boolRow(key, val)
+	case "volume":
+		return codeRow("Volume", asString(val))
+	case "path":
+		p := asString(val)
+		return plainRow("Host path", "<code>"+template.HTMLEscapeString(p)+"</code>", hostPathHint(p))
+	case "policy":
+		return codeRow("Policy", asString(val))
+	case "cidr":
+		c := asString(val)
+		return plainRow("CIDR", "<code>"+template.HTMLEscapeString(c)+"</code>", cidrHint(c))
+	case "labels":
+		return labelsRow("Labels", val)
+	case "failurePolicy":
+		fp := asString(val)
+		hint := ""
+		if strings.EqualFold(fp, "Ignore") {
+			hint = "Webhook failures are silently allowed — admission policy effectively off"
+		}
+		return plainRow("failurePolicy", "<code>"+template.HTMLEscapeString(fp)+"</code>", hint)
+	case "objectSelector":
+		return selectorRow("objectSelector", val)
+	case "namespaceSelector":
+		return selectorRow("namespaceSelector", val)
+	case "rules":
+		// Two distinct shapes produce a "rules" key:
+		//   - admission webhook RuleWithOperations objects (have apiGroups/operations/resources)
+		//   - serviceaccount EffectiveRule summaries (have verbs/resources/api_groups + source_*)
+		// We sniff the first element to decide.
+		if isEffectiveRuleSlice(val) {
+			return effectiveRulesRow(val)
+		}
+		return admissionRulesRow(val)
+	case "type":
+		t := asString(val)
+		return plainRow("Type", "<code>"+template.HTMLEscapeString(t)+"</code>", secretTypeLabelDelta(t))
+	case "matched_keys":
+		return chipRow("Matched keys", toStringSlice(val), nil, false)
+	case "name":
+		return codeRow("Name", asString(val))
+	case "workloads":
+		return workloadsRow(val)
+	case "dangerous_permissions":
+		return dangerChipRow("Dangerous permissions", toStringSlice(val))
+	}
+	return jsonFallbackRow(key, val)
+}
+
+// secretTypeLabelDelta returns the friendly label for a Secret type, or "" when the
+// type is already self-explanatory (i.e. the lookup returns the input unchanged).
+func secretTypeLabelDelta(t string) string {
+	label := secretTypeLabel(t)
+	if label == t {
+		return ""
+	}
+	return label
+}
+
+// renderEscalationPath emits a numbered ordered list of step cards describing the
+// per-hop chain from the source subject to the privesc sink. Returns "" for empty
+// input so the template `{{ if … }}` gate can suppress the whole section.
+func renderEscalationPath(hops []models.EscalationHop) template.HTML {
+	if len(hops) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<ol class="attack-chain">`)
+	for _, hop := range hops {
+		b.WriteString(`<li class="attack-step">`)
+
+		b.WriteString(`<div class="step-hd"><span class="step-num">Step `)
+		b.WriteString(fmt.Sprintf("%d", hop.Step))
+		b.WriteString(`</span> <code class="step-action">`)
+		b.WriteString(template.HTMLEscapeString(hop.Action))
+		b.WriteString(`</code></div>`)
+
+		from := subjectKey(hop.FromSubject)
+		to := subjectKey(hop.ToSubject)
+		if from != "" || to != "" {
+			b.WriteString(`<div class="step-edge">`)
+			if from != "" {
+				b.WriteString(`From <code>`)
+				b.WriteString(template.HTMLEscapeString(from))
+				b.WriteString(`</code>`)
+			}
+			if to != "" {
+				if from != "" {
+					b.WriteString(` → `)
+				}
+				b.WriteString(`<code>`)
+				b.WriteString(template.HTMLEscapeString(to))
+				b.WriteString(`</code>`)
+			}
+			b.WriteString(`</div>`)
+		}
+
+		if hop.Permission != "" {
+			b.WriteString(`<div class="step-meta"><span class="k">Permission</span> <code>`)
+			b.WriteString(template.HTMLEscapeString(hop.Permission))
+			b.WriteString(`</code></div>`)
+		}
+		if hop.Gains != "" {
+			b.WriteString(`<div class="step-meta"><span class="k">Gains</span> <span class="v">`)
+			b.WriteString(template.HTMLEscapeString(hop.Gains))
+			b.WriteString(`</span></div>`)
+		}
+		b.WriteString(`</li>`)
+	}
+	b.WriteString(`</ol>`)
+	return template.HTML(b.String())
+}
+
+// subjectKey returns "Kind/[namespace/]name" or "" when the SubjectRef is empty.
+// Empty subjects show up at the tail of escalation paths where the hop terminates
+// at a synthetic sink (cluster_admin, node_escape) rather than another subject.
+func subjectKey(s models.SubjectRef) string {
+	if s.Kind == "" && s.Name == "" {
+		return ""
+	}
+	if s.Namespace == "" {
+		return fmt.Sprintf("%s/%s", s.Kind, s.Name)
+	}
+	return fmt.Sprintf("%s/%s/%s", s.Kind, s.Namespace, s.Name)
+}
+
+// chipRow renders a labeled list of chips. If hint is non-nil and returns a non-empty
+// string for a chip's value, that chip gets a tooltip and a small inline hint badge
+// below the row. When dangerOnWildcard is true, "*" chips render with the .wild class.
+func chipRow(label string, values []string, hint func(string) string, dangerOnWildcard bool) string {
+	if len(values) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(label))
+	b.WriteString(`</span><span class="ev-val">`)
+	var hints []string
+	for _, v := range values {
+		class := "ev-chip"
+		h := ""
+		if hint != nil {
+			h = hint(v)
+		}
+		if dangerOnWildcard && v == "*" {
+			class += " wild"
+			if h == "" {
+				h = "Wildcard — every value"
+			}
+		} else if h != "" {
+			class += " danger"
+		}
+		b.WriteString(`<span class="`)
+		b.WriteString(class)
+		if h != "" {
+			b.WriteString(`" title="`)
+			b.WriteString(template.HTMLEscapeString(h))
+		}
+		b.WriteString(`">`)
+		b.WriteString(template.HTMLEscapeString(v))
+		b.WriteString(`</span>`)
+		if h != "" {
+			hints = append(hints, fmt.Sprintf("<code>%s</code> — %s",
+				template.HTMLEscapeString(v), template.HTMLEscapeString(h)))
+		}
+	}
+	b.WriteString(`</span>`)
+	if len(hints) > 0 {
+		b.WriteString(`<div class="ev-hints">`)
+		for _, h := range hints {
+			b.WriteString(`<div class="ev-hint">`)
+			b.WriteString(h)
+			b.WriteString(`</div>`)
+		}
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// dangerChipRow renders a chip list always styled as "danger" — used for the
+// already-pre-flagged "dangerous_permissions" payload from the serviceaccount module.
+func dangerChipRow(label string, values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(label))
+	b.WriteString(`</span><span class="ev-val">`)
+	for _, v := range values {
+		b.WriteString(`<span class="ev-chip danger">`)
+		b.WriteString(template.HTMLEscapeString(v))
+		b.WriteString(`</span>`)
+	}
+	b.WriteString(`</span></div>`)
+	return b.String()
+}
+
+// apiGroupRow special-cases the empty-string core group (renders as "core/v1") and
+// adds glossary hints for known sensitive groups.
+func apiGroupRow(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">API groups</span><span class="ev-val">`)
+	var hints []string
+	for _, v := range values {
+		display := v
+		if v == "" {
+			display = "core/v1"
+		}
+		class := "ev-chip"
+		h := apiGroupHint(v)
+		if v == "*" {
+			class += " wild"
+		} else if h != "" {
+			class += " danger"
+		}
+		b.WriteString(`<span class="`)
+		b.WriteString(class)
+		if h != "" {
+			b.WriteString(`" title="`)
+			b.WriteString(template.HTMLEscapeString(h))
+		}
+		b.WriteString(`">`)
+		b.WriteString(template.HTMLEscapeString(display))
+		b.WriteString(`</span>`)
+		if h != "" {
+			hints = append(hints, fmt.Sprintf("<code>%s</code> — %s",
+				template.HTMLEscapeString(display), template.HTMLEscapeString(h)))
+		}
+	}
+	b.WriteString(`</span>`)
+	if len(hints) > 0 {
+		b.WriteString(`<div class="ev-hints">`)
+		for _, h := range hints {
+			b.WriteString(`<div class="ev-hint">`)
+			b.WriteString(h)
+			b.WriteString(`</div>`)
+		}
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// plainRow emits "Label: value" with an optional hint line below. value is HTML —
+// callers must escape any analyzer-supplied content before passing it in.
+func plainRow(label, valueHTML, hint string) string {
+	if valueHTML == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(label))
+	b.WriteString(`</span><span class="ev-val">`)
+	b.WriteString(valueHTML)
+	b.WriteString(`</span>`)
+	if hint != "" {
+		b.WriteString(`<div class="ev-hint">`)
+		b.WriteString(template.HTMLEscapeString(hint))
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// codeRow emits "Label: <code>value</code>" — the default for short identifiers.
+func codeRow(label, value string) string {
+	if value == "" {
+		return ""
+	}
+	return plainRow(label, "<code>"+template.HTMLEscapeString(value)+"</code>", "")
+}
+
+// kubectlRow emits a code-styled value plus a small inline kubectl command the user
+// can run to inspect the referenced object. Generated commands are static strings
+// over user-controlled names, so we escape the embedded value defensively.
+func kubectlRow(label, value, kubectl string) string {
+	if value == "" {
+		return ""
+	}
+	hint := ""
+	if kubectl != "" {
+		hint = "Inspect: " + kubectl
+	}
+	return plainRow(label, "<code>"+template.HTMLEscapeString(value)+"</code>", hint)
+}
+
+// boolRow emits a labeled true/false badge with a one-line meaning hint when known.
+func boolRow(key string, val any) string {
+	bv, ok := val.(bool)
+	if !ok {
+		// Some analyzers might emit "true"/"false" strings; coerce.
+		if s, isStr := val.(string); isStr {
+			bv = strings.EqualFold(s, "true")
+			ok = true
+		}
+	}
+	if !ok {
+		return jsonFallbackRow(key, val)
+	}
+	state := "false"
+	class := "ev-chip"
+	if bv {
+		state = "true"
+		class += " danger"
+	}
+	hint := ""
+	if bv {
+		hint = hostNamespaceHint(key)
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(key))
+	b.WriteString(`</span><span class="ev-val"><span class="`)
+	b.WriteString(class)
+	b.WriteString(`">`)
+	b.WriteString(state)
+	b.WriteString(`</span></span>`)
+	if hint != "" {
+		b.WriteString(`<div class="ev-hint">`)
+		b.WriteString(template.HTMLEscapeString(hint))
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// labelsRow renders a Kubernetes label map (key → value) as chip pairs.
+func labelsRow(label string, val any) string {
+	m, ok := val.(map[string]any)
+	if !ok || len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(label))
+	b.WriteString(`</span><span class="ev-val">`)
+	for _, k := range keys {
+		v := fmt.Sprint(m[k])
+		b.WriteString(`<span class="ev-chip">`)
+		b.WriteString(template.HTMLEscapeString(k))
+		b.WriteString(`=`)
+		b.WriteString(template.HTMLEscapeString(v))
+		b.WriteString(`</span>`)
+	}
+	b.WriteString(`</span></div>`)
+	return b.String()
+}
+
+// selectorRow translates a Kubernetes LabelSelector (matchLabels / matchExpressions)
+// into one or more plain-English sentences. Falls back to JSON if the structure
+// doesn't look like a standard selector.
+func selectorRow(label string, val any) string {
+	m, ok := val.(map[string]any)
+	if !ok {
+		return jsonFallbackRow(label, val)
+	}
+	if len(m) == 0 {
+		return plainRow(label, "<code>{}</code>", "Empty selector — matches everything")
+	}
+	var sentences []string
+	if ml, ok := m["matchLabels"].(map[string]any); ok && len(ml) > 0 {
+		keys := make([]string, 0, len(ml))
+		for k := range ml {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			sentences = append(sentences, fmt.Sprintf("label <code>%s</code> = <code>%s</code>",
+				template.HTMLEscapeString(k), template.HTMLEscapeString(fmt.Sprint(ml[k]))))
+		}
+	}
+	if me, ok := m["matchExpressions"].([]any); ok {
+		for _, raw := range me {
+			expr, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			key := asString(expr["key"])
+			op := asString(expr["operator"])
+			values := toStringSlice(expr["values"])
+			sentences = append(sentences, expressionSentence(key, op, values))
+		}
+	}
+	if len(sentences) == 0 {
+		return jsonFallbackRow(label, val)
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(label))
+	b.WriteString(`</span><span class="ev-val ev-stack">`)
+	for _, s := range sentences {
+		b.WriteString(`<div class="ev-sentence">`)
+		b.WriteString(s)
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</span></div>`)
+	return b.String()
+}
+
+// expressionSentence turns a matchExpression {key, operator, values} into prose.
+// Values are HTML-escaped; the result is HTML.
+func expressionSentence(key, op string, values []string) string {
+	keyHTML := "<code>" + template.HTMLEscapeString(key) + "</code>"
+	switch strings.ToLower(op) {
+	case "exists":
+		return "label " + keyHTML + " exists"
+	case "doesnotexist":
+		return "label " + keyHTML + " is absent"
+	case "in":
+		return "label " + keyHTML + " is one of [" + chipsInline(values) + "]"
+	case "notin":
+		return "label " + keyHTML + " is NOT one of [" + chipsInline(values) + "]"
+	default:
+		return template.HTMLEscapeString(op) + " " + keyHTML + " [" + chipsInline(values) + "]"
+	}
+}
+
+func chipsInline(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, "<code>"+template.HTMLEscapeString(v)+"</code>")
+	}
+	return strings.Join(parts, ", ")
+}
+
+// admissionRulesRow renders MutatingWebhookConfig RuleWithOperations entries.
+func admissionRulesRow(val any) string {
+	arr, ok := val.([]any)
+	if !ok || len(arr) == 0 {
+		return jsonFallbackRow("rules", val)
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">Webhook rules</span><span class="ev-val ev-stack">`)
+	for _, raw := range arr {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		ops := toStringSlice(m["operations"])
+		groups := toStringSlice(m["apiGroups"])
+		versions := toStringSlice(m["apiVersions"])
+		resources := toStringSlice(m["resources"])
+		b.WriteString(`<div class="ev-sentence">`)
+		if len(ops) > 0 {
+			b.WriteString(`<strong>` + template.HTMLEscapeString(strings.Join(ops, ", ")) + `</strong> on `)
+		}
+		joined := joinGVR(groups, versions, resources)
+		b.WriteString(`<code>` + template.HTMLEscapeString(joined) + `</code>`)
+		if scope := asString(m["scope"]); scope != "" {
+			b.WriteString(` <span class="ev-mut">(` + template.HTMLEscapeString(scope) + `)</span>`)
+		}
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</span></div>`)
+	return b.String()
+}
+
+func joinGVR(groups, versions, resources []string) string {
+	g := "*"
+	if len(groups) > 0 {
+		g = strings.Join(groups, ",")
+		if g == "" {
+			g = "core"
+		}
+	}
+	v := "*"
+	if len(versions) > 0 {
+		v = strings.Join(versions, ",")
+	}
+	r := "*"
+	if len(resources) > 0 {
+		r = strings.Join(resources, ",")
+	}
+	return g + "/" + v + ":" + r
+}
+
+// isEffectiveRuleSlice sniffs whether a "rules" payload looks like the serviceaccount
+// EffectiveRule summary (verbs+resources+source_role) vs the admission RuleWithOperations
+// shape (operations+apiGroups+apiVersions).
+func isEffectiveRuleSlice(val any) bool {
+	arr, ok := val.([]any)
+	if !ok || len(arr) == 0 {
+		return false
+	}
+	first, ok := arr[0].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, hasVerbs := first["verbs"]
+	_, hasSourceRole := first["source_role"]
+	return hasVerbs && hasSourceRole
+}
+
+// effectiveRulesRow renders the serviceaccount module's EffectiveRule summary as a
+// compact permissions table.
+func effectiveRulesRow(val any) string {
+	arr, ok := val.([]any)
+	if !ok || len(arr) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">Effective rules</span><span class="ev-val ev-stack">`)
+	for _, raw := range arr {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		verbs := toStringSlice(m["verbs"])
+		resources := toStringSlice(m["resources"])
+		groups := toStringSlice(m["api_groups"])
+		ns := asString(m["namespace"])
+		role := asString(m["source_role"])
+		binding := asString(m["source_binding"])
+
+		b.WriteString(`<div class="ev-rule">`)
+		b.WriteString(`<div class="ev-rule-head">`)
+		b.WriteString(renderChips(verbs, verbHint, true))
+		b.WriteString(` on `)
+		b.WriteString(renderChips(resources, resourceHint, true))
+		if len(groups) > 0 {
+			b.WriteString(` in <code>`)
+			b.WriteString(template.HTMLEscapeString(strings.Join(groups, ",")))
+			b.WriteString(`</code>`)
+		}
+		b.WriteString(`</div>`)
+		b.WriteString(`<div class="ev-rule-meta">via <code>`)
+		b.WriteString(template.HTMLEscapeString(role))
+		b.WriteString(`</code> (binding <code>`)
+		b.WriteString(template.HTMLEscapeString(binding))
+		b.WriteString(`</code>)`)
+		if ns != "" {
+			b.WriteString(` in namespace <code>`)
+			b.WriteString(template.HTMLEscapeString(ns))
+			b.WriteString(`</code>`)
+		} else {
+			b.WriteString(` <span class="ev-mut">(cluster scope)</span>`)
+		}
+		b.WriteString(`</div></div>`)
+	}
+	b.WriteString(`</span></div>`)
+	return b.String()
+}
+
+// renderChips emits an inline run of chips (no row wrapper) for use inside other rows.
+func renderChips(values []string, hint func(string) string, dangerOnWildcard bool) string {
+	var b strings.Builder
+	for _, v := range values {
+		class := "ev-chip"
+		h := ""
+		if hint != nil {
+			h = hint(v)
+		}
+		if dangerOnWildcard && v == "*" {
+			class += " wild"
+		} else if h != "" {
+			class += " danger"
+		}
+		b.WriteString(`<span class="`)
+		b.WriteString(class)
+		if h != "" {
+			b.WriteString(`" title="`)
+			b.WriteString(template.HTMLEscapeString(h))
+		}
+		b.WriteString(`">`)
+		b.WriteString(template.HTMLEscapeString(v))
+		b.WriteString(`</span>`)
+	}
+	return b.String()
+}
+
+// workloadsRow lists workload references with a kubectl inspect hint.
+func workloadsRow(val any) string {
+	arr, ok := val.([]any)
+	if !ok || len(arr) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row"><span class="ev-key">Workloads</span><span class="ev-val ev-stack">`)
+	for _, raw := range arr {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind := asString(m["kind"])
+		name := asString(m["name"])
+		ns := asString(m["namespace"])
+		display := name
+		if kind != "" {
+			display = kind + "/" + name
+		}
+		b.WriteString(`<div class="ev-sentence"><code>`)
+		b.WriteString(template.HTMLEscapeString(display))
+		b.WriteString(`</code>`)
+		if ns != "" {
+			b.WriteString(` in namespace <code>`)
+			b.WriteString(template.HTMLEscapeString(ns))
+			b.WriteString(`</code>`)
+		}
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</span></div>`)
+	return b.String()
+}
+
+// jsonFallbackRow prints "Label: <pre>json</pre>" for any unknown shape.
+func jsonFallbackRow(key string, val any) string {
+	pretty, err := json.MarshalIndent(val, "", "  ")
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="ev-row ev-row-block"><span class="ev-key">`)
+	b.WriteString(template.HTMLEscapeString(key))
+	b.WriteString(`</span><pre class="ev-json"><code>`)
+	b.WriteString(template.HTMLEscapeString(string(pretty)))
+	b.WriteString(`</code></pre></div>`)
+	return b.String()
+}
+
+// asString coerces an interface{} value (string, fmt.Stringer, anything) to string.
+func asString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+// toStringSlice coerces a JSON-decoded []any into []string. Non-string elements are
+// rendered via fmt.Sprint. Returns nil for non-slice input.
+func toStringSlice(v any) []string {
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			out = append(out, fmt.Sprint(item))
+		}
+		return out
+	}
+	return nil
+}
+
+// sourceRoleCmd builds a kubectl command to inspect the role that granted the
+// permission. Cluster-scoped (no namespace) → clusterrole, otherwise → role -n ns.
+func sourceRoleCmd(name string, obj map[string]any) string {
+	if name == "" {
+		return ""
+	}
+	ns := asString(obj["namespace"])
+	scope := strings.ToLower(asString(obj["scope"]))
+	if scope == "cluster" || ns == "" {
+		return "kubectl get clusterrole " + name + " -o yaml"
+	}
+	return "kubectl get role " + name + " -n " + ns + " -o yaml"
+}
+
+// sourceBindingCmd builds the parallel kubectl command for the binding.
+func sourceBindingCmd(name string, obj map[string]any) string {
+	if name == "" {
+		return ""
+	}
+	ns := asString(obj["namespace"])
+	scope := strings.ToLower(asString(obj["scope"]))
+	if scope == "cluster" || ns == "" {
+		return "kubectl get clusterrolebinding " + name + " -o yaml"
+	}
+	return "kubectl get rolebinding " + name + " -n " + ns + " -o yaml"
+}

--- a/internal/report/evidence_render_test.go
+++ b/internal/report/evidence_render_test.go
@@ -1,0 +1,303 @@
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+func TestRenderEvidenceRBACWildcard(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"api_groups":     []string{""},
+		"resources":      []string{"secrets"},
+		"verbs":          []string{"get", "list", "*"},
+		"source_role":    "reader",
+		"source_binding": "reader-binding",
+		"namespace":      "prod",
+		"scope":          "namespace",
+	})
+	out := string(renderEvidence(raw))
+	for _, want := range []string{
+		"Verbs", "Resources", "API groups",
+		"reader", "reader-binding", "prod",
+		"ev-chip wild", // wildcard verb chip
+		"core/v1",      // empty api group rendered as core/v1
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("RBAC wildcard render missing %q\n---\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "Holds credentials") {
+		t.Errorf("expected secrets resource hint, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidencePodSecHostPath(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"volume": "docker-sock",
+		"path":   "/var/run/docker.sock",
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "/var/run/docker.sock") {
+		t.Errorf("expected docker.sock path in output:\n%s", out)
+	}
+	if !strings.Contains(out, "container engine takeover") {
+		t.Errorf("expected docker socket hint, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidencePodSecHostNetwork(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"hostNetwork": true,
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "hostNetwork") {
+		t.Errorf("expected hostNetwork key, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ev-chip danger") {
+		t.Errorf("expected danger-classed boolean chip, got:\n%s", out)
+	}
+	// HTML escaping turns the apostrophe in "node's" into &#39;, so look for a span
+	// of the hint that contains no apostrophe.
+	if !strings.Contains(out, "Shares the node") || !strings.Contains(out, "network namespace") {
+		t.Errorf("expected hostNetwork hint, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidencePodSecMutableImage(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"container": "app",
+		"image":     "nginx:latest",
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "nginx:latest") {
+		t.Errorf("expected image string, got:\n%s", out)
+	}
+	if !strings.Contains(out, ":latest is mutable") {
+		t.Errorf("expected mutable-tag hint, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidenceNetworkCIDRInternet(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"policy": "allow-broad",
+		"cidr":   "0.0.0.0/0",
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "0.0.0.0/0") {
+		t.Errorf("expected CIDR string, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Entire IPv4 internet") {
+		t.Errorf("expected internet CIDR hint, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidenceAdmissionFailureIgnore(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"failurePolicy": "Ignore",
+		"namespaceSelector": map[string]any{
+			"matchExpressions": []any{
+				map[string]any{
+					"key":      "kubernetes.io/metadata.name",
+					"operator": "NotIn",
+					"values":   []any{"kube-system"},
+				},
+			},
+		},
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "Ignore") {
+		t.Errorf("expected failurePolicy value, got:\n%s", out)
+	}
+	if !strings.Contains(out, "admission policy effectively off") {
+		t.Errorf("expected fail-open hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "is NOT one of") {
+		t.Errorf("expected NotIn translation, got:\n%s", out)
+	}
+	if !strings.Contains(out, "kube-system") {
+		t.Errorf("expected exempted namespace, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidenceSecretsType(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"type": "kubernetes.io/service-account-token",
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "kubernetes.io/service-account-token") {
+		t.Errorf("expected raw type, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Long-lived ServiceAccount token") {
+		t.Errorf("expected friendly secret-type label, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidenceServiceAccount(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"workloads": []any{
+			map[string]any{"kind": "Deployment", "name": "api", "namespace": "prod"},
+		},
+		"rules": []any{
+			map[string]any{
+				"verbs":          []any{"get", "list"},
+				"resources":      []any{"secrets"},
+				"api_groups":     []any{""},
+				"namespace":      "prod",
+				"source_role":    "reader",
+				"source_binding": "reader-binding",
+			},
+		},
+		"dangerous_permissions": []any{"create pods (cluster)", "impersonate (cluster)"},
+	})
+	out := string(renderEvidence(raw))
+	for _, want := range []string{
+		"Deployment/api", "prod",
+		"reader", "reader-binding",
+		"create pods (cluster)", "impersonate (cluster)",
+		"ev-chip danger",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ServiceAccount render missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderEvidenceUnknownKeyFallback(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"future_field": map[string]any{"a": 1, "b": "two"},
+	})
+	out := string(renderEvidence(raw))
+	if !strings.Contains(out, "future_field") {
+		t.Errorf("expected unknown key in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ev-json") {
+		t.Errorf("expected JSON fallback class, got:\n%s", out)
+	}
+}
+
+func TestRenderEvidenceEmptyAndInvalid(t *testing.T) {
+	if got := string(renderEvidence(nil)); got != "" {
+		t.Errorf("nil Evidence should render empty, got %q", got)
+	}
+	if got := string(renderEvidence(json.RawMessage(`"just a string"`))); got != "" {
+		t.Errorf("non-object Evidence should render empty, got %q", got)
+	}
+	if got := string(renderEvidence(json.RawMessage(`{}`))); got != "" {
+		t.Errorf("empty object Evidence should render empty, got %q", got)
+	}
+}
+
+func TestRenderEvidenceSuppressesPrivescSummary(t *testing.T) {
+	// privesc evidence keys are intentionally suppressed from the structured view —
+	// the EscalationPath renderer below covers the same ground more readably.
+	raw, _ := json.Marshal(map[string]any{
+		"target":        "cluster_admin_equivalent",
+		"hop_count":     2,
+		"techniques":    []any{"pod_exec", "impersonate"},
+		"first_action":  "pod_exec",
+		"chain_summary": []any{"1. pod_exec", "2. impersonate"},
+	})
+	out := string(renderEvidence(raw))
+	if out != "" {
+		t.Errorf("expected empty render for privesc-only summary keys, got:\n%s", out)
+	}
+}
+
+func TestRenderEscalationPathTwoHop(t *testing.T) {
+	hops := []models.EscalationHop{
+		{
+			Step:        1,
+			Action:      "pod_create_token_theft",
+			FromSubject: models.SubjectRef{Kind: "ServiceAccount", Name: "privileged-reader", Namespace: "vulnerable"},
+			ToSubject:   models.SubjectRef{Kind: "ServiceAccount", Name: "default", Namespace: "vulnerable"},
+			Permission:  "create pods",
+			Gains:       "can create pods that mount ServiceAccount vulnerable/default",
+		},
+		{
+			Step:        2,
+			Action:      "pod_host_escape",
+			FromSubject: models.SubjectRef{Kind: "ServiceAccount", Name: "default", Namespace: "vulnerable"},
+			ToSubject:   models.SubjectRef{}, // sink
+			Permission:  "hostNetwork,privileged,hostPath:/",
+			Gains:       "runs in pod vulnerable/risky-app with hostNetwork, privileged, hostPath:/",
+		},
+	}
+	out := string(renderEscalationPath(hops))
+	for _, want := range []string{
+		"Step 1", "Step 2",
+		"pod_create_token_theft", "pod_host_escape",
+		"ServiceAccount/vulnerable/privileged-reader",
+		"ServiceAccount/vulnerable/default",
+		"create pods",
+		"hostNetwork,privileged,hostPath:/",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("EscalationPath render missing %q\n---\n%s", want, out)
+		}
+	}
+	// Step 2's empty ToSubject should not produce a "From → /" arrow with empty trailing code.
+	if strings.Contains(out, "→ <code></code>") {
+		t.Errorf("empty ToSubject should not produce empty <code> tag:\n%s", out)
+	}
+}
+
+func TestRenderEscalationPathEmpty(t *testing.T) {
+	if got := string(renderEscalationPath(nil)); got != "" {
+		t.Errorf("nil hops should render empty, got %q", got)
+	}
+}
+
+func TestHostPathHintWalksParents(t *testing.T) {
+	if got := hostPathHint("/var/run/docker.sock"); !strings.Contains(got, "container engine takeover") {
+		t.Errorf("exact match failed: %q", got)
+	}
+	if got := hostPathHint("/etc/kubernetes/pki/ca.crt"); !strings.Contains(got, "PKI") {
+		t.Errorf("parent walk to /etc/kubernetes/pki failed: %q", got)
+	}
+	if got := hostPathHint("/totally/unknown/path"); !strings.Contains(got, "Node root") {
+		t.Errorf("unknown path should walk up to root: %q", got)
+	}
+	if got := hostPathHint(""); got != "" {
+		t.Errorf("empty path should return empty hint: %q", got)
+	}
+}
+
+func TestCIDRHintContainment(t *testing.T) {
+	if got := cidrHint("0.0.0.0/0"); !strings.Contains(got, "Entire IPv4 internet") {
+		t.Errorf("0.0.0.0/0 hint missing: %q", got)
+	}
+	if got := cidrHint("10.5.0.0/16"); !strings.Contains(got, "RFC1918") {
+		t.Errorf("RFC1918 containment hint missing for 10.5.0.0/16: %q", got)
+	}
+	if got := cidrHint("169.254.169.254/32"); !strings.Contains(got, "metadata") {
+		t.Errorf("metadata service hint missing: %q", got)
+	}
+	if got := cidrHint("8.8.8.8/32"); got != "" {
+		t.Errorf("public IP outside well-known ranges should have no hint: %q", got)
+	}
+}
+
+func TestMutableImageHint(t *testing.T) {
+	cases := map[string]string{
+		"nginx:latest": ":latest is mutable",
+		"nginx":        "No tag",
+		"nginx:1.25.3": "",
+		"foo/bar:v1.0": "",
+		"":             "",
+	}
+	for in, wantSub := range cases {
+		got := mutableImageHint(in)
+		if wantSub == "" {
+			if got != "" {
+				t.Errorf("mutableImageHint(%q) = %q, expected empty", in, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, wantSub) {
+			t.Errorf("mutableImageHint(%q) = %q, want substring %q", in, got, wantSub)
+		}
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -601,6 +601,18 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding)
 		"remediationStepHTML": func(step string) template.HTML {
 			return template.HTML(renderInlineCode(step))
 		},
+		// evidenceHTML renders Finding.Evidence as a labeled grid with chips and glossary
+		// hints rather than raw JSON. The original payload is still available below in a
+		// "Show raw JSON" sub-details emitted by the template.
+		"evidenceHTML": func(raw json.RawMessage) template.HTML {
+			return renderEvidence(raw)
+		},
+		// escalationPathHTML renders Finding.EscalationPath as a numbered ordered list of
+		// per-hop step cards. Returns "" for empty input so the template gate suppresses
+		// the surrounding section on non-privesc findings.
+		"escalationPathHTML": func(hops []models.EscalationHop) template.HTML {
+			return renderEscalationPath(hops)
+		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular
@@ -2235,11 +2247,15 @@ const htmlTemplate = `<!doctype html>
     .finding .rem ol li { margin-bottom: 4px; }
     .finding .rem ol li:last-child { margin-bottom: 0; }
     .finding .rem code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-size: 12px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
-    .finding .refs { margin: 10px 0 0; font-size: 13px; color: var(--text-mut); }
-    .finding .refs a { word-break: break-all; }
-    .finding .refs ul { list-style: none; padding-left: 0; margin: 6px 0 0; display: grid; gap: 4px; }
-    .finding .refs ul li { padding-left: 14px; position: relative; }
-    .finding .refs ul li::before { content: "↗"; position: absolute; left: 0; color: var(--text-dim); }
+    .finding details.refs { margin-top: 10px; font-size: 13px; color: var(--text-mut); }
+    .finding details.refs summary { cursor: pointer; user-select: none; font-size: 12px; color: var(--text-mut); padding: 6px 10px; border: 1px dashed var(--border); border-radius: 8px; display: inline-flex; align-items: center; gap: 6px; letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600; }
+    .finding details.refs[open] summary { color: var(--accent); border-color: var(--border-strong); border-style: solid; }
+    .finding details.refs summary .ref-count { font-size: 10.5px; color: var(--text-dim); background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 999px; letter-spacing: 0; text-transform: none; font-weight: 600; }
+    .finding details.refs[open] summary .ref-count { color: var(--accent); background: rgba(106,183,255,0.12); }
+    .finding details.refs a { word-break: break-all; }
+    .finding details.refs ul { list-style: none; padding-left: 0; margin: 8px 0 0; display: grid; gap: 4px; }
+    .finding details.refs ul li { padding-left: 14px; position: relative; }
+    .finding details.refs ul li::before { content: "↗"; position: absolute; left: 0; color: var(--text-dim); }
     .finding .mitre { margin: 10px 0 0; font-size: 12.5px; color: var(--text-mut); display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
     .finding .mitre .k { color: var(--text-dim); }
     .finding .mitre a { display: inline-flex; align-items: center; padding: 2px 8px; border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; text-decoration: none; background: rgba(255,255,255,0.02); }
@@ -2248,6 +2264,51 @@ const htmlTemplate = `<!doctype html>
     .finding details summary { cursor: pointer; user-select: none; font-size: 12px; color: var(--text-mut); padding: 6px 10px; border: 1px dashed var(--border); border-radius: 8px; display: inline-block; letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600; }
     .finding details[open] summary { color: var(--accent); border-color: var(--border-strong); border-style: solid; }
     .finding details pre { margin-top: 10px; }
+
+    /* Observed attack chain (privesc EscalationPath) */
+    .finding .chain { margin-top: 12px; padding: 12px 14px; background: rgba(255,90,90,0.06); border: 1px solid rgba(255,90,90,0.22); border-radius: 10px; }
+    .finding .chain .k { color: var(--critical, #ff5a5a); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
+    .finding .chain ol.attack-chain { list-style: none; padding-left: 0; margin: 0; display: grid; gap: 10px; counter-reset: step; }
+    .finding .chain ol.attack-chain li.attack-step { padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: rgba(255,255,255,0.02); font-size: 13px; line-height: 1.5; color: var(--text); }
+    .finding .chain .step-hd { display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px; }
+    .finding .chain .step-num { font-weight: 700; color: var(--accent); font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+    .finding .chain .step-action { background: rgba(255,255,255,0.06); padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
+    .finding .chain .step-edge { color: var(--text-mut); margin-bottom: 4px; font-size: 13px; }
+    .finding .chain .step-edge code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text); }
+    .finding .chain .step-meta { font-size: 12.5px; color: var(--text-mut); margin-top: 2px; }
+    .finding .chain .step-meta .k { display: inline; color: var(--text-dim); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 6px; }
+    .finding .chain .step-meta code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; }
+
+    /* Humanized Evidence section */
+    .finding .evidence { margin-top: 12px; padding: 10px 12px; background: rgba(255,255,255,0.02); border: 1px solid var(--border); border-radius: 10px; }
+    .finding .evidence > .k { color: var(--text-mut); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
+    .finding .ev-grid { display: grid; grid-template-columns: max-content 1fr; column-gap: 14px; row-gap: 0; font-size: 13px; line-height: 1.5; color: var(--text); }
+    .finding .ev-row { display: grid; grid-template-columns: subgrid; grid-column: 1 / -1; row-gap: 2px; align-items: baseline; padding: 5px 0; border-top: 1px solid rgba(255,255,255,0.04); }
+    .finding .ev-row:first-child { border-top: 0; padding-top: 0; }
+    .finding .ev-row.ev-row-block { display: block; }
+    .finding .ev-key { color: var(--text-dim); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; white-space: nowrap; }
+    .finding .ev-val { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; min-width: 0; }
+    .finding .ev-val.ev-stack { flex-direction: column; align-items: stretch; gap: 6px; }
+    .finding .ev-val code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); word-break: break-all; }
+    .finding .ev-chip { display: inline-flex; padding: 1px 7px; border: 1px solid var(--border); border-radius: 6px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text); background: rgba(255,255,255,0.03); }
+    .finding .ev-chip.danger { border-color: rgba(255,154,60,0.5); color: #ffb060; background: rgba(255,154,60,0.08); }
+    .finding .ev-chip.wild { border-color: rgba(255,90,90,0.5); color: #ff7777; background: rgba(255,90,90,0.1); font-weight: 700; }
+    .finding .ev-hints { grid-column: 2; display: grid; gap: 1px; margin-top: 2px; }
+    .finding .ev-hint { font-size: 11.5px; color: var(--text-mut); padding-left: 0; }
+    .finding .ev-hint code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 4px; font-size: 11px; }
+    .finding .ev-sentence { font-size: 12.5px; color: var(--text); }
+    .finding .ev-sentence code { background: rgba(255,255,255,0.06); padding: 1px 5px; border-radius: 4px; font-size: 11px; }
+    .finding .ev-rule { padding: 6px 8px; border: 1px solid var(--border); border-radius: 8px; background: rgba(255,255,255,0.02); display: grid; gap: 3px; }
+    .finding .ev-rule-head { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; font-size: 12.5px; color: var(--text); }
+    .finding .ev-rule-meta { font-size: 11.5px; color: var(--text-mut); }
+    .finding .ev-mut { color: var(--text-dim); font-size: 11px; }
+    .finding .ev-json { margin: 0; padding: 8px 10px; background: rgba(0,0,0,0.25); border: 1px solid var(--border); border-radius: 6px; overflow-x: auto; font-size: 11.5px; }
+    .finding .evidence-raw { margin-top: 8px; }
+    .finding .evidence-raw summary { font-size: 11px; }
+    @media (max-width: 720px) {
+      .finding .ev-row { grid-template-columns: 1fr; }
+      .finding .ev-hints { grid-column: 1; }
+    }
 
     .notes { display: grid; gap: 8px; font-size: 13px; color: var(--text-mut); }
     .notes li { padding: 8px 10px; background: rgba(255,154,60,0.07); border: 1px solid rgba(255,154,60,0.22); border-radius: 8px; list-style: none; }
@@ -2625,6 +2686,12 @@ const htmlTemplate = `<!doctype html>
             </ol>
           </div>
           {{ end }}
+          {{ if .EscalationPath }}
+          <div class="chain">
+            <span class="k">Observed attack chain</span>
+            {{ escalationPathHTML .EscalationPath }}
+          </div>
+          {{ end }}
           {{ if or .Remediation .RemediationSteps }}
           <div class="rem">
             <span class="k">Remediation</span>
@@ -2642,20 +2709,29 @@ const htmlTemplate = `<!doctype html>
             {{ range .MitreTechniques }}<a href="{{ .URL }}" target="_blank" rel="noopener noreferrer" title="{{ .Name }}">{{ .ID }}</a>{{ end }}
           </div>
           {{ end }}
+          {{ if .Evidence }}
+          <div class="evidence">
+            <span class="k">Evidence</span>
+            {{ evidenceHTML .Evidence }}
+            <details class="evidence-raw">
+              <summary>Show raw JSON</summary>
+              <pre><code>{{ json .Evidence }}</code></pre>
+            </details>
+          </div>
+          {{ end }}
           {{ if .LearnMore }}
-          <div class="refs">
-            <span>References</span>
+          <details class="refs">
+            <summary>References <span class="ref-count">{{ len .LearnMore }}</span></summary>
             <ul>
               {{ range .LearnMore }}<li><a href="{{ .URL }}" target="_blank" rel="noopener noreferrer">{{ .Title }}</a></li>{{ end }}
             </ul>
-          </div>
+          </details>
           {{ else if .References }}
-          <div class="refs">References: {{ range $i, $ref := .References }}{{ if $i }}, {{ end }}<a href="{{ $ref }}" target="_blank" rel="noopener noreferrer">{{ $ref }}</a>{{ end }}</div>
-          {{ end }}
-          {{ if .Evidence }}
-          <details>
-            <summary>Evidence</summary>
-            <pre><code>{{ json .Evidence }}</code></pre>
+          <details class="refs">
+            <summary>References <span class="ref-count">{{ len .References }}</span></summary>
+            <ul>
+              {{ range .References }}<li><a href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ . }}</a></li>{{ end }}
+            </ul>
           </details>
           {{ end }}
         </article>


### PR DESCRIPTION
## Summary
- Replace the raw-JSON \`EVIDENCE\` block in each finding card with a labeled grid that decodes analyzer payloads into chips, glossary hints, translated LabelSelectors, and \`kubectl\` inspect commands. Wildcards (\`*\`) are flagged red, well-known dangerous verbs (\`impersonate\`, \`escalate\`, \`bind\`, \`patch\`, \`update\`, …) get explanation lines, sensitive host paths (\`/\`, \`/var/run/docker.sock\`, \`/etc/kubernetes/pki\`, …) and CIDRs (\`0.0.0.0/0\`, link-local metadata, RFC1918) are annotated from a small glossary. The original payload remains accessible via a "Show raw JSON" sub-\`<details>\`.
- Render \`Finding.EscalationPath\` as an "Observed attack chain" section on privesc findings — each hop shows the action, \`From → To\` subjects, the enabling permission, and the attacker's gains. Until now this slice was only summarised inside Evidence.
- Reorder the card so Evidence sits above References, collapse References behind a count chip, and use CSS subgrid so every evidence row shares one column width regardless of key length.

## Test plan
- [x] \`make build\`
- [x] \`make test\` (new \`internal/report/evidence_render_test.go\` covers RBAC wildcard / podsec hostPath+hostNetwork+mutable-image / network CIDR / admission \`failurePolicy: Ignore\` with NotIn selector / secret type / serviceaccount workloads+rules+dangerous_permissions / unknown-key fallback / privesc summary suppression / EscalationPath rendering / glossary helpers)
- [x] \`make lint\`
- [x] \`./bin/kubesplaining report --input-file findings.json --metadata-file scan-metadata.json\` against the existing e2e findings; visually inspect:
  - RBAC \`KUBE-PRIVESC-001\` (cluster-wide \`create pods\`) — chip+hint annotations
  - \`KUBE-ESCAPE-006\` — \`/\` host path annotated "Node root filesystem — full host takeover"
  - \`KUBE-NETPOL-WEAKNESS-002\` — \`0.0.0.0/0\` CIDR annotated "Entire IPv4 internet"
  - \`KUBE-ADMISSION-001\` — \`failurePolicy: Ignore\` annotated "admission policy effectively off"; webhook rule rendered as \`CREATE on core/v1:pods\`
  - \`KUBE-PRIVESC-PATH-*\` — Observed attack chain renders the multi-hop chain
  - References collapse — closed by default with a count chip, expand on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)