### PR TITLE
Keep kind cluster after make e2e; switch user context to it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ scan: build
 
 delete:
 	kind delete cluster --name $(KIND_CLUSTER_NAME)
+	@if [ -f "$(HOME)/.kube/config" ]; then \
+		KUBECONFIG="$(HOME)/.kube/config" kind delete cluster --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || true; \
+	fi
 
 clean:
 	rm -rf ./bin ./kubesplaining-report ./.tmp

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubesplaining-e2e}"
 KUBECONFIG_PATH="${KUBECONFIG:-${ROOT_DIR}/.tmp/kubeconfig}"
-KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-1}"
+USER_KUBECONFIG="${USER_KUBECONFIG:-${HOME}/.kube/config}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -29,12 +30,20 @@ mkdir -p "${ROOT_DIR}/.tmp"
 cleanup() {
   if [[ "${KEEP_CLUSTER}" != "1" ]]; then
     kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+    if [[ -f "${USER_KUBECONFIG}" ]]; then
+      KUBECONFIG="${USER_KUBECONFIG}" kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+    fi
   fi
 }
 
 trap cleanup EXIT
 
+# Always start fresh: tear down any prior cluster of the same name, including
+# the stale entry in the user's default kubeconfig from a previous run.
 kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+if [[ -f "${USER_KUBECONFIG}" ]]; then
+  KUBECONFIG="${USER_KUBECONFIG}" kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+fi
 kind create cluster --name "${KIND_CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PATH}" --wait 90s
 
 kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f "${ROOT_DIR}/testdata/e2e/vulnerable.yaml"
@@ -95,5 +104,14 @@ if (( ${#missing[@]} > 0 )); then
   exit 1
 fi
 echo "all ${#EXPECTED_RULES[@]} expected rule IDs present"
+
+if [[ "${KEEP_CLUSTER}" == "1" ]]; then
+  mkdir -p "$(dirname "${USER_KUBECONFIG}")"
+  touch "${USER_KUBECONFIG}"
+  KUBECONFIG="${USER_KUBECONFIG}" kind export kubeconfig --name "${KIND_CLUSTER_NAME}" >/dev/null
+  echo "kubectl context set to kind-${KIND_CLUSTER_NAME} in ${USER_KUBECONFIG}"
+  echo "  try: kubectl get pods -A"
+  echo "  to remove: make delete"
+fi
 
 echo "kind e2e completed successfully"


### PR DESCRIPTION
## Summary
- `KEEP_CLUSTER` defaults to `1` so the kind cluster persists after `make e2e`; on success the script merges the kind context into `~/.kube/config` and sets it current, so `kubectl get pods -A` just works.
- A re-run still tears down the prior cluster first, and now also clears the stale `kind-<name>` entry from `~/.kube/config` so the new credentials replace it cleanly.
- `make delete` removes the kind context from `~/.kube/config` as well.

Override with `KEEP_CLUSTER=0` to restore the old auto-delete-on-exit behavior.

## Test plan
- [x] `make e2e` from a clean state — cluster persists; `kubectl config current-context` is `kind-kubesplaining-e2e`; `kubectl get pods -A` lists fixture pods.
- [x] Run `make e2e` a second time — old cluster is torn down before the new one comes up; user kubeconfig has fresh credentials.
- [x] `make delete` — cluster gone and `kind-kubesplaining-e2e` entry removed from `~/.kube/config`.
- [x] `KEEP_CLUSTER=0 make e2e` — cluster removed at end; user kubeconfig cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)