### PR TITLE
Group identical findings into rule cards on the Findings tab

### DIFF
--- a/internal/report/assets/graph.js
+++ b/internal/report/assets/graph.js
@@ -42,10 +42,19 @@
   }
 
   function applyFindingsFilter() {
-    var articles = document.querySelectorAll('article.finding');
+    // Findings are now rendered as per-subject .finding instances inside .rule-group cards.
+    // Filter at instance granularity, then roll the visibility up to rule groups and module
+    // sections so empty containers collapse cleanly.
+    var instances = document.querySelectorAll('.finding[data-rule]');
+    // When any filter narrows the result set, auto-open matching <details> instances so
+    // the user lands on relevant evidence without an extra click.
+    var anyFilter = false;
+    for (var fk = 0; fk < FILTER_KEYS.length; fk++) {
+      if (filterState[FILTER_KEYS[fk]] != null) { anyFilter = true; break; }
+    }
     var n = 0;
-    for (var i = 0; i < articles.length; i++) {
-      var a = articles[i];
+    for (var i = 0; i < instances.length; i++) {
+      var a = instances[i];
       var keep = true;
       for (var k = 0; k < FILTER_KEYS.length; k++) {
         var key = FILTER_KEYS[k];
@@ -59,13 +68,22 @@
         if (got !== want) { keep = false; break; }
       }
       a.style.display = keep ? '' : 'none';
-      if (keep) n++;
+      if (keep) {
+        n++;
+        if (anyFilter && a.tagName === 'DETAILS') a.open = true;
+      }
     }
-    // Hide module sections whose findings are all filtered out.
+    // Hide rule-group cards whose instances are all filtered out.
+    var groups = document.querySelectorAll('.rule-group');
+    for (var g = 0; g < groups.length; g++) {
+      var visibleInGroup = groups[g].querySelectorAll('.finding[data-rule]:not([style*="display: none"])').length;
+      groups[g].style.display = visibleInGroup ? '' : 'none';
+    }
+    // Hide module sections whose rule-groups are all filtered out.
     var sections = document.querySelectorAll('section.module-section');
     for (var s = 0; s < sections.length; s++) {
-      var visible = sections[s].querySelectorAll('article.finding:not([style*="display: none"])').length;
-      sections[s].style.display = visible ? '' : 'none';
+      var visibleSec = sections[s].querySelectorAll('.rule-group:not([style*="display: none"])').length;
+      sections[s].style.display = visibleSec ? '' : 'none';
     }
     renderFilterChips();
   }

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -282,7 +282,7 @@
     a.chip-link:hover { filter: brightness(1.18); border-bottom: 1px solid currentColor; }
     a.chip-link:active { transform: translateY(1px); }
     @keyframes findingFlash { 0% { box-shadow: 0 0 0 0 rgba(106,183,255,0.55); } 60% { box-shadow: 0 0 0 8px rgba(106,183,255,0.15); } 100% { box-shadow: 0 0 0 0 rgba(106,183,255,0); } }
-    .finding.finding-flash { animation: findingFlash 1.5s ease-out; }
+    .finding.finding-flash, .rule-group.finding-flash { animation: findingFlash 1.5s ease-out; }
 
     .two-col { display: grid; grid-template-columns: 1.2fr 1fr; gap: 16px; }
     .dist-list { display: grid; gap: 12px; }
@@ -410,6 +410,52 @@
     .finding.high { border-left-color: var(--high); }
     .finding.med  { border-left-color: var(--medium); }
     .finding.low  { border-left-color: var(--low); }
+
+    /* Rule-group cards collapse all instances sharing a RuleID into one card so the
+       shared educational content (MITRE, References) renders once and per-subject
+       evidence/remediation sits behind a per-instance disclosure. The instances
+       inherit .finding styling above so existing per-finding selectors keep working. */
+    .rule-list { display: grid; gap: 16px; }
+    .rule-group { border: 1px solid var(--border); border-radius: 16px; padding: 18px 20px; background: var(--surface); border-left: 4px solid var(--border); }
+    .rule-group.crit { border-left-color: var(--critical); }
+    .rule-group.high { border-left-color: var(--high); }
+    .rule-group.med  { border-left-color: var(--medium); }
+    .rule-group.low  { border-left-color: var(--low); }
+    .rule-hd { display: flex; align-items: center; gap: 10px 14px; flex-wrap: wrap; }
+    .rule-hd .rule-title { flex: 1 1 320px; font-size: 16.5px; line-height: 1.35; letter-spacing: -0.01em; }
+    .rule-hd .rule-title code { background: rgba(255,255,255,0.04); padding: 1px 6px; border-radius: 4px; font-size: 12.5px; }
+    .rule-meta-pills { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-left: auto; }
+    .rule-group .rule { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); letter-spacing: 0.02em; }
+    .rule-group .score-lbl { font-size: 12px; color: var(--text-mut); }
+    .rule-group .score-lbl strong { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
+    .rule-instance-count { font-size: 11.5px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.02); }
+    .rule-shared { padding: 10px 0 4px; border-top: 1px solid var(--border-soft); margin-top: 12px; }
+    .rule-shared .mitre { margin: 4px 0; }
+    .rule-shared > details.refs { margin-top: 6px; }
+    .rule-instances { margin-top: 14px; }
+    .rule-instances-hd { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-mut); font-weight: 700; margin: 0 0 8px; }
+
+    /* A finding rendered as a per-instance disclosure inside a rule group: collapsed
+       by default for groups with 3+ instances, expanded for 1–2. The summary row
+       gives subject + scope + score; the full content (description, attacker
+       scenario, evidence, remediation) lives in .instance-body. */
+    .instance.finding { border-radius: 10px; padding: 0; border-left-width: 1px; background: rgba(255,255,255,0.012); margin-bottom: 6px; }
+    .instance.finding[open] { background: rgba(255,255,255,0.025); }
+    .instance.finding > .instance-hd { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 10px 14px; cursor: pointer; user-select: none; list-style: none; outline: none; }
+    .instance.finding > .instance-hd::-webkit-details-marker { display: none; }
+    .instance.finding > .instance-hd::before { content: "▸"; color: var(--text-dim); font-size: 11px; transition: transform 0.15s ease; flex: 0 0 auto; line-height: 1; }
+    .instance.finding[open] > .instance-hd::before { transform: rotate(90deg); }
+    .instance.finding > .instance-hd:hover { background: rgba(255,255,255,0.025); }
+    .instance.finding > .instance-hd:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; border-radius: 10px; }
+    .instance-title { flex: 1 1 240px; min-width: 0; font-size: 13.5px; color: var(--text); overflow: hidden; text-overflow: ellipsis; }
+    .instance-title code { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 12.5px; background: rgba(255,255,255,0.04); padding: 1px 6px; border-radius: 4px; color: var(--text); }
+    .instance-scope { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-mut); padding: 2px 7px; border: 1px solid var(--border-soft); border-radius: 999px; background: rgba(255,255,255,0.02); }
+    .instance-score { font-size: 12px; color: var(--text-mut); font-variant-numeric: tabular-nums; }
+    .instance-body { padding: 4px 16px 14px; border-top: 1px solid var(--border-soft); }
+    .instance-body .finding-hd-inner { margin: 8px 0 4px; }
+    .instance-body .finding-title-inner { font-size: 13.5px; font-weight: 600; color: var(--text); margin: 0; }
+    /* Reuse .finding child selectors for instance bodies — the existing CSS for
+       .finding .meta / .desc / .scenario / .evidence already targets descendants. */
     .finding-hd { display: flex; align-items: flex-start; gap: 14px; flex-wrap: wrap; }
     .finding-hd h3 { font-size: 16px; flex: 1 1 300px; }
     .finding .rule { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); letter-spacing: 0.02em; }
@@ -912,101 +958,126 @@
       </div>
     </section>
 
-    {{ range .Modules }}
+    {{ range $module := .Modules }}
     <section class="module-section" data-tab="findings" data-module="{{ .ID }}" id="{{ .ID }}">
       <div class="module-hd">
         <h2>{{ .Label }}</h2>
-        <span class="mh-count">{{ .Summary.Total }} {{ pluralize .Summary.Total "finding" "findings" }} · {{ .Summary.Critical }} critical · {{ .Summary.High }} high · {{ .Summary.Medium }} medium · {{ .Summary.Low }} low</span>
+        <span class="mh-count">{{ .Summary.Total }} {{ pluralize .Summary.Total "finding" "findings" }} · {{ len .RuleGroups }} {{ pluralize (len .RuleGroups) "rule" "rules" }} · {{ .Summary.Critical }} critical · {{ .Summary.High }} high · {{ .Summary.Medium }} medium · {{ .Summary.Low }} low</span>
       </div>
-      <div class="finding-list">
-        {{ range .Findings }}
-        {{ $anchor := index $.AnchorByID .ID }}
-        <article class="finding {{ sevClass .Severity }}"{{ if $anchor }} id="{{ $anchor }}"{{ end }} data-rule="{{ .RuleID }}" data-severity="{{ sevClass .Severity }}" data-category="{{ catKey .Category }}"{{ if .Scope.Level }} data-scope="{{ .Scope.Level }}"{{ end }}{{ if .Resource }} data-resource="{{ resource .Resource }}"{{ end }}>
-          <div class="finding-hd">
-            <h3>{{ inlineHTML .Title }}</h3>
-            <span class="badge-sev {{ sevClass .Severity }}">{{ sevShort .Severity }}</span>
-            <span class="rule">{{ .RuleID }}</span>
-            <span class="score-lbl">Score <strong>{{ score .Score }}</strong></span>
-          </div>
-          {{ if or .Scope.Level .Scope.Detail }}
-          <div class="scope-row">
-            {{ if .Scope.Level }}<span class="scope-chip {{ .Scope.Level }}" title="Blast-radius level">Scope · {{ scopeLabel .Scope.Level }}</span>{{ end }}
-            {{ if .Scope.Detail }}<span class="scope-detail">{{ scopeDetailHTML .Scope.Detail }}</span>{{ end }}
-          </div>
-          {{ end }}
-          <div class="meta">
-            <span><span class="k">Category:</span> {{ catLabel .Category }}</span>
-            {{ if .Subject }}<span><span class="k">Subject:</span> <code>{{ subject .Subject }}</code></span>{{ end }}
-            {{ if .Resource }}<span><span class="k">Resource:</span> <code>{{ resource .Resource }}</code></span>{{ end }}
-            {{ if and (not .Subject) .Namespace }}<span><span class="k">Namespace:</span> <code>{{ .Namespace }}</code></span>{{ end }}
-          </div>
-          <div class="desc">{{ descriptionHTML .Description }}</div>
-          {{ if .Impact }}
-          <div class="impact">
-            <span class="k">Impact</span>
-            <span class="v">{{ inlineHTML .Impact }}</span>
-          </div>
-          {{ end }}
-          {{ $edu := findingEducationHTML . }}
-          {{ if or .AttackScenario .EscalationPath $edu }}
-          <div class="scenario">
-            <span class="k">How an attacker abuses this</span>
-            {{ if $edu }}{{ $edu }}{{ end }}
-            {{ if .AttackScenario }}
-            <ol class="attack-narrative">
-              {{ range .AttackScenario }}<li>{{ inlineHTML . }}</li>{{ end }}
-            </ol>
-            {{ end }}
-            {{ if .EscalationPath }}
-            <div class="attack-chain-wrap">
-              {{ escalationPathHTML .EscalationPath }}
+      <div class="rule-list">
+        {{ range $module.RuleGroups }}
+        <article class="rule-group {{ sevClass .TopSeverity }}" id="{{ .Anchor }}" data-rule="{{ .RuleID }}" data-severity="{{ sevClass .TopSeverity }}">
+          <header class="rule-hd">
+            <span class="badge-sev {{ sevClass .TopSeverity }}">{{ sevShort .TopSeverity }}</span>
+            <h3 class="rule-title">{{ inlineHTML .RuleTitle }}</h3>
+            <span class="rule-meta-pills">
+              <span class="rule">{{ .RuleID }}</span>
+              <span class="rule-instance-count">{{ .InstanceCount }} {{ pluralize .InstanceCount "subject" "subjects" }}</span>
+              <span class="score-lbl">Score <strong>{{ score .MaxScore }}{{ if ne .MaxScore .MinScore }}–{{ score .MinScore }}{{ end }}</strong></span>
+            </span>
+          </header>
+          {{ if or .MitreTechniques .LearnMore .References }}
+          <div class="rule-shared">
+            {{ if .MitreTechniques }}
+            <div class="mitre">
+              <span class="k">MITRE ATT&amp;CK:</span>
+              {{ range .MitreTechniques }}<a href="{{ .URL }}" target="_blank" rel="noopener noreferrer" title="{{ .Name }}">{{ .ID }}</a>{{ end }}
             </div>
             {{ end }}
-          </div>
-          {{ end }}
-          {{ if or .Remediation .RemediationSteps }}
-          <div class="rem">
-            <span class="k">Remediation</span>
-            {{ if .Remediation }}<div class="summary">{{ inlineHTML .Remediation }}</div>{{ end }}
-            {{ if .RemediationSteps }}
-            <ol>
-              {{ range .RemediationSteps }}<li>{{ remediationStepHTML . }}</li>{{ end }}
-            </ol>
+            {{ if .LearnMore }}
+            <details class="refs">
+              <summary>References <span class="ref-count">{{ len .LearnMore }}</span></summary>
+              <ul>
+                {{ range .LearnMore }}<li><a href="{{ .URL }}" target="_blank" rel="noopener noreferrer">{{ .Title }}</a></li>{{ end }}
+              </ul>
+            </details>
+            {{ else if .References }}
+            <details class="refs">
+              <summary>References <span class="ref-count">{{ len .References }}</span></summary>
+              <ul>
+                {{ range .References }}<li><a href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ . }}</a></li>{{ end }}
+              </ul>
+            </details>
             {{ end }}
           </div>
           {{ end }}
-          {{ if .MitreTechniques }}
-          <div class="mitre">
-            <span class="k">MITRE ATT&amp;CK:</span>
-            {{ range .MitreTechniques }}<a href="{{ .URL }}" target="_blank" rel="noopener noreferrer" title="{{ .Name }}">{{ .ID }}</a>{{ end }}
-          </div>
-          {{ end }}
-          {{ $ev := evidenceHTML .Evidence }}
-          {{ if $ev }}
-          <div class="evidence">
-            <span class="k">Evidence</span>
-            {{ $ev }}
-            <details class="evidence-raw">
-              <summary>Show raw JSON</summary>
-              <pre><code>{{ json .Evidence }}</code></pre>
+          <div class="rule-instances">
+            <h4 class="rule-instances-hd">{{ if eq .InstanceCount 1 }}Affected subject{{ else }}Affected subjects ({{ .InstanceCount }}){{ end }}</h4>
+            {{ $group := . }}
+            {{ range $i, $f := .Findings }}
+            <details class="instance finding {{ sevClass $f.Severity }}"{{ if le $group.InstanceCount 2 }} open{{ end }} data-rule="{{ $f.RuleID }}" data-severity="{{ sevClass $f.Severity }}" data-category="{{ catKey $f.Category }}"{{ if $f.Scope.Level }} data-scope="{{ $f.Scope.Level }}"{{ end }}{{ if $f.Resource }} data-resource="{{ resource $f.Resource }}"{{ end }}{{ if $f.Subject }} data-subject="{{ subject $f.Subject }}"{{ end }}>
+              <summary class="instance-hd">
+                <span class="badge-sev {{ sevClass $f.Severity }}">{{ sevShort $f.Severity }}</span>
+                <span class="instance-title">{{ if $f.Subject }}<code>{{ subject $f.Subject }}</code>{{ else if $f.Resource }}<code>{{ resource $f.Resource }}</code>{{ else }}{{ inlineHTML $f.Title }}{{ end }}</span>
+                {{ if $f.Scope.Level }}<span class="instance-scope" title="Blast-radius level">{{ scopeLabel $f.Scope.Level }}</span>{{ end }}
+                <span class="instance-score">{{ score $f.Score }}</span>
+              </summary>
+              <div class="instance-body">
+                <div class="finding-hd-inner">
+                  <h5 class="finding-title-inner">{{ inlineHTML $f.Title }}</h5>
+                </div>
+                {{ if or $f.Scope.Level $f.Scope.Detail }}
+                <div class="scope-row">
+                  {{ if $f.Scope.Level }}<span class="scope-chip {{ $f.Scope.Level }}" title="Blast-radius level">Scope · {{ scopeLabel $f.Scope.Level }}</span>{{ end }}
+                  {{ if $f.Scope.Detail }}<span class="scope-detail">{{ scopeDetailHTML $f.Scope.Detail }}</span>{{ end }}
+                </div>
+                {{ end }}
+                <div class="meta">
+                  <span><span class="k">Category:</span> {{ catLabel $f.Category }}</span>
+                  {{ if $f.Subject }}<span><span class="k">Subject:</span> <code>{{ subject $f.Subject }}</code></span>{{ end }}
+                  {{ if $f.Resource }}<span><span class="k">Resource:</span> <code>{{ resource $f.Resource }}</code></span>{{ end }}
+                  {{ if and (not $f.Subject) $f.Namespace }}<span><span class="k">Namespace:</span> <code>{{ $f.Namespace }}</code></span>{{ end }}
+                </div>
+                <div class="desc">{{ descriptionHTML $f.Description }}</div>
+                {{ if $f.Impact }}
+                <div class="impact">
+                  <span class="k">Impact</span>
+                  <span class="v">{{ inlineHTML $f.Impact }}</span>
+                </div>
+                {{ end }}
+                {{ $edu := findingEducationHTML $f }}
+                {{ if or $f.AttackScenario $f.EscalationPath $edu }}
+                <div class="scenario">
+                  <span class="k">How an attacker abuses this</span>
+                  {{ if $edu }}{{ $edu }}{{ end }}
+                  {{ if $f.AttackScenario }}
+                  <ol class="attack-narrative">
+                    {{ range $f.AttackScenario }}<li>{{ inlineHTML . }}</li>{{ end }}
+                  </ol>
+                  {{ end }}
+                  {{ if $f.EscalationPath }}
+                  <div class="attack-chain-wrap">
+                    {{ escalationPathHTML $f.EscalationPath }}
+                  </div>
+                  {{ end }}
+                </div>
+                {{ end }}
+                {{ if or $f.Remediation $f.RemediationSteps }}
+                <div class="rem">
+                  <span class="k">Remediation</span>
+                  {{ if $f.Remediation }}<div class="summary">{{ inlineHTML $f.Remediation }}</div>{{ end }}
+                  {{ if $f.RemediationSteps }}
+                  <ol>
+                    {{ range $f.RemediationSteps }}<li>{{ remediationStepHTML . }}</li>{{ end }}
+                  </ol>
+                  {{ end }}
+                </div>
+                {{ end }}
+                {{ $ev := evidenceHTML $f.Evidence }}
+                {{ if $ev }}
+                <div class="evidence">
+                  <span class="k">Evidence</span>
+                  {{ $ev }}
+                  <details class="evidence-raw">
+                    <summary>Show raw JSON</summary>
+                    <pre><code>{{ json $f.Evidence }}</code></pre>
+                  </details>
+                </div>
+                {{ end }}
+              </div>
             </details>
+            {{ end }}
           </div>
-          {{ end }}
-          {{ if .LearnMore }}
-          <details class="refs">
-            <summary>References <span class="ref-count">{{ len .LearnMore }}</span></summary>
-            <ul>
-              {{ range .LearnMore }}<li><a href="{{ .URL }}" target="_blank" rel="noopener noreferrer">{{ .Title }}</a></li>{{ end }}
-            </ul>
-          </details>
-          {{ else if .References }}
-          <details class="refs">
-            <summary>References <span class="ref-count">{{ len .References }}</span></summary>
-            <ul>
-              {{ range .References }}<li><a href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ . }}</a></li>{{ end }}
-            </ul>
-          </details>
-          {{ end }}
         </article>
         {{ end }}
       </div>

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -230,6 +230,143 @@ func TestBuildHTMLDataTOCEntries(t *testing.T) {
 	}
 }
 
+func TestBuildHTMLDataRuleGroups(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.NewSnapshot()
+	findings := []models.Finding{
+		// Three findings sharing one RuleID (different subjects) — should collapse
+		// into one RuleGroup with InstanceCount=3 and the highest severity bubbled up.
+		{
+			ID:       "f1",
+			RuleID:   "KUBE-RBAC-1",
+			Severity: models.SeverityHigh,
+			Score:    8.0,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "`ServiceAccount/default/a` can reach cluster-admin",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "a", Namespace: "default"},
+			MitreTechniques: []models.MitreTechnique{
+				{ID: "T1078", Name: "Valid Accounts", URL: "https://attack.mitre.org/techniques/T1078/"},
+			},
+			References: []string{"https://example.com/rbac-1"},
+			Tags:       []string{"module:rbac"},
+		},
+		{
+			ID:       "f2",
+			RuleID:   "KUBE-RBAC-1",
+			Severity: models.SeverityCritical, // top severity for the group
+			Score:    9.5,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "`Group/admins` can reach cluster-admin",
+			Subject:  &models.SubjectRef{Kind: "Group", Name: "admins"},
+			Tags:     []string{"module:rbac"},
+		},
+		{
+			ID:       "f3",
+			RuleID:   "KUBE-RBAC-1",
+			Severity: models.SeverityHigh,
+			Score:    7.5,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "`ServiceAccount/default/b` can reach cluster-admin",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "b", Namespace: "default"},
+			Tags:     []string{"module:rbac"},
+		},
+		// A second rule in the same module — separate group with InstanceCount=1.
+		{
+			ID:       "f4",
+			RuleID:   "KUBE-RBAC-2",
+			Severity: models.SeverityHigh,
+			Score:    7.0,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "Bind/escalate granted",
+			Tags:     []string{"module:rbac"},
+		},
+	}
+
+	data := BuildHTMLData(snapshot, findings)
+
+	var rbac *ModuleSection
+	for i := range data.Modules {
+		if data.Modules[i].ID == "rbac" {
+			rbac = &data.Modules[i]
+			break
+		}
+	}
+	if rbac == nil {
+		t.Fatalf("expected an RBAC module section")
+	}
+	if got := len(rbac.RuleGroups); got != 2 {
+		t.Fatalf("expected 2 RuleGroups (one per RuleID), got %d", got)
+	}
+	first := rbac.RuleGroups[0]
+	if first.RuleID != "KUBE-RBAC-1" {
+		t.Fatalf("first group RuleID: want KUBE-RBAC-1, got %s", first.RuleID)
+	}
+	if first.InstanceCount != 3 {
+		t.Fatalf("first group InstanceCount: want 3, got %d", first.InstanceCount)
+	}
+	if first.TopSeverity != models.SeverityCritical {
+		t.Fatalf("first group TopSeverity: want Critical, got %s", first.TopSeverity)
+	}
+	if first.MaxScore != 9.5 || first.MinScore != 7.5 {
+		t.Fatalf("first group score range: want [7.5, 9.5], got [%v, %v]", first.MinScore, first.MaxScore)
+	}
+	if first.Anchor != "finding-KUBE-RBAC-1" {
+		t.Fatalf("first group Anchor: want finding-KUBE-RBAC-1, got %q", first.Anchor)
+	}
+	// MITRE / References should be lifted from the exemplar (first occurrence).
+	if len(first.MitreTechniques) != 1 || first.MitreTechniques[0].ID != "T1078" {
+		t.Fatalf("first group MitreTechniques: want lifted from exemplar, got %#v", first.MitreTechniques)
+	}
+	if len(first.References) != 1 || first.References[0] != "https://example.com/rbac-1" {
+		t.Fatalf("first group References: want lifted from exemplar, got %#v", first.References)
+	}
+	// RuleTitle should be subject-neutralized — the exemplar's subject was
+	// "Group/admins", which prefixes the title; the helper replaces it with "Subjects".
+	if !strings.Contains(first.RuleTitle, "Subjects ") {
+		t.Fatalf("first group RuleTitle: want subject-neutralized, got %q", first.RuleTitle)
+	}
+	if rbac.RuleGroups[1].RuleID != "KUBE-RBAC-2" || rbac.RuleGroups[1].InstanceCount != 1 {
+		t.Fatalf("second group: want KUBE-RBAC-2 / count=1, got %#v", rbac.RuleGroups[1])
+	}
+}
+
+func TestRuleTitleForGroup(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		title string
+		subj  *models.SubjectRef
+		want  string
+	}{
+		{
+			title: "`ServiceAccount/default/risky` can reach cluster-admin equivalent in 1 hop(s)",
+			subj:  &models.SubjectRef{Kind: "ServiceAccount", Name: "risky", Namespace: "default"},
+			want:  "Subjects can reach cluster-admin equivalent in 1 hop(s)",
+		},
+		{
+			title: "Group/kubeadm:cluster-admins can reach cluster-admin",
+			subj:  &models.SubjectRef{Kind: "Group", Name: "kubeadm:cluster-admins"},
+			want:  "Subjects can reach cluster-admin",
+		},
+		{
+			title: "Wildcard verb on wildcard resource",
+			subj:  nil,
+			want:  "Wildcard verb on wildcard resource",
+		},
+		{
+			title: "Privesc path", // subject set but not a leading match — leave alone
+			subj:  &models.SubjectRef{Kind: "ServiceAccount", Name: "x", Namespace: "y"},
+			want:  "Privesc path",
+		},
+	}
+	for _, tc := range cases {
+		got := ruleTitleForGroup(models.Finding{Title: tc.title, Subject: tc.subj})
+		if got != tc.want {
+			t.Errorf("ruleTitleForGroup(title=%q): got %q, want %q", tc.title, got, tc.want)
+		}
+	}
+}
+
 func TestRenderInlineCodeMarkdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -119,6 +119,7 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 	// section structs the template already iterates.
 	for i := range modules {
 		modules[i].Entries = buildTOCEntries(modules[i].Findings, anchorByID)
+		modules[i].RuleGroups = buildRuleGroups(modules[i].Findings, anchorByID)
 	}
 	for i := range categories {
 		categories[i].Entries = buildTOCEntries(categoryMap[models.RiskCategory(categories[i].Key)], anchorByID)
@@ -417,6 +418,93 @@ func heatLevel(n int) int {
 	default:
 		return 5
 	}
+}
+
+// buildRuleGroups collapses a slice of findings (already in render order) into one RuleGroup
+// per RuleID. Each group's first finding becomes the "exemplar" — its Title is used as the
+// subject-neutralized rule title, and its MITRE / References / LearnMore become the rule-level
+// shared content. TopSeverity / MaxScore / MinScore are computed across the group.
+//
+// Order of groups preserves the first-occurrence order of the input findings (which is already
+// severity-then-score sorted upstream), so the rendered Findings tab still shows the most
+// dangerous rules first.
+func buildRuleGroups(findings []models.Finding, anchorByID map[string]string) []RuleGroup {
+	if len(findings) == 0 {
+		return nil
+	}
+	type acc struct {
+		group   RuleGroup
+		members []models.Finding
+		order   int
+	}
+	byRule := make(map[string]*acc, len(findings))
+	order := 0
+	for _, f := range findings {
+		entry, ok := byRule[f.RuleID]
+		if !ok {
+			entry = &acc{
+				group: RuleGroup{
+					RuleID:          f.RuleID,
+					RuleTitle:       ruleTitleForGroup(f),
+					TopSeverity:     f.Severity,
+					MaxScore:        f.Score,
+					MinScore:        f.Score,
+					MitreTechniques: f.MitreTechniques,
+					LearnMore:       f.LearnMore,
+					References:      f.References,
+				},
+				order: order,
+			}
+			if a, found := anchorByID[f.ID]; found {
+				entry.group.Anchor = a
+			} else {
+				entry.group.Anchor = "finding-" + f.RuleID
+			}
+			byRule[f.RuleID] = entry
+			order++
+		} else {
+			if f.Severity.Rank() > entry.group.TopSeverity.Rank() {
+				entry.group.TopSeverity = f.Severity
+			}
+			if f.Score > entry.group.MaxScore {
+				entry.group.MaxScore = f.Score
+			}
+			if f.Score < entry.group.MinScore {
+				entry.group.MinScore = f.Score
+			}
+		}
+		entry.members = append(entry.members, f)
+	}
+	groups := make([]RuleGroup, len(byRule))
+	for _, e := range byRule {
+		e.group.Findings = e.members
+		e.group.InstanceCount = len(e.members)
+		groups[e.order] = e.group
+	}
+	return groups
+}
+
+// ruleTitleForGroup returns a subject-neutral version of a finding's Title, suitable as the
+// header for a rule card. Many finding titles embed the subject ("`ServiceAccount/X` can reach
+// cluster-admin equivalent in 1 hop(s)"); we strip that leading subject and replace it with
+// "Subjects" so the title reads as a description of the rule, not a single instance. Falls
+// back to the raw title for rules whose titles don't follow that pattern.
+func ruleTitleForGroup(f models.Finding) string {
+	title := strings.TrimSpace(f.Title)
+	if f.Subject == nil || title == "" {
+		return title
+	}
+	subj := subjectDisplay(f.Subject)
+	if subj == "" || subj == "-" {
+		return title
+	}
+	for _, prefix := range []string{"`" + subj + "` ", subj + " "} {
+		if strings.HasPrefix(title, prefix) {
+			rest := strings.TrimPrefix(title, prefix)
+			return "Subjects " + rest
+		}
+	}
+	return title
 }
 
 // buildTOCEntries collapses a slice of findings into one TOCEntry per RuleID, keeping the

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -25,12 +25,37 @@ type Hotspot struct {
 }
 
 // ModuleSection groups findings by the module that emitted them for per-module display in the HTML report.
+// RuleGroups is the rendering view: findings are bucketed by RuleID so the template can render shared
+// rule-level content (title, MITRE, References) once and list per-subject instances below.
+// Findings is preserved for callers that want the flat list (TOC builders, snapshot exports).
 type ModuleSection struct {
-	ID       string // slug used as an anchor ID
-	Label    string
-	Summary  Summary
-	Findings []models.Finding
-	Entries  []TOCEntry // collapsed one-row-per-RuleID list for the Findings-tab TOC
+	ID         string // slug used as an anchor ID
+	Label      string
+	Summary    Summary
+	Findings   []models.Finding
+	RuleGroups []RuleGroup
+	Entries    []TOCEntry // collapsed one-row-per-RuleID list for the Findings-tab TOC
+}
+
+// RuleGroup collapses all findings sharing a RuleID into a single rendering unit. Each group
+// renders once as a "rule card" with shared educational content (rule title, MITRE techniques,
+// References) at the top, and one collapsed <details> instance per affected subject below.
+//
+// TopSeverity is the highest severity across instances; MaxScore/MinScore bracket the score range.
+// Anchor matches AnchorByID for the first instance — narrative chips and TOC rows already point
+// here, so the rule card lands on existing deep-links without churn.
+type RuleGroup struct {
+	RuleID          string
+	RuleTitle       string // subject-neutralized title for the rule header
+	TopSeverity     models.Severity
+	MaxScore        float64
+	MinScore        float64
+	InstanceCount   int
+	Anchor          string
+	MitreTechniques []models.MitreTechnique
+	LearnMore       []models.Reference
+	References      []string
+	Findings        []models.Finding
 }
 
 // CategorySection groups findings by RiskCategory for the "By Attack Theme" panel; it does not carry the findings themselves.


### PR DESCRIPTION
## Summary

- Collapse findings sharing a `RuleID` into a single **rule card** on the Findings tab — shared MITRE techniques, References, and rule title render once, with one collapsed `<details>` per affected subject below.
- Hybrid open default: expanded for 1–2 instances, collapsed for 3+. Filters now operate on instances, hide rule cards whose instances are all filtered out, and auto-open matching `<details>` so users land on the relevant evidence without an extra click.
- Score range, top severity, and instance count bubble up to the rule card header (e.g. `Score 9.8–9.3 · 8 subjects`).

## Why

The previous Findings tab rendered each finding as an independent card with the full description, Background glossary, MITRE chips, and References list — even when 24 of those cards were the same `KUBE-PRIVESC-PATH-CLUSTER-ADMIN` rule differing only by subject. Scanning the tab was exhausting and the only material per-instance differences (subject, evidence, attack chain) were buried under repeated boilerplate.

## Impact

Verified against the saved e2e snapshot (88 findings):

- **42 rule cards** now host **88 instances** (down from 88 separate cards)
- Report file size: **1.3 MB → 1.0 MB** (~23% reduction) with zero educational content dropped
- `KUBE-PRIVESC-PATH-CLUSTER-ADMIN` renders once with title `Subjects can reach cluster-admin equivalent in 1 hop(s) · 8 subjects · Score 9.8–9.3` — was 8 near-identical cards before
- TOC anchors, narrative chip cross-links, and severity/module/category/resource filter chips all still resolve to the right place (anchor lifts to the rule card; previously the per-rule anchor was on the first finding's `<article>`)

## Architecture notes

- New `RuleGroup` struct on `ModuleSection.RuleGroups` carries the rule-level shared content lifted from the exemplar finding (first-occurrence). Flat `ModuleSection.Findings` is preserved for the existing TOC builder and any other flat consumers.
- `ruleTitleForGroup()` strips a leading subject from titles like `` `ServiceAccount/X` can reach cluster-admin `` → `Subjects can reach cluster-admin`. Falls back to the raw title for rules whose titles don't follow that pattern.
- CSS reuses the existing `.finding *` selectors for instance bodies — each `<details>` instance still carries the `finding` class, so existing styles apply unchanged.
- Vanilla `<details>` for collapse, no JS framework. Filter logic in `graph.js` rolls visibility up: `.finding[data-rule]` → `.rule-group` → `section.module-section`.

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] New unit tests `TestBuildHTMLDataRuleGroups` and `TestRuleTitleForGroup` cover grouping, top-severity bubbling, score range, anchor lift, MITRE/References lift, and the subject-stripping helper
- [x] Rendered the e2e snapshot through the new template and visually verified rule cards, collapsed instance summary rows, and expand-on-click
- [x] Reviewer: open the rendered `report.html` and click through Privesc rule cards (most have multiple instances) — confirm header, MITRE/References, and per-instance evidence/remediation all render correctly
- [x] Reviewer: confirm severity / module / category / resource filter chips still narrow the list and auto-open matching instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)