### PR TITLE
Make attack-chain readable; fix sticky-header bleed + graph banner layout

### DIFF
--- a/internal/analyzer/privesc/content.go
+++ b/internal/analyzer/privesc/content.go
@@ -68,24 +68,114 @@ func scopeForPath(source models.SubjectRef, target models.EscalationTarget) mode
 	}
 }
 
-// hopNarrative renders one hop into a single-sentence attacker step using the hop's
-// own Gains field plus the technique label.
+// hopNarrative renders one hop into a natural-prose sentence describing what the
+// attacker does at that step. The output goes into Finding.AttackScenario, which
+// the report template wraps in an <ol> — so we deliberately omit any "Step N:"
+// prefix (the list renders the number) and write each hop as a self-contained
+// sentence using the technique's human-readable title rather than its slug.
+//
+// The technique titles here intentionally mirror internal/report/glossary.go's
+// Techniques map. We don't import that map directly because the privesc analyzer
+// must not depend on the report package; if a slug is added there it should be
+// reflected here too. Fallback prose is generic but still readable.
 func hopNarrative(hop models.EscalationHop) string {
-	parts := []string{}
-	if hop.Action != "" {
-		parts = append(parts, fmt.Sprintf("technique `%s`", hop.Action))
-	}
+	from := backtickSubject(hop.FromSubject)
+	to := backtickSubject(hop.ToSubject)
+	hasTo := to != ""
+	perm := ""
 	if hop.Permission != "" {
-		parts = append(parts, fmt.Sprintf("via permission `%s`", hop.Permission))
+		perm = fmt.Sprintf("`%s`", hop.Permission)
 	}
-	if hop.Gains != "" {
-		parts = append(parts, hop.Gains)
+	gains := strings.TrimSpace(hop.Gains)
+
+	switch hop.Action {
+	case "bound_to_cluster_admin":
+		return fmt.Sprintf("%s is bound directly to the `cluster-admin` ClusterRole — no chain step is needed beyond compromising the subject itself.", from)
+
+	case "wildcard_permission":
+		return fmt.Sprintf("The identity %s already holds wildcard verbs on wildcard resources (%s), which is functionally identical to `cluster-admin`. The attacker can take any action on any resource in the cluster without further escalation.", from, perm)
+
+	case "modify_role_binding":
+		return fmt.Sprintf("Acting as %s, the attacker abuses RoleBinding write access (%s) to add themselves (or any subject they control) to a high-privilege ClusterRoleBinding — typically `cluster-admin`. They don't need the target role's permissions today, only the ability to change bindings.", from, perm)
+
+	case "bind_or_escalate":
+		if hasTo {
+			return fmt.Sprintf("Acting as %s, the attacker uses the RBAC `bind`/`escalate` bypass (%s) to grant themselves a role they do not currently hold and bind to %s. `bind`/`escalate` is the carve-out that lets the holder escape RBAC's normal \"you can only grant what you have\" guardrail.", from, perm, to)
+		}
+		return fmt.Sprintf("Acting as %s, the attacker uses the RBAC `bind`/`escalate` bypass (%s) to grant themselves any role they choose — typically `cluster-admin`. `bind`/`escalate` is the carve-out that lets the holder escape RBAC's normal \"you can only grant what you have\" guardrail.", from, perm)
+
+	case "impersonate":
+		if hasTo {
+			return fmt.Sprintf("Acting as %s, the attacker uses RBAC impersonation (the `impersonate` verb on %s) to send API requests as %s — the kube-apiserver honours the `Impersonate-User` / `Impersonate-Group` headers and authorizes the request against the impersonated identity's permissions instead of the attacker's.", from, perm, to)
+		}
+		return fmt.Sprintf("Acting as %s, the attacker uses RBAC impersonation (the `impersonate` verb on %s) to send API requests as any identity in the cluster — including `system:masters`, which the apiserver hard-codes as cluster-admin. Granting `impersonate` on `groups: [\"*\"]` is functionally a cluster-admin grant.", from, perm)
+
+	case "impersonate_system_masters":
+		return fmt.Sprintf("Acting as %s, the attacker impersonates the `system:masters` group (%s). The kube-apiserver hard-codes that group as authorized for every operation regardless of RBAC — a single such grant collapses the entire authorization layer.", from, perm)
+
+	case "read_secrets":
+		return fmt.Sprintf("Acting as %s, the attacker reads ServiceAccount tokens out of the cluster's Secrets store (%s) and uses one of those tokens — typically a control-plane controller's — to escalate. Read-access on Secrets is the most consequential single verb in Kubernetes RBAC because every other identity's credential lives in a Secret object somewhere.", from, perm)
+
+	case "nodes_proxy":
+		return fmt.Sprintf("Acting as %s, the attacker uses `nodes/proxy` (%s) to forward requests directly to the kubelet on each node. Combined with the kubelet's `/exec` endpoint this becomes a primitive for running commands inside any pod the kubelet can see.", from, perm)
+
+	case "pod_create_token_theft":
+		if hasTo {
+			return fmt.Sprintf("Acting as %s, the attacker creates a pod that mounts the %s ServiceAccount and then reads `/var/run/secrets/kubernetes.io/serviceaccount/token` from inside the container. The pod becomes a token-theft primitive: any ServiceAccount the attacker can mount, they can lift.", from, to)
+		}
+		return fmt.Sprintf("Acting as %s, the attacker creates a pod that mounts a privileged ServiceAccount and reads `/var/run/secrets/kubernetes.io/serviceaccount/token` from inside the container — the pod is a token-theft primitive.", from)
+
+	case "pod_exec":
+		if hasTo {
+			return fmt.Sprintf("Acting as %s, the attacker uses `pods/exec` (%s) to open a shell inside %s and inherit whatever ServiceAccount or host privileges that container holds.", from, perm, to)
+		}
+		return fmt.Sprintf("Acting as %s, the attacker uses `pods/exec` (%s) to open a shell inside a privileged pod and inherit whatever ServiceAccount or host privileges that container holds.", from, perm)
+
+	case "token_request":
+		if hasTo {
+			return fmt.Sprintf("Acting as %s, the attacker calls the `serviceaccounts/token` subresource (%s) to mint a fresh, valid token for %s — no pod creation required, and a thinner audit trail than the pod-mount route.", from, perm, to)
+		}
+		return fmt.Sprintf("Acting as %s, the attacker calls the `serviceaccounts/token` subresource (%s) to mint a fresh token for a privileged ServiceAccount — no pod creation required, and a thinner audit trail than the pod-mount route.", from, perm)
+
+	case "mint_arbitrary_token":
+		return fmt.Sprintf("Acting as %s, the attacker calls `serviceaccounts/token` at cluster scope (%s) to mint a token for any ServiceAccount in any namespace. With no `resourceNames` constraint, the verb amounts to a credential-issuing oracle.", from, perm)
+
+	case "pod_host_escape":
+		return fmt.Sprintf("Acting as %s, the attacker schedules a pod with host-level access (`privileged: true`, `hostPath: /`, `hostPID`, or `hostNetwork`) and escapes onto the underlying node. From there they read every co-located pod's filesystem, every projected ServiceAccount token on that node, and the kubelet's client cert.", from)
 	}
-	prefix := fmt.Sprintf("Step %d: from `%s` to `%s`", hop.Step, hop.FromSubject.Key(), hop.ToSubject.Key())
-	if len(parts) == 0 {
-		return prefix + "."
+
+	// Fallback: unknown technique slug. Produce readable prose using the raw fields
+	// rather than a colon-and-semicolon dump, so a future analyzer rule that emits
+	// a new slug still reads sensibly until a case is added above.
+	var b strings.Builder
+	fmt.Fprintf(&b, "Acting as %s", from)
+	if hasTo {
+		fmt.Fprintf(&b, ", the attacker uses the `%s` technique to reach %s", hop.Action, to)
+	} else if hop.Action != "" {
+		fmt.Fprintf(&b, ", the attacker uses the `%s` technique", hop.Action)
 	}
-	return prefix + " — " + strings.Join(parts, "; ") + "."
+	if perm != "" {
+		fmt.Fprintf(&b, " via %s", perm)
+	}
+	if gains != "" {
+		fmt.Fprintf(&b, " — %s", gains)
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+// backtickSubject returns a Markdown backtick-wrapped Key() for a subject, or
+// "" when the SubjectRef is empty (e.g. the tail of an escalation path whose
+// terminal hop ends at a synthetic sink — cluster_admin, node_escape — instead
+// of another subject). Callers that reference the target should branch on the
+// empty case to produce sink-aware prose, since an empty backtick pair reads
+// as a rendering bug to the reader.
+func backtickSubject(s models.SubjectRef) string {
+	key := s.Key()
+	if key == "" || key == "/" {
+		return ""
+	}
+	return fmt.Sprintf("`%s`", key)
 }
 
 // hopsRemediation surfaces the hop most suitable for breaking the chain: prefer mid-chain

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -42,7 +42,7 @@
     h2 { font-size: 19px; }
     h3 { font-size: 15.5px; }
 
-    .topbar { border-bottom: 1px solid var(--border-soft); background: rgba(10,13,22,0.72); position: sticky; top: 0; z-index: 5; }
+    .topbar { border-bottom: 1px solid var(--border-soft); background: rgba(10,13,22,0.96); -webkit-backdrop-filter: blur(12px) saturate(140%); backdrop-filter: blur(12px) saturate(140%); position: sticky; top: 0; z-index: 5; }
     .topbar-inner { max-width: 1280px; margin: 0 auto; padding: 14px 28px; display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
     .brand { display: flex; align-items: center; gap: 12px; }
     .brand-mark { width: 30px; height: 30px; border-radius: 8px;
@@ -115,10 +115,12 @@
     .risk-factors li::before { content: '▸'; position: absolute; left: 2px; color: var(--accent); font-size: 11px; top: 1px; }
     .risk-factors li strong { color: var(--text); font-weight: 600; }
 
-    .graph-intro { color: var(--text-mut); font-size: 14px; max-width: 820px; margin: 0 0 4px; }
+    .graph-header-row { display: flex; gap: 24px; align-items: flex-start; flex-wrap: wrap; margin: 0 0 6px; }
+    .graph-header-row > * { margin: 0; }
+    .graph-intro { color: var(--text-mut); font-size: 14px; max-width: 820px; flex: 1 1 420px; margin: 0 0 4px; }
     .graph-intro strong { color: var(--text); }
     .graph-intro .kp-hint { display: inline-block; margin-left: 4px; color: var(--accent); font-size: 12.5px; }
-    .graph-truncated-notice { color: var(--text-mut); font-size: 12.5px; max-width: 820px; margin: 8px 0 6px; padding: 8px 12px; background: rgba(255,154,60,0.06); border-left: 2px solid rgba(255,154,60,0.55); border-radius: 4px; line-height: 1.5; }
+    .graph-truncated-notice { color: var(--text-mut); font-size: 12.5px; flex: 1 1 360px; min-width: 280px; padding: 8px 12px; background: rgba(255,154,60,0.06); border-left: 2px solid rgba(255,154,60,0.55); border-radius: 4px; line-height: 1.5; }
     .graph-truncated-notice strong { color: var(--text); }
     .graph-truncated-badge { display: inline-block; font-weight: 600; color: var(--text); margin-right: 6px; padding: 1px 6px; background: rgba(255,154,60,0.18); border-radius: 3px; font-size: 11.5px; letter-spacing: 0.02em; }
     .graph-wrap { margin-top: 10px; overflow-x: auto; }
@@ -440,9 +442,16 @@
     .finding .chain .k { color: var(--critical, #ff5a5a); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
     .finding .chain ol.attack-chain { list-style: none; padding-left: 0; margin: 0; display: grid; gap: 10px; counter-reset: step; }
     .finding .chain ol.attack-chain li.attack-step { padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: rgba(255,255,255,0.02); font-size: 13px; line-height: 1.5; color: var(--text); }
-    .finding .chain .step-hd { display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px; }
+    .finding .chain .step-hd { display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px; flex-wrap: wrap; }
     .finding .chain .step-num { font-weight: 700; color: var(--accent); font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
-    .finding .chain .step-action { background: rgba(255,255,255,0.06); padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
+    .finding .chain .step-title { color: var(--text); font-weight: 600; font-size: 13px; }
+    .finding .chain .step-action { background: rgba(255,255,255,0.06); padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text-mut); }
+    .finding .chain .step-explainer { margin: 4px 0 8px; color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
+    .finding .chain .step-explainer p { margin: 0 0 6px; }
+    .finding .chain .step-explainer p:last-child { margin-bottom: 0; }
+    .finding .chain .step-explainer code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
+    .finding .chain .step-explainer strong { color: var(--text); font-weight: 600; }
+    .finding .chain .step-explainer em { color: var(--text); font-style: italic; }
     .finding .chain .step-edge { color: var(--text-mut); margin-bottom: 4px; font-size: 13px; }
     .finding .chain .step-edge code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text); }
     .finding .chain .step-meta { font-size: 12.5px; color: var(--text-mut); margin-top: 2px; }
@@ -584,10 +593,12 @@
             <span class="legend-item"><span class="legend-dot high"></span>high edge</span>
           </div>
         </div>
-        <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves — so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
-        {{ if .Graph.Truncated }}
-        <p class="graph-truncated-notice"><span class="graph-truncated-badge">Showing {{ .Graph.Shown }} of {{ .Graph.TotalCaps }}</span>To keep the diagram readable, capabilities are capped at 10. The slate first guarantees one cap per impact category present in the cluster, then fills remaining slots by severity and score. The <strong>Findings</strong> tab has the complete list.</p>
-        {{ end }}
+        <div class="graph-header-row">
+          <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves — so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
+          {{ if .Graph.Truncated }}
+          <p class="graph-truncated-notice"><span class="graph-truncated-badge">Showing {{ .Graph.Shown }} of {{ .Graph.TotalCaps }}</span>To keep the diagram readable, capabilities are capped at 10. The slate first guarantees one cap per impact category present in the cluster, then fills remaining slots by severity and score. The <strong>Findings</strong> tab has the complete list.</p>
+          {{ end }}
+        </div>
         <div class="kp-filters" role="toolbar" aria-label="Filter the attack graph">
           <span class="kp-filters-label">Show</span>
           <button type="button" class="kp-chip" data-filter="sev" data-value="crit" aria-pressed="true"><span class="kp-chip-dot crit"></span>Critical</button>
@@ -882,10 +893,11 @@
             {{ range .MitreTechniques }}<a href="{{ .URL }}" target="_blank" rel="noopener noreferrer" title="{{ .Name }}">{{ .ID }}</a>{{ end }}
           </div>
           {{ end }}
-          {{ if .Evidence }}
+          {{ $ev := evidenceHTML .Evidence }}
+          {{ if $ev }}
           <div class="evidence">
             <span class="k">Evidence</span>
-            {{ evidenceHTML .Evidence }}
+            {{ $ev }}
             <details class="evidence-raw">
               <summary>Show raw JSON</summary>
               <pre><code>{{ json .Evidence }}</code></pre>

--- a/internal/report/evidence_render.go
+++ b/internal/report/evidence_render.go
@@ -190,22 +190,51 @@ func secretTypeLabelDelta(t string) string {
 }
 
 // renderEscalationPath emits a numbered ordered list of step cards describing the
-// per-hop chain from the source subject to the privesc sink. Returns "" for empty
-// input so the template `{{ if … }}` gate can suppress the whole section.
+// per-hop chain from the source subject to the privesc sink. Each card surfaces the
+// human-readable technique title and a one-paragraph explainer from the Techniques
+// glossary so a reader who has never seen the slug (`impersonate`, `wildcard_permission`)
+// learns what it means in place. Returns "" for empty input so the template
+// `{{ if … }}` gate can suppress the whole section.
+//
+// The "Step N of M" prefix is omitted for single-hop chains — there is no chain to
+// follow, so numbering reads as ceremony.
 func renderEscalationPath(hops []models.EscalationHop) template.HTML {
 	if len(hops) == 0 {
 		return ""
 	}
+	total := len(hops)
 	var b strings.Builder
 	b.WriteString(`<ol class="attack-chain">`)
 	for _, hop := range hops {
 		b.WriteString(`<li class="attack-step">`)
 
-		b.WriteString(`<div class="step-hd"><span class="step-num">Step `)
-		b.WriteString(fmt.Sprintf("%d", hop.Step))
-		b.WriteString(`</span> <code class="step-action">`)
-		b.WriteString(template.HTMLEscapeString(hop.Action))
-		b.WriteString(`</code></div>`)
+		expl, hasExpl := Techniques[hop.Action]
+		title := expl.Title
+		if title == "" {
+			title = hop.Action
+		}
+
+		b.WriteString(`<div class="step-hd">`)
+		if total > 1 {
+			b.WriteString(`<span class="step-num">Step `)
+			b.WriteString(fmt.Sprintf("%d of %d", hop.Step, total))
+			b.WriteString(`</span> `)
+		}
+		b.WriteString(`<span class="step-title">`)
+		b.WriteString(template.HTMLEscapeString(title))
+		b.WriteString(`</span>`)
+		if hop.Action != "" && hop.Action != title {
+			b.WriteString(` <code class="step-action">`)
+			b.WriteString(template.HTMLEscapeString(hop.Action))
+			b.WriteString(`</code>`)
+		}
+		b.WriteString(`</div>`)
+
+		if hasExpl && expl.Plain != "" {
+			b.WriteString(`<div class="step-explainer">`)
+			b.WriteString(string(expl.Plain))
+			b.WriteString(`</div>`)
+		}
 
 		from := subjectKey(hop.FromSubject)
 		to := subjectKey(hop.ToSubject)
@@ -228,12 +257,12 @@ func renderEscalationPath(hops []models.EscalationHop) template.HTML {
 		}
 
 		if hop.Permission != "" {
-			b.WriteString(`<div class="step-meta"><span class="k">Permission</span> <code>`)
+			b.WriteString(`<div class="step-meta"><span class="k">Permission granted</span> <code>`)
 			b.WriteString(template.HTMLEscapeString(hop.Permission))
 			b.WriteString(`</code></div>`)
 		}
 		if hop.Gains != "" {
-			b.WriteString(`<div class="step-meta"><span class="k">Gains</span> <span class="v">`)
+			b.WriteString(`<div class="step-meta"><span class="k">Gives the attacker</span> <span class="v">`)
 			b.WriteString(template.HTMLEscapeString(hop.Gains))
 			b.WriteString(`</span></div>`)
 		}

--- a/internal/report/glossary.go
+++ b/internal/report/glossary.go
@@ -196,6 +196,24 @@ var Glossary = map[string]GlossaryEntry{
 // Techniques maps a privesc-action key (matching the Action strings in
 // internal/analyzer/privesc/graph.go) to its educational content.
 var Techniques = map[string]TechniqueExplainer{
+	"impersonate_system_masters": {
+		Title: "Impersonation of system:masters",
+		Plain: template.HTML(`<p>The <code>impersonate</code> verb on <code>groups: ["*"]</code> (or explicitly on <code>system:masters</code>) lets the holder send requests as the hard-coded <code>system:masters</code> group. The kube-apiserver short-circuits authorization for that group — every API call succeeds regardless of RBAC.</p><p>This is the worst-case impersonation grant: it bypasses the cluster's entire RBAC layer rather than borrowing another principal's permissions.</p>`),
+		Mitre: "T1078.004 — Cloud Accounts",
+		AttackerSteps: []AttackerStep{
+			{Note: "Confirm the bypass works by querying as system:masters", Cmd: "kubectl auth can-i --list --as=system:masters --as-group=system:masters"},
+			{Note: "Read every Secret cluster-wide", Cmd: "kubectl --as=system:masters --as-group=system:masters get secrets -A"},
+		},
+	},
+	"mint_arbitrary_token": {
+		Title: "Mint a token for any ServiceAccount",
+		Plain: template.HTML(`<p>The <code>create</code> verb on <code>serviceaccounts/token</code> at cluster scope (without <code>resourceNames</code>) lets the holder mint a fresh, valid token for <em>any</em> ServiceAccount in any namespace. No pod creation or exec needed, and it leaves a thinner audit trail than the pod-mount route.</p>`),
+		Mitre: "T1528 — Steal Application Access Token",
+		AttackerSteps: []AttackerStep{
+			{Note: "Mint a 24h token for a privileged ServiceAccount", Cmd: "kubectl create token <sa> -n <ns> --duration=24h"},
+			{Note: "Call the API as the ServiceAccount using the minted token", Cmd: "curl --header 'Authorization: Bearer <token>' https://kubernetes.default.svc/api/..."},
+		},
+	},
 	"impersonate": {
 		Title: "RBAC impersonation",
 		Plain: template.HTML(`<p>Kubernetes has a built-in "act as another user" feature — the <code>impersonate</code> verb on <code>users</code>, <code>groups</code>, or <code>serviceaccounts</code>. Anyone with that verb can submit requests as <em>any</em> identity, bypassing whatever permissions they don't have themselves.</p><p>Granting <code>impersonate</code> on <code>groups</code> = <code>["*"]</code> is equivalent to cluster-admin: the holder can impersonate <code>system:masters</code>.</p>`),

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -195,5 +196,88 @@ func TestHTMLReportInteractiveGraph(t *testing.T) {
 		if !strings.Contains(html, needle) {
 			t.Errorf("rendered HTML missing %q", needle)
 		}
+	}
+}
+
+// TestHTMLReportHidesEvidenceWhenAllKeysSuppressed verifies the template-level gate
+// for the Evidence section. Privesc-path findings carry only suppressed evidence keys
+// (target/hop_count/techniques/first_action/chain_summary), so renderEvidence returns
+// "" — and the surrounding wrapper must hide rather than emit an empty box.
+// Sister test: TestRenderEvidenceSuppressesPrivescSummary in evidence_render_test.go
+// covers the unit-level behavior of renderEvidence; this one covers the template gate.
+func TestHTMLReportHidesEvidenceWhenAllKeysSuppressed(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	snapshot := models.NewSnapshot()
+
+	rawEvidence, err := json.Marshal(map[string]any{
+		"target":        "cluster_admin_equivalent",
+		"hop_count":     1,
+		"techniques":    []string{"impersonate"},
+		"first_action":  "impersonate",
+		"chain_summary": []string{"1. impersonate"},
+	})
+	if err != nil {
+		t.Fatalf("marshal evidence: %v", err)
+	}
+
+	findings := []models.Finding{
+		{
+			ID:       "KUBE-PRIVESC-PATH-CLUSTER-ADMIN:ServiceAccount/default/risky:cluster_admin_equivalent",
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Score:    9.8,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "Privesc path",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "risky", Namespace: "default"},
+			Evidence: rawEvidence,
+			EscalationPath: []models.EscalationHop{
+				{
+					Step:        1,
+					Action:      "impersonate",
+					FromSubject: models.SubjectRef{Kind: "ServiceAccount", Name: "risky", Namespace: "default"},
+					Permission:  "impersonate users",
+					Gains:       "cluster-admin",
+				},
+			},
+			Tags: []string{"module:privesc"},
+		},
+	}
+
+	if _, err := Write(tmpDir, []string{"html"}, snapshot, findings); err != nil {
+		t.Fatalf("Write html: %v", err)
+	}
+	htmlBytes, err := os.ReadFile(filepath.Join(tmpDir, "report.html"))
+	if err != nil {
+		t.Fatalf("read report.html: %v", err)
+	}
+	html := string(htmlBytes)
+
+	// Sanity: the OBSERVED ATTACK CHAIN block still rendered — that's what justifies
+	// hiding Evidence in the first place.
+	if !strings.Contains(html, `class="attack-chain"`) {
+		t.Fatalf("expected EscalationPath markup (attack-chain) to render, but it is missing")
+	}
+
+	// The technique glossary explainer must surface for any known hop technique
+	// (here: "impersonate"). If this assertion ever fails, the chain card has
+	// regressed back to printing slugs without their plain-English description.
+	if !strings.Contains(html, `class="step-explainer"`) {
+		t.Fatalf("expected glossary-driven step-explainer markup in attack-chain card, but it is missing")
+	}
+	// And the human-readable technique title (from glossary.Techniques) must be
+	// surfaced rather than only the raw slug.
+	if !strings.Contains(html, `RBAC impersonation`) {
+		t.Fatalf("expected technique title %q in chain card, but it is missing", "RBAC impersonation")
+	}
+
+	// The "Evidence" header markup must NOT appear, since the structured grid was empty.
+	if strings.Contains(html, `<span class="k">Evidence</span>`) {
+		t.Errorf("Evidence section still rendered for fully-suppressed payload — expected the wrapper to be hidden")
+	}
+	// The "Show raw JSON" toggle is part of the same wrapper — it must also be gone.
+	if strings.Contains(html, `class="evidence-raw"`) {
+		t.Errorf("evidence-raw <details> still rendered for fully-suppressed payload — expected the wrapper to be hidden")
 	}
 }


### PR DESCRIPTION
## Summary

- **Attack-chain card now teaches.** Each hop in "Observed attack chain" leads with the glossary's human title (e.g. `RBAC impersonation` instead of `impersonate`) followed by the plain-English explainer paragraph — so a reader newer to RBAC learns what the slug means in place. The slug is demoted to a small monospace tag. `Step N` prefix is hidden when the chain is single-hop (no chain to follow), and uses `Step N of M` otherwise. Labels softened: `Permission` → `Permission granted`, `Gains` → `Gives the attacker`. Added missing glossary entries for `impersonate_system_masters` and `mint_arbitrary_token` so every analyzer-emitted slug has copy.
- **"How an attacker abuses this" reads as prose.** Rewrote `internal/analyzer/privesc/content.go::hopNarrative` from a `Step N: from X to Y — technique foo; via permission …; …` template into a per-technique switch producing natural sentences. Each terminal-hop case (where `ToSubject` is a synthetic sink) is handled separately so the prose never reads "to act as the source subject".
- **Sticky topbar no longer bleeds.** `.topbar` background bumped from `rgba(10,13,22,0.72)` to `0.96` plus `backdrop-filter: blur(12px) saturate(140%)`; scrolled body text no longer ghosts through.
- **Attack-paths intro and capability-cap banner share one row.** New `.graph-header-row` flex container lays the intro paragraph on the left (capped at 820px) and the amber `Showing N of M …` banner on the right (filling remaining width). Stacks gracefully on narrow viewports via `flex-wrap`.

## Test plan

- [x] `make test` passes (covers the new `step-explainer` + `RBAC impersonation` markup assertions in `report_test.go`)
- [x] `make lint` passes
- [x] Render `testdata/snapshots/minimal-risky.json` and visually confirm:
  - [x] Single-hop chain card shows technique title + explainer + no `Step N` prefix
  - [x] Multi-hop chain card shows `Step N of M` per hop
  - [x] "How an attacker abuses this" reads as prose, not key-value soup
  - [x] Scrolling: no body text bleeds through the sticky header
  - [x] Attack-paths tab: intro + amber banner share one row when truncation is engaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)