### PR TITLE
Add categorized Findings index TOC with By module / By category views

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -373,6 +373,31 @@
     .module-link:hover { background: var(--surface-hover); border-color: var(--border-strong); }
     .module-link .mn-count { font-size: 11px; color: var(--text-mut); background: rgba(255,255,255,0.03); padding: 1px 7px; border-radius: 999px; font-variant-numeric: tabular-nums; }
 
+    .findings-toc { margin-top: 14px; padding: 14px 16px 4px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); }
+    .findings-toc .toc-hd { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .findings-toc .toc-title { color: var(--text-mut); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em; }
+    .toc-tabs { display: inline-flex; gap: 4px; padding: 3px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.02); }
+    .toc-tabs button { font: inherit; font-size: 12px; font-weight: 600; color: var(--text-mut); background: transparent; border: 0; padding: 6px 14px; border-radius: 999px; cursor: pointer; transition: color 0.15s ease, background 0.15s ease; }
+    .toc-tabs button:hover { color: var(--text); }
+    .toc-tabs button[aria-selected="true"] { color: var(--accent); background: rgba(106,183,255,0.14); }
+    .toc-pane[hidden] { display: none; }
+    .toc-group { border-top: 1px solid var(--border-soft); padding: 10px 0; }
+    .toc-group:first-child { border-top: 0; padding-top: 4px; }
+    .toc-group > summary { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; cursor: pointer; padding: 6px 4px; list-style: none; user-select: none; }
+    .toc-group > summary::-webkit-details-marker { display: none; }
+    .toc-group > summary::before { content: ""; width: 8px; height: 8px; border-right: 2px solid var(--text-mut); border-bottom: 2px solid var(--text-mut); transform: rotate(-45deg); transition: transform 0.15s ease; flex: 0 0 auto; align-self: center; }
+    .toc-group[open] > summary::before { transform: rotate(45deg); }
+    .toc-group > summary:hover .toc-group-label { color: var(--text); }
+    .toc-group-label { font-size: 14px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
+    .toc-group-meta { color: var(--text-mut); font-size: 12px; font-variant-numeric: tabular-nums; }
+    .toc-rows { list-style: none; margin: 6px 0 4px; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 4px 12px; }
+    .toc-row a { display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--text); padding: 6px 10px; border-radius: 8px; font-size: 13px; line-height: 1.35; transition: background 0.12s ease; }
+    .toc-row a:hover { background: rgba(255,255,255,0.04); }
+    .toc-row .badge-sev { flex: 0 0 auto; }
+    .toc-row-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .toc-row-count { flex: 0 0 auto; font-size: 11px; color: var(--text-mut); background: rgba(255,255,255,0.04); padding: 1px 7px; border-radius: 999px; font-variant-numeric: tabular-nums; }
+    @media (max-width: 720px) { .toc-rows { grid-template-columns: 1fr; } }
+
     .module-section { margin-top: 28px; }
     .module-section .module-hd { display: flex; align-items: baseline; gap: 14px; margin-bottom: 12px; flex-wrap: wrap; padding-bottom: 12px; border-bottom: 1px solid var(--border-soft); }
     .module-hd h2 { font-size: 22px; letter-spacing: -0.02em; }
@@ -847,6 +872,46 @@
       {{ range .Modules }}<a class="module-link" href="#{{ .ID }}">{{ .Label }} <span class="mn-count">{{ .Summary.Total }}</span></a>{{ end }}
     </nav>
 
+    <section class="findings-toc" data-tab="findings" aria-label="Findings index">
+      <div class="toc-hd">
+        <span class="toc-title">Findings index</span>
+        <div class="toc-tabs" role="tablist" aria-label="Group findings by">
+          <button type="button" role="tab" aria-selected="true"  aria-controls="toc-by-module"   data-toc-tab="module">By module</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="toc-by-category" data-toc-tab="category">By category</button>
+        </div>
+      </div>
+      <div id="toc-by-module" class="toc-pane" role="tabpanel">
+        {{ range .Modules }}
+        <details class="toc-group">
+          <summary>
+            <span class="toc-group-label">{{ .Label }}</span>
+            <span class="toc-group-meta">{{ .Summary.Total }} {{ pluralize .Summary.Total "finding" "findings" }} · {{ len .Entries }} {{ pluralize (len .Entries) "rule" "rules" }}</span>
+          </summary>
+          <ul class="toc-rows">
+            {{ range .Entries }}
+            <li class="toc-row {{ sevClass .Severity }}"><a href="#{{ .Anchor }}"><span class="badge-sev {{ sevClass .Severity }}">{{ sevShort .Severity }}</span><span class="toc-row-title">{{ inlineHTML .Title }}</span>{{ if gt .Count 1 }}<span class="toc-row-count">×{{ .Count }}</span>{{ end }}</a></li>
+            {{ end }}
+          </ul>
+        </details>
+        {{ end }}
+      </div>
+      <div id="toc-by-category" class="toc-pane" role="tabpanel" hidden>
+        {{ range .Categories }}
+        <details class="toc-group">
+          <summary>
+            <span class="toc-group-label">{{ .Label }}</span>
+            <span class="toc-group-meta">{{ .Summary.Total }} {{ pluralize .Summary.Total "finding" "findings" }} · {{ len .Entries }} {{ pluralize (len .Entries) "rule" "rules" }}</span>
+          </summary>
+          <ul class="toc-rows">
+            {{ range .Entries }}
+            <li class="toc-row {{ sevClass .Severity }}"><a href="#{{ .Anchor }}"><span class="badge-sev {{ sevClass .Severity }}">{{ sevShort .Severity }}</span><span class="toc-row-title">{{ inlineHTML .Title }}</span>{{ if gt .Count 1 }}<span class="toc-row-count">×{{ .Count }}</span>{{ end }}</a></li>
+            {{ end }}
+          </ul>
+        </details>
+        {{ end }}
+      </div>
+    </section>
+
     {{ range .Modules }}
     <section class="module-section" data-tab="findings" data-module="{{ .ID }}" id="{{ .ID }}">
       <div class="module-hd">
@@ -951,6 +1016,22 @@
 
     <p class="footer">Kubesplaining · {{ if .Snapshot.Metadata.KubesplainingVersion }}{{ .Snapshot.Metadata.KubesplainingVersion }} · {{ end }}{{ .Summary.Total }} findings · {{ len .Modules }} modules</p>
   </main>
+  <script>
+    (function () {
+      var tabs = document.querySelectorAll('.findings-toc .toc-tabs [role="tab"]');
+      if (!tabs.length) return;
+      tabs.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          tabs.forEach(function (t) {
+            var on = t === btn;
+            t.setAttribute('aria-selected', on ? 'true' : 'false');
+            var panel = document.getElementById(t.getAttribute('aria-controls'));
+            if (panel) panel.hidden = !on;
+          });
+        });
+      });
+    })();
+  </script>
   <script>{{ .GraphScript }}</script>
 </body>
 </html>

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -130,6 +130,106 @@ func TestBuildHTMLDataGroupsFindings(t *testing.T) {
 	}
 }
 
+func TestBuildHTMLDataTOCEntries(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.NewSnapshot()
+	findings := []models.Finding{
+		// Two findings sharing one RuleID — the TOC must collapse them into one
+		// entry with Count=2 and pick the higher severity (Critical here).
+		{
+			ID:       "f1",
+			RuleID:   "KUBE-RBAC-1",
+			Severity: models.SeverityCritical,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "Wildcard verb on wildcard resource",
+			Tags:     []string{"module:rbac"},
+		},
+		{
+			ID:       "f2",
+			RuleID:   "KUBE-RBAC-1",
+			Severity: models.SeverityHigh,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "Wildcard verb on wildcard resource",
+			Tags:     []string{"module:rbac"},
+		},
+		// A second rule in the same module — lower severity so it sorts after the
+		// collapsed entry above.
+		{
+			ID:       "f3",
+			RuleID:   "KUBE-RBAC-2",
+			Severity: models.SeverityHigh,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "Bind/escalate verb granted",
+			Tags:     []string{"module:rbac"},
+		},
+		// Different module + category — exercises the by-category bucketing.
+		{
+			ID:       "f4",
+			RuleID:   "KUBE-NETPOL-1",
+			Severity: models.SeverityMedium,
+			Category: models.CategoryLateralMovement,
+			Title:    "Open network",
+			Tags:     []string{"module:network_policy"},
+		},
+	}
+
+	data := BuildHTMLData(snapshot, findings)
+
+	// Locate the RBAC module section deterministically (order varies with severity sort).
+	var rbac *ModuleSection
+	for i := range data.Modules {
+		if data.Modules[i].ID == "rbac" {
+			rbac = &data.Modules[i]
+			break
+		}
+	}
+	if rbac == nil {
+		t.Fatalf("expected an RBAC module section, got modules: %#v", data.Modules)
+	}
+
+	if got := len(rbac.Entries); got != 2 {
+		t.Fatalf("RBAC TOC: expected 2 entries (one per RuleID), got %d: %#v", got, rbac.Entries)
+	}
+	first := rbac.Entries[0]
+	if first.RuleID != "KUBE-RBAC-1" {
+		t.Fatalf("RBAC TOC[0]: expected RuleID KUBE-RBAC-1 (highest severity), got %s", first.RuleID)
+	}
+	if first.Severity != models.SeverityCritical {
+		t.Fatalf("RBAC TOC[0]: expected severity to be raised to Critical, got %s", first.Severity)
+	}
+	if first.Count != 2 {
+		t.Fatalf("RBAC TOC[0]: expected Count=2 (collapsed instances), got %d", first.Count)
+	}
+	if first.Anchor != "finding-KUBE-RBAC-1" {
+		t.Fatalf("RBAC TOC[0]: expected Anchor=finding-KUBE-RBAC-1, got %q", first.Anchor)
+	}
+	if rbac.Entries[1].RuleID != "KUBE-RBAC-2" {
+		t.Fatalf("RBAC TOC[1]: expected RuleID KUBE-RBAC-2, got %s", rbac.Entries[1].RuleID)
+	}
+	if rbac.Entries[1].Count != 1 {
+		t.Fatalf("RBAC TOC[1]: expected Count=1, got %d", rbac.Entries[1].Count)
+	}
+
+	// By-category view — Privilege Escalation should hold both KUBE-RBAC-* rules.
+	var privesc *CategorySection
+	for i := range data.Categories {
+		if data.Categories[i].CSSKey == "privesc" {
+			privesc = &data.Categories[i]
+			break
+		}
+	}
+	if privesc == nil {
+		t.Fatalf("expected a Privilege Escalation category section, got: %#v", data.Categories)
+	}
+	if got := len(privesc.Entries); got != 2 {
+		t.Fatalf("Privesc category TOC: expected 2 entries, got %d: %#v", got, privesc.Entries)
+	}
+	if privesc.Entries[0].RuleID != "KUBE-RBAC-1" || privesc.Entries[0].Anchor != "finding-KUBE-RBAC-1" {
+		t.Fatalf("Privesc category TOC[0]: unexpected entry %#v", privesc.Entries[0])
+	}
+}
+
 func TestRenderInlineCodeMarkdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -114,6 +114,16 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 		}
 	}
 
+	// Build the per-group TOC rows after AnchorByID is populated so each TOC row can
+	// link to the rule's representative anchor. We attach Entries directly onto the
+	// section structs the template already iterates.
+	for i := range modules {
+		modules[i].Entries = buildTOCEntries(modules[i].Findings, anchorByID)
+	}
+	for i := range categories {
+		categories[i].Entries = buildTOCEntries(categoryMap[models.RiskCategory(categories[i].Key)], anchorByID)
+	}
+
 	data := htmlReportData{
 		Snapshot:      snapshot,
 		Summary:       summary,
@@ -407,4 +417,67 @@ func heatLevel(n int) int {
 	default:
 		return 5
 	}
+}
+
+// buildTOCEntries collapses a slice of findings into one TOCEntry per RuleID, keeping the
+// highest severity seen and counting instances. Sort order: severity rank desc → count desc
+// → title asc — matches how the rest of the report orders findings, so the TOC reads top-down
+// by importance. Anchor comes from anchorByID, which is keyed on Finding.ID and only set on
+// the first occurrence of each rule across all modules; we look up via the first finding we
+// see for each RuleID in this group, falling back to "finding-<RuleID>" so the link still
+// works even if the lookup misses (defensive — should not happen in practice).
+func buildTOCEntries(findings []models.Finding, anchorByID map[string]string) []TOCEntry {
+	if len(findings) == 0 {
+		return nil
+	}
+	type acc struct {
+		title    string
+		severity models.Severity
+		anchor   string
+		count    int
+		order    int // first-seen order, used as a stable tiebreaker
+	}
+	byRule := make(map[string]*acc, len(findings))
+	order := 0
+	for _, f := range findings {
+		entry, ok := byRule[f.RuleID]
+		if !ok {
+			entry = &acc{title: f.Title, severity: f.Severity, order: order}
+			if a, found := anchorByID[f.ID]; found {
+				entry.anchor = a
+			} else {
+				entry.anchor = "finding-" + f.RuleID
+			}
+			byRule[f.RuleID] = entry
+			order++
+		} else if f.Severity.Rank() > entry.severity.Rank() {
+			entry.severity = f.Severity
+		}
+		entry.count++
+	}
+	entries := make([]TOCEntry, 0, len(byRule))
+	for ruleID, e := range byRule {
+		entries = append(entries, TOCEntry{
+			RuleID:   ruleID,
+			Title:    e.title,
+			Severity: e.severity,
+			Anchor:   e.anchor,
+			Count:    e.count,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		ri := entries[i].Severity.Rank()
+		rj := entries[j].Severity.Rank()
+		if ri != rj {
+			return ri > rj
+		}
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		if entries[i].Title != entries[j].Title {
+			return entries[i].Title < entries[j].Title
+		}
+		return entries[i].RuleID < entries[j].RuleID
+	})
+	return entries
 }

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -30,6 +30,7 @@ type ModuleSection struct {
 	Label    string
 	Summary  Summary
 	Findings []models.Finding
+	Entries  []TOCEntry // collapsed one-row-per-RuleID list for the Findings-tab TOC
 }
 
 // CategorySection groups findings by RiskCategory for the "By Attack Theme" panel; it does not carry the findings themselves.
@@ -39,6 +40,19 @@ type CategorySection struct {
 	CSSKey  string
 	Label   string
 	Summary Summary
+	Entries []TOCEntry // collapsed one-row-per-RuleID list for the Findings-tab TOC
+}
+
+// TOCEntry is one row in the Findings-tab table-of-contents — a single rule, the highest
+// severity it fired at within its group, and the number of finding instances it produced.
+// Anchor points at the deterministic per-rule anchor (id="finding-<RuleID>") that the
+// first occurrence of each rule already carries on its <article> card.
+type TOCEntry struct {
+	RuleID   string
+	Title    string
+	Severity models.Severity
+	Anchor   string
+	Count    int
 }
 
 // NarrativeCard is an auto-detected attack chain — a short plain-English walkthrough of how specific


### PR DESCRIPTION
## Summary

- Adds a collapsible **Findings index** card on top of the Findings tab — one row per unique RuleID with severity badge, title, and `×N` instance count, deep-linking to the existing `id="finding-<RuleID>"` anchors.
- Two togglable grouping views: **By module** (Privesc, RBAC, Pod Security, …) and **By category** (Privilege Escalation, Lateral Movement, …) — same set of rules re-bucketed.
- All groups collapsed by default to keep large reports scannable; each `<details>` group toggles independently.
- TOC entries are populated server-side on `ModuleSection`/`CategorySection` via a new `buildTOCEntries` helper that collapses by RuleID, raises severity to the highest seen, and sorts by severity → count → title.

Reuses the existing `AnchorByID` mapping (`internal/report/summary.go`) so deep links stay in lockstep with rendered cards. No new rule IDs, no analyzer or schema changes — purely a report-rendering improvement.

## Test plan

- [x] `make build`
- [x] `make lint`
- [x] `make test` — including new `TestBuildHTMLDataTOCEntries` covering count collapse, severity raise, sort order, and anchor wiring
- [x] `make e2e` against a kind cluster (121 findings → 88 with standard preset; all 44 expected rule IDs present)
- [x] Visual check: open the rendered `report.html`, confirm both panes render, toggle works, and clicking a TOC row scrolls to the matching finding card

🤖 Generated with [Claude Code](https://claude.com/claude-code)