### PR TITLE
Combine attacker walkthrough sections; surface glossary copy in findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,20 @@ Every analyzer emits `models.Finding` with a stable `RuleID` (`KUBE-<MODULE>-<NU
 
 `Finding.ID` is the deterministic per-instance key (`RULE:ns:name`); `RuleID` is shared across instances of the same rule. Exclusions never delete findings — they set `Excluded=true` + `ExclusionReason` so the report can still display them.
 
+### Report-layer educational content (`internal/report/glossary.go`)
+
+Three maps carry presentation-only copy that deliberately does **not** live on `models.Finding`, so JSON/CSV/SARIF outputs stay clean and copy can iterate without re-running scans:
+
+- `Glossary[Kind]` — definitions of subject/resource Kinds (`ServiceAccount`, `Pod`, `Secret`, `Deployment`, ...) with `Title` / `Short` / `Long` / `DocURL`.
+- `Techniques[ActionSlug]` — attacker-technique explainers keyed by chain-hop `Action` (`impersonate`, `read_secrets`, `pod_host_escape`, ...) with `Title` / `Plain` / `Mitre` / `AttackerSteps`.
+- `Categories[CategoryName]` — impact-lane copy for the Attack Graph (`privilege_escalation`, `lateral_movement`, ...).
+
+`GlossaryKeyForSubject` / `GlossaryKeyForResource` / `TechniqueKeyForFinding` (all in `glossary.go`) resolve a `Finding` to keys. Both the interactive Attack Graph (`attack_graph.go` → `GraphPayload`) and the static Findings tab (`education_render.go` → `findingEducationHTML`) consume them.
+
+The static **"How an attacker abuses this"** section is one combined `.scenario` wrapper that holds, in order: a `Background` block of glossary cards (Subject / Resource / Technique definitions), the `AttackScenario` narrative (`<ol class="attack-narrative">`), and the `EscalationPath` chain cards (`<ol class="attack-chain">`). The Background block suppresses its Technique entry when the chain renders technique copy per-hop, to avoid duplication. There is no separate "Observed attack chain" section anymore.
+
+When you add a rule that targets a new resource/subject Kind, or a new privesc Action slug, also add the corresponding `Glossary` / `Techniques` entry — otherwise the Background block silently drops that aspect.
+
 ## Conventions worth preserving
 
 - Package doc comments at the top of each `package foo` file describe the package's role; new files should follow the same pattern.

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -408,10 +408,32 @@
     .finding .impact .k { color: #ff9a3c; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; padding-top: 2px; }
     .finding .impact .v { color: var(--text); }
     .finding .scenario { margin: 10px 0; padding: 12px 14px; background: rgba(255,154,60,0.04); border: 1px solid rgba(255,154,60,0.18); border-radius: 10px; }
-    .finding .scenario .k { color: #ff9a3c; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
-    .finding .scenario ol { margin: 0; padding-left: 20px; color: var(--text); font-size: 13px; line-height: 1.6; }
-    .finding .scenario ol li { margin-bottom: 4px; }
-    .finding .scenario ol li:last-child { margin-bottom: 0; }
+    .finding .scenario > .k { color: #ff9a3c; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
+    .finding .scenario ol.attack-narrative { margin: 0; padding-left: 20px; color: var(--text); font-size: 13px; line-height: 1.6; }
+    .finding .scenario ol.attack-narrative li { margin-bottom: 4px; }
+    .finding .scenario ol.attack-narrative li:last-child { margin-bottom: 0; }
+    .finding .scenario .attack-chain-wrap { margin-top: 12px; }
+
+    /* Background (glossary/technique educational copy) — surfaces the same definitions
+       the interactive Attack Graph carries, so a reader does not have to leave the
+       Findings tab to learn what a ServiceAccount is or what the impersonate verb does. */
+    .finding .education { margin-bottom: 12px; padding: 10px 12px; background: rgba(106,183,255,0.05); border: 1px solid rgba(106,183,255,0.18); border-radius: 8px; }
+    .finding .education .edu-k { color: var(--accent); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
+    .finding .education .edu-cards { display: grid; gap: 8px; }
+    .finding .education .edu-card { padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); }
+    .finding .education .edu-hd { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; margin-bottom: 4px; }
+    .finding .education .edu-label { font-size: 10.5px; color: var(--text-dim); font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; padding: 1px 6px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.03); }
+    .finding .education .edu-title { color: var(--text); font-weight: 600; font-size: 13px; }
+    .finding .education .edu-body { color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
+    .finding .education .edu-body p { margin: 0 0 6px; }
+    .finding .education .edu-body p:last-child { margin-bottom: 0; }
+    .finding .education .edu-body code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
+    .finding .education .edu-body strong { color: var(--text); font-weight: 600; }
+    .finding .education .edu-body em { color: var(--text); font-style: italic; }
+    .finding .education .edu-body ul { margin: 4px 0 6px; padding-left: 18px; }
+    .finding .education .edu-body ul li { margin-bottom: 3px; }
+    .finding .education .edu-doc { display: inline-block; margin-top: 6px; font-size: 11.5px; color: var(--accent); text-decoration: none; }
+    .finding .education .edu-doc:hover { text-decoration: underline; }
     .finding .rem { padding: 12px 14px; background: rgba(106,183,255,0.05); border: 1px solid rgba(106,183,255,0.18); border-radius: 10px; font-size: 13.5px; line-height: 1.55; }
     .finding .rem .k { color: var(--accent); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
     .finding .rem .summary { color: var(--text); margin-bottom: 8px; }
@@ -437,26 +459,24 @@
     .finding details[open] summary { color: var(--accent); border-color: var(--border-strong); border-style: solid; }
     .finding details pre { margin-top: 10px; }
 
-    /* Observed attack chain (privesc EscalationPath) */
-    .finding .chain { margin-top: 12px; padding: 12px 14px; background: rgba(255,90,90,0.06); border: 1px solid rgba(255,90,90,0.22); border-radius: 10px; }
-    .finding .chain .k { color: var(--critical, #ff5a5a); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 8px; display: block; }
-    .finding .chain ol.attack-chain { list-style: none; padding-left: 0; margin: 0; display: grid; gap: 10px; counter-reset: step; }
-    .finding .chain ol.attack-chain li.attack-step { padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: rgba(255,255,255,0.02); font-size: 13px; line-height: 1.5; color: var(--text); }
-    .finding .chain .step-hd { display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px; flex-wrap: wrap; }
-    .finding .chain .step-num { font-weight: 700; color: var(--accent); font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
-    .finding .chain .step-title { color: var(--text); font-weight: 600; font-size: 13px; }
-    .finding .chain .step-action { background: rgba(255,255,255,0.06); padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text-mut); }
-    .finding .chain .step-explainer { margin: 4px 0 8px; color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
-    .finding .chain .step-explainer p { margin: 0 0 6px; }
-    .finding .chain .step-explainer p:last-child { margin-bottom: 0; }
-    .finding .chain .step-explainer code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
-    .finding .chain .step-explainer strong { color: var(--text); font-weight: 600; }
-    .finding .chain .step-explainer em { color: var(--text); font-style: italic; }
-    .finding .chain .step-edge { color: var(--text-mut); margin-bottom: 4px; font-size: 13px; }
-    .finding .chain .step-edge code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text); }
-    .finding .chain .step-meta { font-size: 12.5px; color: var(--text-mut); margin-top: 2px; }
-    .finding .chain .step-meta .k { display: inline; color: var(--text-dim); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 6px; }
-    .finding .chain .step-meta code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    /* Structured attack-chain cards (privesc EscalationPath), nested inside .scenario */
+    .finding .scenario ol.attack-chain { list-style: none; padding-left: 0; margin: 0; display: grid; gap: 10px; counter-reset: step; }
+    .finding .scenario ol.attack-chain li.attack-step { padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: rgba(255,255,255,0.02); font-size: 13px; line-height: 1.5; color: var(--text); }
+    .finding .scenario .step-hd { display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px; flex-wrap: wrap; }
+    .finding .scenario .step-num { font-weight: 700; color: var(--accent); font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+    .finding .scenario .step-title { color: var(--text); font-weight: 600; font-size: 13px; }
+    .finding .scenario .step-action { background: rgba(255,255,255,0.06); padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text-mut); }
+    .finding .scenario .step-explainer { margin: 4px 0 8px; color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
+    .finding .scenario .step-explainer p { margin: 0 0 6px; }
+    .finding .scenario .step-explainer p:last-child { margin-bottom: 0; }
+    .finding .scenario .step-explainer code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
+    .finding .scenario .step-explainer strong { color: var(--text); font-weight: 600; }
+    .finding .scenario .step-explainer em { color: var(--text); font-style: italic; }
+    .finding .scenario .step-edge { color: var(--text-mut); margin-bottom: 4px; font-size: 13px; }
+    .finding .scenario .step-edge code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text); }
+    .finding .scenario .step-meta { font-size: 12.5px; color: var(--text-mut); margin-top: 2px; }
+    .finding .scenario .step-meta .k { display: inline; color: var(--text-dim); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 6px; }
+    .finding .scenario .step-meta code { background: rgba(255,255,255,0.06); padding: 1px 6px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; }
 
     /* Humanized Evidence section */
     .finding .evidence { margin-top: 12px; padding: 10px 12px; background: rgba(255,255,255,0.02); border: 1px solid var(--border); border-radius: 10px; }
@@ -862,18 +882,21 @@
             <span class="v">{{ inlineHTML .Impact }}</span>
           </div>
           {{ end }}
-          {{ if .AttackScenario }}
+          {{ $edu := findingEducationHTML . }}
+          {{ if or .AttackScenario .EscalationPath $edu }}
           <div class="scenario">
             <span class="k">How an attacker abuses this</span>
-            <ol>
+            {{ if $edu }}{{ $edu }}{{ end }}
+            {{ if .AttackScenario }}
+            <ol class="attack-narrative">
               {{ range .AttackScenario }}<li>{{ inlineHTML . }}</li>{{ end }}
             </ol>
-          </div>
-          {{ end }}
-          {{ if .EscalationPath }}
-          <div class="chain">
-            <span class="k">Observed attack chain</span>
-            {{ escalationPathHTML .EscalationPath }}
+            {{ end }}
+            {{ if .EscalationPath }}
+            <div class="attack-chain-wrap">
+              {{ escalationPathHTML .EscalationPath }}
+            </div>
+            {{ end }}
           </div>
           {{ end }}
           {{ if or .Remediation .RemediationSteps }}

--- a/internal/report/education_render.go
+++ b/internal/report/education_render.go
@@ -1,0 +1,88 @@
+// Package report — combined educational block for the static Findings tab.
+// renderFindingEducation pulls relevant Glossary entries (subject kind, resource kind)
+// and the Techniques entry for the finding, then renders them as a "Background" block
+// inside the "How an attacker abuses this" section. This brings the same explanatory
+// copy that drives the interactive Attack Graph side-panel into every finding card,
+// so a reader does not need to click into the graph to learn what a ServiceAccount is
+// or what the impersonate verb does.
+//
+// All HTML is constructed from in-process Glossary/Techniques values whose Long/Plain
+// fields are already template.HTML. Subject/resource keys come from analyzer-supplied
+// SubjectRef/ResourceRef but are routed through HTMLEscapeString before composing.
+package report
+
+import (
+	"html/template"
+	"strings"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+// renderFindingEducation returns a "Background" HTML block listing the relevant
+// glossary/technique definitions for f. Returns "" when nothing applies — the
+// template gates the wrapper on this.
+//
+// Dedupe rule: when the finding has an EscalationPath, the per-hop chain cards
+// already render Techniques[hop.Action].Plain for each step; in that case we
+// suppress the technique entry here to avoid duplicating it. Non-chain findings
+// still get the technique entry up top so RBAC/podsec/admission/etc. findings
+// pick up the same educational copy a privesc finding has always had.
+func renderFindingEducation(f models.Finding) template.HTML {
+	var blocks []string
+
+	// Subject (ServiceAccount, User, Group, system:masters).
+	if key := GlossaryKeyForSubject(f.Subject); key != "" {
+		if entry, ok := Glossary[key]; ok {
+			blocks = append(blocks, educationCard(entry.Title, "Subject", entry.Long, entry.DocURL))
+		}
+	}
+
+	// Resource (Pod, Secret, ConfigMap, Role, ClusterRoleBinding, ...).
+	if key := GlossaryKeyForResource(f.Resource); key != "" {
+		if entry, ok := Glossary[key]; ok {
+			blocks = append(blocks, educationCard(entry.Title, "Resource", entry.Long, entry.DocURL))
+		}
+	}
+
+	// Technique — only when the chain section won't already explain it per-hop.
+	if len(f.EscalationPath) == 0 {
+		if key := TechniqueKeyForFinding(f); key != "" {
+			if entry, ok := Techniques[key]; ok {
+				blocks = append(blocks, educationCard(entry.Title, "Technique", entry.Plain, ""))
+			}
+		}
+	}
+
+	if len(blocks) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(`<div class="education"><span class="edu-k">Background</span><div class="edu-cards">`)
+	for _, blk := range blocks {
+		b.WriteString(blk)
+	}
+	b.WriteString(`</div></div>`)
+	return template.HTML(b.String())
+}
+
+// educationCard renders one definition: a label badge, a title, the body HTML, and
+// an optional Kubernetes-docs link. Title and label are HTML-escaped; body is already
+// trusted template.HTML from the in-process Glossary/Techniques maps.
+func educationCard(title, label string, body template.HTML, docURL string) string {
+	var b strings.Builder
+	b.WriteString(`<div class="edu-card"><div class="edu-hd"><span class="edu-label">`)
+	b.WriteString(template.HTMLEscapeString(label))
+	b.WriteString(`</span><span class="edu-title">`)
+	b.WriteString(template.HTMLEscapeString(title))
+	b.WriteString(`</span></div><div class="edu-body">`)
+	b.WriteString(string(body))
+	b.WriteString(`</div>`)
+	if docURL != "" {
+		b.WriteString(`<a class="edu-doc" href="`)
+		b.WriteString(template.HTMLEscapeString(docURL))
+		b.WriteString(`" target="_blank" rel="noopener noreferrer">Kubernetes docs ↗</a>`)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}

--- a/internal/report/writers.go
+++ b/internal/report/writers.go
@@ -228,6 +228,12 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding)
 		"escalationPathHTML": func(hops []models.EscalationHop) template.HTML {
 			return renderEscalationPath(hops)
 		},
+		// findingEducationHTML returns a "Background" block of glossary/technique
+		// definitions tailored to the finding (subject kind, resource kind, technique).
+		// Returns "" when no entries apply, gating the wrapper.
+		"findingEducationHTML": func(f models.Finding) template.HTML {
+			return renderFindingEducation(f)
+		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular


### PR DESCRIPTION
## Summary

- Merge the per-finding **"How an attacker abuses this"** and **"Observed attack chain"** sections into one wrapper. They described the same chain in two visual styles, so privesc findings showed the middle hops twice. The merged section keeps both — narrative gives bookend context (initial compromise + final outcome), cards give per-hop technique detail — under a single heading.
- Add a **Background** sub-block that pulls the educational copy previously only available in the interactive Attack Graph side-panel: subject Kind definition (`ServiceAccount`, `User`, `Group`), resource Kind definition (`Pod`, `Secret`, `ConfigMap`, ...), and the attacker-technique explainer. Each card has a label badge, title, body, and optional Kubernetes-docs link. The Technique entry is suppressed on chain findings to avoid duplicating copy the chain cards already render per-hop.
- New `findingEducationHTML` template func backed by `renderFindingEducation` in `internal/report/education_render.go`. Reuses the existing `GlossaryKeyForSubject` / `GlossaryKeyForResource` / `TechniqueKeyForFinding` resolvers in `glossary.go`. Educational copy stays in the presentation layer — not added to `models.Finding`, so JSON / CSV / SARIF outputs are byte-identical.
- CLAUDE.md gains a "Report-layer educational content" subsection so a future contributor knows that adding a rule which targets a new Kind or privesc Action also needs the corresponding Glossary / Techniques entry, or the Background block silently drops that aspect.

## Test plan

- [x] `make test` and `make lint` pass.
- [x] Generated a report against `testdata/snapshots/minimal-risky.json`: 15 of 20 findings carry a Background block. The 5 without target `NetworkPolicy` / `MutatingWebhookConfiguration` kinds, which aren't in the glossary yet — copy-only follow-up, not a regression.
- [x] Verified the privesc-path finding (`KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS`) shows Subject definition + narrative `<ol>` + chain cards under one heading, with **no duplicated technique copy** between Background and chain cards.
- [x] Confirmed non-privesc findings (e.g. `KUBE-RBAC-OVERBROAD`, `KUBE-PRIVESC-001/005`, `KUBE-ESCAPE-*`) now surface their technique explainer in the Background block — previously only chain-emitting findings carried any technique copy at all.
- [x] Visual eyeball in a browser before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)