### PR TITLE
Expand e2e to 44 rules; diversify attack-graph impact lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export PATH := $(CURDIR)/bin:$(PATH)
 
 GOFILES := $(shell $(CURDIR)/bin/rg --files -g '*.go')
 
-.PHONY: setup build test lint e2e scan clean
+.PHONY: setup build test lint e2e scan delete clean
 
 setup:
 	$(GOENV) go mod download
@@ -36,6 +36,9 @@ e2e: build
 # via ARGS, e.g. `make scan ARGS="--threshold high --only-modules privesc"`.
 scan: build
 	$(BINARY) scan $(ARGS)
+
+delete:
+	kind delete cluster --name $(KIND_CLUSTER_NAME)
 
 clean:
 	rm -rf ./bin ./kubesplaining-report ./.tmp

--- a/internal/analyzer/privesc/graph.go
+++ b/internal/analyzer/privesc/graph.go
@@ -15,6 +15,8 @@ const (
 	sinkClusterAdmin      = "sink:cluster_admin"
 	sinkKubeSystemSecrets = "sink:kube_system_secrets"
 	sinkNodeEscape        = "sink:node_escape"
+	sinkSystemMasters     = "sink:system_masters"
+	sinkTokenMint         = "sink:token_mint"
 )
 
 // nodeID returns the canonical graph-node ID for a subject.
@@ -32,6 +34,8 @@ func BuildGraph(snapshot models.Snapshot) *models.EscalationGraph {
 	addSink(graph, sinkClusterAdmin, models.TargetClusterAdmin)
 	addSink(graph, sinkKubeSystemSecrets, models.TargetKubeSystemSecrets)
 	addSink(graph, sinkNodeEscape, models.TargetNodeEscape)
+	addSink(graph, sinkSystemMasters, models.TargetSystemMasters)
+	addSink(graph, sinkTokenMint, models.TargetTokenMint)
 
 	subjectsByNs := serviceAccountsByNamespace(snapshot)
 	podSAsByNs := podServiceAccountsByNamespace(snapshot)
@@ -118,6 +122,15 @@ func addEdgesForRule(
 		})
 	}
 
+	if matchesResourceVerb(rule, []string{"groups"}, []string{"impersonate"}) {
+		addEdge(graph, from, sinkSystemMasters, &models.EscalationEdge{
+			Technique:   "KUBE-PRIVESC-008",
+			Action:      "impersonate_system_masters",
+			Permission:  verbResource(rule, "groups"),
+			Description: "can impersonate the system:masters group, bypassing all RBAC",
+		})
+	}
+
 	if matchesResourceVerb(rule, []string{"secrets"}, []string{"get", "list", "watch"}) {
 		if clusterScope || rule.Namespace == "kube-system" {
 			addEdge(graph, from, sinkKubeSystemSecrets, &models.EscalationEdge{
@@ -184,6 +197,15 @@ func addEdgesForRule(
 				Description: fmt.Sprintf("can mint tokens for ServiceAccount %s/%s", target.Namespace, target.Name),
 			})
 		}
+	}
+
+	if clusterScope && matchesResourceVerb(rule, []string{"serviceaccounts/token"}, []string{"create"}) {
+		addEdge(graph, from, sinkTokenMint, &models.EscalationEdge{
+			Technique:   "KUBE-PRIVESC-014",
+			Action:      "mint_arbitrary_token",
+			Permission:  "create serviceaccounts/token (cluster-wide)",
+			Description: "can mint a service-account token for any ServiceAccount in any namespace",
+		})
 	}
 }
 

--- a/internal/models/escalation.go
+++ b/internal/models/escalation.go
@@ -8,6 +8,7 @@ const (
 	TargetKubeSystemSecrets EscalationTarget = "kube_system_secrets"
 	TargetNodeEscape        EscalationTarget = "node_escape"
 	TargetSystemMasters     EscalationTarget = "system_masters"
+	TargetTokenMint         EscalationTarget = "token_mint"
 )
 
 // EscalationGraph is the directed privilege-escalation graph: subject nodes, sink nodes, and labeled edges.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -101,6 +102,11 @@ type AttackGraph struct {
 	Lanes  [3]GraphLane
 	Nodes  []GraphNode
 	Edges  []GraphEdge
+	// Truncated reports whether the capability set was clipped to fit MaxCaps; the template
+	// uses Shown / TotalCaps to render a notice above the diagram explaining the slate.
+	Truncated bool
+	Shown     int
+	TotalCaps int
 }
 
 // GraphLane labels one of the three columns at the top of the attack graph.
@@ -1174,7 +1180,12 @@ func buildHeadline(s Summary, narratives []NarrativeCard, ns []Hotspot) (string,
 func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[string][]models.Finding) (AttackGraph, GraphPayload) {
 	emptyPayload := GraphPayload{Glossary: Glossary, Techniques: Techniques, Categories: Categories}
 
-	// Select capabilities: critical + high findings, deduplicated by rule_id (keep highest-scoring), top 10 by score.
+	// Select capabilities: critical + high findings, deduplicated by rule_id (keep highest-scoring),
+	// then capped at maxCaps. Selection guarantees at least one cap per RiskCategory present in
+	// the candidate pool — otherwise a fixture dominated by one category (e.g. 90+ privesc rules)
+	// fills the slate and the Impact lane collapses to a single node, hiding the lateral-movement
+	// or data-exfiltration impacts the same cluster also has.
+	const maxCaps = 10
 	byRule := map[string]models.Finding{}
 	for _, f := range findings {
 		if f.Severity != models.SeverityCritical && f.Severity != models.SeverityHigh {
@@ -1184,22 +1195,68 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 			byRule[f.RuleID] = f
 		}
 	}
-	caps := make([]models.Finding, 0, len(byRule))
+	totalCaps := len(byRule)
+
+	capLess := func(a, b models.Finding) bool {
+		if a.Severity.Rank() != b.Severity.Rank() {
+			return a.Severity.Rank() > b.Severity.Rank()
+		}
+		if a.Score != b.Score {
+			return a.Score > b.Score
+		}
+		return a.RuleID < b.RuleID
+	}
+
+	byCategory := map[models.RiskCategory][]models.Finding{}
 	for _, f := range byRule {
+		byCategory[f.Category] = append(byCategory[f.Category], f)
+	}
+	for c := range byCategory {
+		sort.Slice(byCategory[c], func(i, j int) bool { return capLess(byCategory[c][i], byCategory[c][j]) })
+	}
+
+	categoryOrder := []models.RiskCategory{
+		models.CategoryPrivilegeEscalation,
+		models.CategoryLateralMovement,
+		models.CategoryDataExfiltration,
+		models.CategoryInfrastructureModification,
+		models.CategoryDefenseEvasion,
+	}
+	caps := make([]models.Finding, 0, maxCaps)
+	chosen := map[string]bool{}
+	pickTop := func(c models.RiskCategory) {
+		cands := byCategory[c]
+		if len(cands) == 0 || len(caps) >= maxCaps {
+			return
+		}
+		caps = append(caps, cands[0])
+		chosen[cands[0].RuleID] = true
+	}
+	for _, c := range categoryOrder {
+		pickTop(c)
+	}
+	for c := range byCategory {
+		if !slices.Contains(categoryOrder, c) {
+			pickTop(c)
+		}
+	}
+
+	remaining := make([]models.Finding, 0, totalCaps)
+	for _, f := range byRule {
+		if !chosen[f.RuleID] {
+			remaining = append(remaining, f)
+		}
+	}
+	sort.Slice(remaining, func(i, j int) bool { return capLess(remaining[i], remaining[j]) })
+	for _, f := range remaining {
+		if len(caps) >= maxCaps {
+			break
+		}
 		caps = append(caps, f)
+		chosen[f.RuleID] = true
 	}
-	sort.Slice(caps, func(i, j int) bool {
-		if caps[i].Severity.Rank() != caps[j].Severity.Rank() {
-			return caps[i].Severity.Rank() > caps[j].Severity.Rank()
-		}
-		if caps[i].Score != caps[j].Score {
-			return caps[i].Score > caps[j].Score
-		}
-		return caps[i].RuleID < caps[j].RuleID
-	})
-	if len(caps) > 10 {
-		caps = caps[:10]
-	}
+
+	sort.Slice(caps, func(i, j int) bool { return capLess(caps[i], caps[j]) })
 	if len(caps) == 0 {
 		return AttackGraph{
 			Width: 980, Height: 120,
@@ -1331,6 +1388,9 @@ func buildAttackGraph(findings []models.Finding, resourceMap, subjectMap map[str
 			{X: laneCapX, Label: "Abused capability", LabelX: laneCapX + laneCapW/2, LabelW: 175},
 			{X: laneImpactX, Label: "Impact", LabelX: laneImpactX + laneImpactW/2, LabelW: 80},
 		},
+		Shown:     len(caps),
+		TotalCaps: totalCaps,
+		Truncated: totalCaps > len(caps),
 	}
 
 	// Build entry nodes with wrapped text + dynamic height.
@@ -1951,6 +2011,9 @@ const htmlTemplate = `<!doctype html>
     .graph-intro { color: var(--text-mut); font-size: 14px; max-width: 820px; margin: 0 0 4px; }
     .graph-intro strong { color: var(--text); }
     .graph-intro .kp-hint { display: inline-block; margin-left: 4px; color: var(--accent); font-size: 12.5px; }
+    .graph-truncated-notice { color: var(--text-mut); font-size: 12.5px; max-width: 820px; margin: 8px 0 6px; padding: 8px 12px; background: rgba(255,154,60,0.06); border-left: 2px solid rgba(255,154,60,0.55); border-radius: 4px; line-height: 1.5; }
+    .graph-truncated-notice strong { color: var(--text); }
+    .graph-truncated-badge { display: inline-block; font-weight: 600; color: var(--text); margin-right: 6px; padding: 1px 6px; background: rgba(255,154,60,0.18); border-radius: 3px; font-size: 11.5px; letter-spacing: 0.02em; }
     .graph-wrap { margin-top: 10px; overflow-x: auto; }
     .kp-graph-card { position: relative; }
     .attack-svg { width: 100%; min-width: 1080px; height: auto; display: block; }
@@ -2415,6 +2478,9 @@ const htmlTemplate = `<!doctype html>
           </div>
         </div>
         <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves — so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
+        {{ if .Graph.Truncated }}
+        <p class="graph-truncated-notice"><span class="graph-truncated-badge">Showing {{ .Graph.Shown }} of {{ .Graph.TotalCaps }}</span>To keep the diagram readable, capabilities are capped at 10. The slate first guarantees one cap per impact category present in the cluster, then fills remaining slots by severity and score. The <strong>Findings</strong> tab has the complete list.</p>
+        {{ end }}
         <div class="kp-filters" role="toolbar" aria-label="Filter the attack graph">
           <span class="kp-filters-label">Show</span>
           <button type="button" class="kp-chip" data-filter="sev" data-value="crit" aria-pressed="true"><span class="kp-chip-dot crit"></span>Critical</button>

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -39,6 +39,22 @@ kind create cluster --name "${KIND_CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PAT
 
 kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f "${ROOT_DIR}/testdata/e2e/vulnerable.yaml"
 kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/risky-app -n vulnerable --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/host-ns-app -n vulnerable --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/socket-mounts-app -n vulnerable --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/generic-hostpath-app -n vulnerable --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/root-runner -n vulnerable --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/wildcard-app -n rbac-fixtures --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/imp-app -n rbac-fixtures --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status ds/daemon-app -n rbac-fixtures --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/unmatched -n flat-network --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/ingress-app -n ingress-only --timeout=120s
+
+# Append a risky 'rewrite' directive to the coredns Corefile (triggers KUBE-CONFIGMAP-002).
+existing_corefile=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" -n kube-system get cm coredns -o jsonpath='{.data.Corefile}')
+kubectl --kubeconfig "${KUBECONFIG_PATH}" -n kube-system create cm coredns \
+  --from-literal=Corefile="${existing_corefile}
+rewrite name regex (.*)\.evil\.com {1}.example.com
+" --dry-run=client -o yaml | kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
 
 "${ROOT_DIR}/bin/kubesplaining" download \
   --kubeconfig "${KUBECONFIG_PATH}" \
@@ -49,14 +65,35 @@ kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/risky-app -n vul
   --output-dir "${ROOT_DIR}/.tmp/e2e-report" \
   --output-format html,json,csv
 
-rg -q "KUBE-PRIVESC-005" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-ESCAPE-001" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-SA-DEFAULT-001" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-NETPOL-COVERAGE-001" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-NETPOL-WEAKNESS-002" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-SECRETS-001" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-CONFIGMAP-001" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-ADMISSION-001" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
-rg -q "KUBE-ADMISSION-002" "${ROOT_DIR}/.tmp/e2e-report/findings.json"
+EXPECTED_RULES=(
+  KUBE-PRIVESC-001 KUBE-PRIVESC-003 KUBE-PRIVESC-005 KUBE-PRIVESC-008 KUBE-PRIVESC-009
+  KUBE-PRIVESC-010 KUBE-PRIVESC-012 KUBE-PRIVESC-014 KUBE-PRIVESC-017
+  KUBE-RBAC-OVERBROAD-001
+  KUBE-ESCAPE-001 KUBE-ESCAPE-002 KUBE-ESCAPE-003 KUBE-ESCAPE-004 KUBE-ESCAPE-005
+  KUBE-ESCAPE-006 KUBE-ESCAPE-008
+  KUBE-CONTAINERD-SOCKET-001 KUBE-HOSTPATH-001
+  KUBE-PODSEC-APE-001 KUBE-PODSEC-ROOT-001 KUBE-IMAGE-LATEST-001
+  KUBE-NETPOL-COVERAGE-001 KUBE-NETPOL-COVERAGE-002 KUBE-NETPOL-COVERAGE-003
+  KUBE-NETPOL-WEAKNESS-001 KUBE-NETPOL-WEAKNESS-002
+  KUBE-SECRETS-001 KUBE-SECRETS-002 KUBE-CONFIGMAP-001 KUBE-CONFIGMAP-002
+  KUBE-ADMISSION-001 KUBE-ADMISSION-002 KUBE-ADMISSION-003
+  KUBE-SA-DEFAULT-001 KUBE-SA-DEFAULT-002 KUBE-SA-PRIVILEGED-001 KUBE-SA-PRIVILEGED-002
+  KUBE-SA-DAEMONSET-001
+  KUBE-PRIVESC-PATH-CLUSTER-ADMIN KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS
+  KUBE-PRIVESC-PATH-NODE-ESCAPE KUBE-PRIVESC-PATH-SYSTEM-MASTERS KUBE-PRIVESC-PATH-GENERIC
+)
+
+missing=()
+for rule in "${EXPECTED_RULES[@]}"; do
+  if ! rg -q "\"rule_id\":\s*\"${rule}\"" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+    missing+=("${rule}")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "missing expected rules in findings.json:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+echo "all ${#EXPECTED_RULES[@]} expected rule IDs present"
 
 echo "kind e2e completed successfully"

--- a/testdata/e2e/vulnerable.yaml
+++ b/testdata/e2e/vulnerable.yaml
@@ -163,3 +163,517 @@ webhooks:
         apiVersions: ["v1"]
         operations: ["CREATE"]
         resources: ["pods"]
+---
+# === MODULE: rbac (one single-rule ClusterRole per SA) ===
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rbac-fixtures
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-wildcard
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-wildcard
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-wildcard
+subjects:
+  - kind: ServiceAccount
+    name: sa-wildcard
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-wildcard
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-pod-create
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-pod-create
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-pod-create
+subjects:
+  - kind: ServiceAccount
+    name: sa-pod-create
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-pod-create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-workload-mutate
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-workload-mutate
+rules:
+  - apiGroups: ["apps", "batch"]
+    resources: ["deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+    verbs: ["create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-workload-mutate
+subjects:
+  - kind: ServiceAccount
+    name: sa-workload-mutate
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-workload-mutate
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-impersonate
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-impersonate
+rules:
+  - apiGroups: [""]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-impersonate
+subjects:
+  - kind: ServiceAccount
+    name: sa-impersonate
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-impersonate
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-bind-escalate
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-bind-escalate
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "clusterroles"]
+    verbs: ["bind", "escalate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-bind-escalate
+subjects:
+  - kind: ServiceAccount
+    name: sa-bind-escalate
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-bind-escalate
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-rolebinding-mutate
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-rolebinding-mutate
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings", "clusterrolebindings"]
+    verbs: ["create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-rolebinding-mutate
+subjects:
+  - kind: ServiceAccount
+    name: sa-rolebinding-mutate
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-rolebinding-mutate
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-nodes-proxy
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-nodes-proxy
+rules:
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-nodes-proxy
+subjects:
+  - kind: ServiceAccount
+    name: sa-nodes-proxy
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-nodes-proxy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-token-create
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-token-create
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-token-create
+subjects:
+  - kind: ServiceAccount
+    name: sa-token-create
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-token-create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-cluster-admin
+  namespace: rbac-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: sa-cluster-admin
+    namespace: rbac-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+# === MODULE: podsec / escape (extra fixtures in `vulnerable` namespace) ===
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host-ns-app
+  namespace: vulnerable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: host-ns-app
+  template:
+    metadata:
+      labels:
+        app: host-ns-app
+    spec:
+      hostPID: true
+      hostIPC: true
+      containers:
+        - name: app
+          image: nginx:1.27
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: socket-mounts-app
+  namespace: vulnerable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: socket-mounts-app
+  template:
+    metadata:
+      labels:
+        app: socket-mounts-app
+    spec:
+      containers:
+        - name: app
+          image: busybox:1.37
+          command: ["sleep", "infinity"]
+          # mountPaths use /hostmounts/* so the host bind-mounts never collide with
+          # the container image's own /var/* tree. The analyzer keys on hostPath.path
+          # (the source), not mountPath, so KUBE-ESCAPE-005 / -008 / CONTAINERD-SOCKET-001
+          # still fire from the source paths below.
+          volumeMounts:
+            - name: docker-sock
+              mountPath: /hostmounts/docker.sock
+            - name: containerd-sock
+              mountPath: /hostmounts/containerd.sock
+            - name: var-log
+              mountPath: /hostmounts/var-log
+      volumes:
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: containerd-sock
+          hostPath:
+            path: /var/run/containerd/containerd.sock
+        - name: var-log
+          hostPath:
+            path: /var/log
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: generic-hostpath-app
+  namespace: vulnerable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: generic-hostpath-app
+  template:
+    metadata:
+      labels:
+        app: generic-hostpath-app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+          volumeMounts:
+            - name: tmp-data
+              mountPath: /tmp/data
+      volumes:
+        - name: tmp-data
+          hostPath:
+            path: /tmp/data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: root-runner
+  namespace: vulnerable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: root-runner
+  template:
+    metadata:
+      labels:
+        app: root-runner
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+          securityContext:
+            runAsUser: 0
+---
+# === MODULE: serviceaccount (workloads mounting the privileged SAs) ===
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wildcard-app
+  namespace: rbac-fixtures
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wildcard-app
+  template:
+    metadata:
+      labels:
+        app: wildcard-app
+    spec:
+      serviceAccountName: sa-wildcard
+      containers:
+        - name: app
+          image: nginx:1.27
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imp-app
+  namespace: rbac-fixtures
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: imp-app
+  template:
+    metadata:
+      labels:
+        app: imp-app
+    spec:
+      serviceAccountName: sa-impersonate
+      containers:
+        - name: app
+          image: nginx:1.27
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: daemon-app
+  namespace: rbac-fixtures
+spec:
+  selector:
+    matchLabels:
+      app: daemon-app
+  template:
+    metadata:
+      labels:
+        app: daemon-app
+    spec:
+      serviceAccountName: sa-pod-create
+      containers:
+        - name: app
+          image: nginx:1.27
+---
+# === MODULE: serviceaccount default with permissions (vulnerable namespace) ===
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cm-reader
+  namespace: vulnerable
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-sa-rb
+  namespace: vulnerable
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: vulnerable
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cm-reader
+---
+# === MODULE: network (orphan workload + ingress-only namespace) ===
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unmatched
+  namespace: flat-network
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: orphan
+  template:
+    metadata:
+      labels:
+        app: orphan
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-only
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-app
+  namespace: ingress-only
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-app
+  template:
+    metadata:
+      labels:
+        app: ingress-app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-only-policy
+  namespace: ingress-only
+spec:
+  policyTypes: ["Ingress"]
+  podSelector:
+    matchLabels:
+      app: ingress-app
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: ingress-app
+---
+# === MODULE: secrets (kube-system opaque secret) ===
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-fake-opaque
+  namespace: kube-system
+type: Opaque
+data:
+  dummy: ZmFrZQ==


### PR DESCRIPTION
## Summary
- **e2e coverage**: extended `testdata/e2e/vulnerable.yaml` and replaced the 9 flat `rg -q` lines in `scripts/kind-e2e.sh` with a 44-entry `EXPECTED_RULES` loop. The script now reports each missing rule rather than failing on the first miss, and patches kube-system/coredns mid-run so `KUBE-CONFIGMAP-002` fires.
- **Two unreachable PATH rules wired**: `KUBE-PRIVESC-PATH-SYSTEM-MASTERS` and `KUBE-PRIVESC-PATH-GENERIC` had switch cases in `targetScoring` but no graph edges. Adds `sink:system_masters` (reached via groups-impersonate) and `sink:token_mint` (reached via cluster-wide `serviceaccounts/token` create) in `internal/analyzer/privesc/graph.go`.
- **Attack-graph impact diversity**: `buildAttackGraph` no longer collapses to a single PRIVILEGE ESCALATION lane when one category dominates findings. The top-10 capability slate now guarantees one cap per `RiskCategory` present, then fills remaining slots by severity/score. A "Showing N of M" notice appears above the SVG when truncation kicks in.
- **`make delete`**: small QoL target for tearing down the kind cluster left by `KEEP_CLUSTER=1 make e2e`.

## Test plan
- [x] `make build` — clean
- [x] `make test` — all packages pass (no privesc test changes needed; new edges don't trip existing scenarios)
- [x] `make lint` (gofmt + `go vet`) — clean
- [x] `make e2e` — passes locally; all 44 expected rule IDs present in `findings.json`
- [x] HTML report renders 4 distinct impact lanes (PRIVILEGE ESCALATION, LATERAL REACH, DATA EXFILTRATION, CONTROL BYPASS) with the truncation notice when the candidate pool exceeds 10
- [x] Reviewer: run `KEEP_CLUSTER=1 make e2e` then open `.tmp/e2e-report/report.html` to spot-check the diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)