### PR TITLE
Qualify RBAC binding/role refs by Kind in descriptions

### DIFF
--- a/internal/analyzer/rbac/analyzer.go
+++ b/internal/analyzer/rbac/analyzer.go
@@ -18,13 +18,34 @@ import (
 type Analyzer struct{}
 
 // effectiveRule is a flattened policy rule tagged with where it came from so findings can point back at it.
+//
+// SourceRole / SourceBinding hold the raw object names (used in Evidence JSON, where
+// machine-readable identifiers are correct). The Kind/Namespace fields let prose
+// renderers qualify those names with their resource Kind — e.g. "ClusterRoleBinding
+// `crb-nodes-proxy`" instead of an opaque "`crb-nodes-proxy`" — which is what the
+// Findings tab needs to be readable for someone who hasn't memorized the cluster.
 type effectiveRule struct {
-	Namespace     string
-	APIGroups     []string
-	Resources     []string
-	Verbs         []string
-	SourceRole    string
-	SourceBinding string
+	Namespace              string
+	APIGroups              []string
+	Resources              []string
+	Verbs                  []string
+	SourceRole             string
+	SourceRoleKind         string
+	SourceRoleNamespace    string
+	SourceBinding          string
+	SourceBindingKind      string
+	SourceBindingNamespace string
+}
+
+// formattedBinding returns the binding rendered as "ClusterRoleBinding `name`" or
+// "RoleBinding `ns/name`" for inclusion in finding prose. See formatBindingRef.
+func (r effectiveRule) formattedBinding() string {
+	return formatBindingRef(r.SourceBindingKind, r.SourceBindingNamespace, r.SourceBinding)
+}
+
+// formattedRole mirrors formattedBinding for the Role/ClusterRole side.
+func (r effectiveRule) formattedRole() string {
+	return formatRoleRef(r.SourceRoleKind, r.SourceRoleNamespace, r.SourceRole)
 }
 
 // effectivePermissions collects every effectiveRule that resolves to a given subject.
@@ -60,17 +81,28 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 	for _, binding := range snapshot.Resources.RoleBindings {
 		rules := referencedRules(binding.RoleRef, binding.Namespace, roleRules, clusterRoleRules)
+		// A RoleBinding's RoleRef.Kind is "Role" (same namespace) or "ClusterRole" (cluster-scoped).
+		// Roles are always co-located with their RoleBinding, so the role's namespace mirrors
+		// binding.Namespace; ClusterRoles have no namespace.
+		roleNamespace := ""
+		if binding.RoleRef.Kind == "Role" {
+			roleNamespace = binding.Namespace
+		}
 		for _, subject := range binding.Subjects {
 			ref := subjectRef(subject, binding.Namespace)
 			perms := getSubject(subjects, ref)
 			for _, rule := range rules {
 				perms.Rules = append(perms.Rules, effectiveRule{
-					Namespace:     binding.Namespace,
-					APIGroups:     append([]string(nil), rule.APIGroups...),
-					Resources:     append([]string(nil), rule.Resources...),
-					Verbs:         append([]string(nil), rule.Verbs...),
-					SourceRole:    binding.RoleRef.Name,
-					SourceBinding: binding.Name,
+					Namespace:              binding.Namespace,
+					APIGroups:              append([]string(nil), rule.APIGroups...),
+					Resources:              append([]string(nil), rule.Resources...),
+					Verbs:                  append([]string(nil), rule.Verbs...),
+					SourceRole:             binding.RoleRef.Name,
+					SourceRoleKind:         binding.RoleRef.Kind,
+					SourceRoleNamespace:    roleNamespace,
+					SourceBinding:          binding.Name,
+					SourceBindingKind:      "RoleBinding",
+					SourceBindingNamespace: binding.Namespace,
 				})
 			}
 		}
@@ -78,16 +110,19 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 	for _, binding := range snapshot.Resources.ClusterRoleBindings {
 		rules := referencedRules(binding.RoleRef, "", roleRules, clusterRoleRules)
+		// ClusterRoleBindings can only reference ClusterRoles; both are cluster-scoped.
 		for _, subject := range binding.Subjects {
 			ref := subjectRef(subject, "")
 			perms := getSubject(subjects, ref)
 			for _, rule := range rules {
 				perms.Rules = append(perms.Rules, effectiveRule{
-					APIGroups:     append([]string(nil), rule.APIGroups...),
-					Resources:     append([]string(nil), rule.Resources...),
-					Verbs:         append([]string(nil), rule.Verbs...),
-					SourceRole:    binding.RoleRef.Name,
-					SourceBinding: binding.Name,
+					APIGroups:         append([]string(nil), rule.APIGroups...),
+					Resources:         append([]string(nil), rule.Resources...),
+					Verbs:             append([]string(nil), rule.Verbs...),
+					SourceRole:        binding.RoleRef.Name,
+					SourceRoleKind:    binding.RoleRef.Kind,
+					SourceBinding:     binding.Name,
+					SourceBindingKind: "ClusterRoleBinding",
 				})
 			}
 		}
@@ -108,54 +143,57 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 				exploitability = 1.2
 			}
 
+			bindingRef := rule.formattedBinding()
+			roleRef := rule.formattedRole()
+
 			switch {
 			case hasWildcard(rule.Verbs) && hasWildcard(rule.Resources) && hasWildcard(rule.APIGroups):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-017", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(9.8*exploitability*blastRadius),
-					contentPrivesc017(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc017(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get", "list", "watch"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-005", models.SeverityHigh, models.CategoryDataExfiltration,
 					scoring.Clamp(8.2*exploitability*blastRadius),
-					contentPrivesc005(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc005(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-001", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(8.4*exploitability*blastRadius),
-					contentPrivesc001(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc001(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-003", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(8.1*exploitability*blastRadius),
-					contentPrivesc003(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc003(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"users", "groups", "serviceaccounts"}) && hasAnyVerb(rule.Verbs, "impersonate"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-008", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(9.4*exploitability*blastRadius),
-					contentPrivesc008(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc008(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"roles", "clusterroles"}) && hasAnyVerb(rule.Verbs, "bind", "escalate"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-009", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(9.2*exploitability*blastRadius),
-					contentPrivesc009(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc009(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-010", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(9.0*exploitability*blastRadius),
-					contentPrivesc010(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc010(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "nodes/proxy") && hasAnyVerb(rule.Verbs, "get"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-012", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(9.3*exploitability*blastRadius),
-					contentPrivesc012(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc012(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "serviceaccounts/token") && hasAnyVerb(rule.Verbs, "create"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-014", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scoring.Clamp(8.0*exploitability*blastRadius),
-					contentPrivesc014(rule.Namespace, perms.Subject, rule.SourceBinding, rule.SourceRole)))
+					contentPrivesc014(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			}
 		}
 	}
@@ -169,7 +207,12 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 				}
 				findings = appendFinding(findings, seen, findingFromContent(
 					ref,
-					effectiveRule{SourceBinding: binding.Name, SourceRole: binding.RoleRef.Name},
+					effectiveRule{
+						SourceBinding:     binding.Name,
+						SourceBindingKind: "ClusterRoleBinding",
+						SourceRole:        binding.RoleRef.Name,
+						SourceRoleKind:    binding.RoleRef.Kind,
+					},
 					"KUBE-RBAC-OVERBROAD-001", models.SeverityCritical, models.CategoryPrivilegeEscalation, 10,
 					contentRBACOverbroad001(ref, binding.Name)))
 			}

--- a/internal/analyzer/rbac/analyzer_test.go
+++ b/internal/analyzer/rbac/analyzer_test.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hardik/kubesplaining/internal/models"
@@ -97,6 +98,91 @@ func TestAnalyzerFlagsClusterAdminBinding(t *testing.T) {
 	}
 
 	assertRulePresent(t, findings, "KUBE-RBAC-OVERBROAD-001")
+}
+
+func TestDescriptionsQualifyBindingAndRoleByKind(t *testing.T) {
+	t.Parallel()
+
+	// Mix of cluster-scoped (CRB → CR) and namespace-scoped (RB → Role) so we exercise both helper branches.
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			ClusterRoles: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1ObjectMeta("cr-secrets", ""),
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"}},
+					},
+				},
+			},
+			Roles: []rbacv1.Role{
+				{
+					ObjectMeta: metav1ObjectMeta("r-pods", "team-a"),
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"create"}},
+					},
+				},
+			},
+			ClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1ObjectMeta("crb-secrets", ""),
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cr-secrets"},
+					Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "snoop", Namespace: "team-a"}},
+				},
+			},
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1ObjectMeta("rb-pods", "team-a"),
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "r-pods"},
+					Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "deployer", Namespace: "team-a"}},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	requireDescriptionContains(t, findings, "KUBE-PRIVESC-005", "ClusterRoleBinding `crb-secrets`")
+	requireDescriptionContains(t, findings, "KUBE-PRIVESC-005", "ClusterRole `cr-secrets`")
+	requireDescriptionContains(t, findings, "KUBE-PRIVESC-001", "RoleBinding `team-a/rb-pods`")
+	requireDescriptionContains(t, findings, "KUBE-PRIVESC-001", "Role `team-a/r-pods`")
+}
+
+func TestFormatHelpersRenderKindAndNamespace(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		kind    string
+		ns      string
+		objName string
+		want    string
+	}{
+		{"clusterrolebinding", "ClusterRoleBinding", "", "crb-foo", "ClusterRoleBinding `crb-foo`"},
+		{"clusterrole", "ClusterRole", "", "cr-foo", "ClusterRole `cr-foo`"},
+		{"rolebinding", "RoleBinding", "team-a", "rb-foo", "RoleBinding `team-a/rb-foo`"},
+		{"role", "Role", "team-a", "r-foo", "Role `team-a/r-foo`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatBindingRef(tc.kind, tc.ns, tc.objName)
+			if got != tc.want {
+				t.Errorf("formatBindingRef(%q,%q,%q) = %q, want %q", tc.kind, tc.ns, tc.objName, got, tc.want)
+			}
+		})
+	}
+}
+
+func requireDescriptionContains(t *testing.T, findings []models.Finding, ruleID, want string) {
+	t.Helper()
+	for _, f := range findings {
+		if f.RuleID == ruleID && strings.Contains(f.Description, want) {
+			return
+		}
+	}
+	t.Fatalf("expected rule %s description to contain %q; not found in %d findings", ruleID, want, len(findings))
 }
 
 func assertRulePresent(t *testing.T, findings []models.Finding, ruleID string) {

--- a/internal/analyzer/rbac/content.go
+++ b/internal/analyzer/rbac/content.go
@@ -60,6 +60,27 @@ func subjectKey(subject models.SubjectRef) string {
 	return subject.Key()
 }
 
+// formatBindingRef renders a RoleBinding/ClusterRoleBinding reference for inclusion
+// in finding prose. ClusterRoleBindings are cluster-scoped and rendered as
+// "ClusterRoleBinding `name`"; RoleBindings include their namespace so a reader
+// can locate them with `kubectl -n <ns> get rolebinding <name>`.
+func formatBindingRef(kind, namespace, name string) string {
+	if kind == "" {
+		return fmt.Sprintf("`%s`", name)
+	}
+	if namespace != "" {
+		return fmt.Sprintf("%s `%s/%s`", kind, namespace, name)
+	}
+	return fmt.Sprintf("%s `%s`", kind, name)
+}
+
+// formatRoleRef renders a Role/ClusterRole reference identically to formatBindingRef.
+// Roles are namespace-scoped (rendered as "Role `ns/name`"); ClusterRoles are
+// cluster-scoped (rendered as "ClusterRole `name`").
+func formatRoleRef(kind, namespace, name string) string {
+	return formatBindingRef(kind, namespace, name)
+}
+
 // kubectlAuthCanI returns the verification command tailored to scope.
 func kubectlAuthCanI(verb, resource string, ruleNamespace string, subject models.SubjectRef) string {
 	scope := "-A"
@@ -169,7 +190,7 @@ func contentPrivesc017(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s wildcard RBAC permissions on `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("RBAC rule binding `%s` → role `%s` grants `*` verbs on `*` resources in `*` apiGroups to %s. %s.\n\n"+
+		Description: fmt.Sprintf("RBAC rule from %s → %s grants `*` verbs on `*` resources in `*` apiGroups to %s. %s.\n\n"+
 			"Wildcards are dangerous beyond their current expansion: any resource type added later (CRDs, new core subresources, future verbs) is automatically granted to this subject without anyone reviewing the change. The Kubernetes project explicitly flags this in `RBAC Good Practices` as an anti-pattern.\n\n"+
 			"In a typical attack, an adversary who reaches a workload bound to this rule has full control: they read every Secret, create privileged pods on any node, bind themselves to additional ClusterRoles, and persist by minting long-lived tokens via the TokenRequest API. There is no further escalation needed — the box is already at the top.",
 			sourceBinding, sourceRole, subjectKey(subject), scope.Detail),
@@ -185,7 +206,7 @@ func contentPrivesc017(ruleNamespace string, subject models.SubjectRef, sourceBi
 		RemediationSteps: []string{
 			fmt.Sprintf("Inventory what %s actually needs — run `%s` and correlate with audit logs filtered on `user.username`.", subjectKey(subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
 			"Author a least-privilege Role/ClusterRole listing only those (apiGroups, resources, verbs); drop every wildcard. Prefer namespace-scoped Role+RoleBinding over ClusterRole+ClusterRoleBinding wherever possible.",
-			fmt.Sprintf("Apply the new binding, delete the wildcard binding `%s`, and verify with `%s` returning `no`.", sourceBinding, kubectlAuthCanI("'*'", "'*'", ruleNamespace, subject)),
+			fmt.Sprintf("Apply the new binding, delete the wildcard binding %s, and verify with `%s` returning `no`.", sourceBinding, kubectlAuthCanI("'*'", "'*'", ruleNamespace, subject)),
 			"Add a ValidatingAdmissionPolicy (or Kyverno/OPA Gatekeeper rule) that rejects any future Role/ClusterRole containing `*` in verbs, resources, or apiGroups.",
 		},
 		LearnMore: []models.Reference{
@@ -206,7 +227,7 @@ func contentPrivesc005(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s read access to Secrets — `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `get`, `list`, or `watch` core `secrets` via binding `%s` → role `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s can `get`, `list`, or `watch` core `secrets` via %s → %s. %s.\n\n"+
 			"The Kubernetes documentation is explicit that `list` and `watch` reveal Secret contents in the response body — they are not metadata-only verbs — so all three verbs leak the same data.\n\n"+
 			"Kubernetes Secrets typically hold ServiceAccount tokens, kubeconfigs, image-pull credentials, TLS private keys, database passwords, and integration secrets for cloud APIs. Once Secret contents are exposed, the holder can authenticate as the corresponding ServiceAccount/user, which usually amplifies the original blast radius far beyond 'read access'. Cluster-wide reads include `kube-system` ServiceAccount tokens, which are routinely cluster-admin-equivalent.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
@@ -244,7 +265,7 @@ func contentPrivesc001(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s pod creation — token-theft and node-takeover path (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `create` pods via binding `%s` → role `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s can `create` pods via %s → %s. %s.\n\n"+
 			"Under Kubernetes' RBAC model, pod creation is one of the most powerful permissions because the API server does not police the privileges of the pod being created — only the create verb itself. A pod is a request to run code as a ServiceAccount; by choosing `spec.serviceAccountName` the attacker borrows the identity (and RBAC permissions) of any ServiceAccount in the target namespace, with the token mounted automatically at `/var/run/secrets/kubernetes.io/serviceaccount/token`.\n\n"+
 			"Beyond identity hopping, a created pod can request `hostPath`, `hostNetwork`, `hostPID`, `privileged: true`, or `SYS_ADMIN` — none of which are blocked by RBAC; only Pod Security Admission or a policy engine (Kyverno, Gatekeeper, ValidatingAdmissionPolicy) can stop them. A typical attack mounts / from the host and reads `/etc/kubernetes/pki/admin.conf` directly.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
@@ -281,7 +302,7 @@ func contentPrivesc003(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s workload-controller mutation can spawn privileged pods — `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `create/update/patch` workload controllers (`deployments`, `daemonsets`, `statefulsets`, `jobs`, `cronjobs`) via `%s` → `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s can `create/update/patch` workload controllers (`deployments`, `daemonsets`, `statefulsets`, `jobs`, `cronjobs`) via %s → %s. %s.\n\n"+
 			"Anyone who can write a workload template inherits the same implicit permissions as `pods/create`: choice of ServiceAccount, choice of Pod Security context, and choice of host-level features. The specific danger of controller mutation (vs. pod create) is durability and stealth: a `kubectl edit deployment` adding a `privileged: true` sidecar produces pods continuously — restart-loop the pod and you get a fresh shell every time.\n\n"+
 			"DaemonSet write is the most dangerous variant because a DaemonSet runs one pod on every node — including new nodes added later. CronJobs offer time-based persistence that survives pod evictions, node reboots, and short-lived RBAC remediations. A realistic incident: an attacker with `patch daemonsets` in `kube-system` mutates `kube-proxy` to add a malicious sidecar inheriting the existing pod's host-mounts and ServiceAccount.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
@@ -318,7 +339,7 @@ func contentPrivesc008(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s `impersonate` permission — `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s has the `impersonate` verb on `users/groups/serviceaccounts` via `%s` → `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s has the `impersonate` verb on `users/groups/serviceaccounts` via %s → %s. %s.\n\n"+
 			"Kubernetes' impersonation lets a request set `Impersonate-User/Impersonate-Group` headers (or `kubectl --as`) so the API server processes the request as a different identity. The Kubernetes project flags this in `RBAC Good Practices` as one of three verbs (alongside `bind` and `escalate`) that override normal RBAC limits.\n\n"+
 			"Most damaging is the ability to impersonate the `system:masters` group, which is hardcoded inside kube-apiserver to bypass RBAC entirely — there is no Role or RoleBinding that grants `system:masters` membership; the apiserver simply trusts the assertion. `kubectl --as=admin --as-group=system:masters get secrets -A` runs as cluster-admin, full stop. Impersonation is also stealthier than a binding change because audit logs show `user.username` as the original subject.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
@@ -355,7 +376,7 @@ func contentPrivesc009(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s `bind/escalate` on roles — RBAC bypass (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s has the `bind` or `escalate` verb on `roles/clusterroles` via `%s` → `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s has the `bind` or `escalate` verb on `roles/clusterroles` via %s → %s. %s.\n\n"+
 			"Kubernetes' RBAC normally enforces a privilege-escalation guard: you cannot create a Role/RoleBinding granting permissions you do not already hold. The `escalate` and `bind` verbs are explicit, documented exceptions to that guard.\n\n"+
 			"`escalate` lets the subject author or modify a Role/ClusterRole with verbs and resources they don't currently possess — they rewrite an existing Role they're already bound to and instantly inherit whatever they wrote into it.\n\n"+
 			"`bind` lets the subject create a RoleBinding/ClusterRoleBinding referencing a (Cluster)Role they don't already hold. With `bind` on `clusterroles`, an attacker creates a ClusterRoleBinding from themselves to `cluster-admin` and is done in one step.",
@@ -393,7 +414,7 @@ func contentPrivesc010(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s write access to (Cluster)RoleBindings — self-grant path (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `create/update/patch` `rolebindings/clusterrolebindings` via `%s` → `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s can `create/update/patch` `rolebindings/clusterrolebindings` via %s → %s. %s.\n\n"+
 			"RoleBinding write is the most direct self-grant path in Kubernetes. Even with the API-level escalation guard active (binding only to roles whose permissions you already have), this permission is dangerous: if the subject already holds any powerful permission (often inherited from a default ClusterRole like `view/edit`), they can re-bind it to backup identities for persistence.\n\n"+
 			"A RoleBinding can also reference a *ClusterRole*, granting that ClusterRole's permissions inside the binding's namespace — so `create rolebindings` in `kube-system` is effectively cluster-admin-on-kube-system. Combined with `bind` on `clusterroles` (KUBE-PRIVESC-009), this bypasses the escalation guard entirely and yields cluster-admin in one step. Microsoft's Threat Matrix for Kubernetes documents this as the `Cluster-admin binding` technique.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
@@ -434,7 +455,7 @@ func contentPrivesc012(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("`get nodes/proxy` — kubelet exec via API server (`%s`)", subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `get` `nodes/proxy` via `%s` → `%s`. Despite the read-only-sounding `get` verb, this permission lets the holder execute arbitrary commands inside any pod on any node by tunneling through the API server to the kubelet's internal HTTP API — `/exec`, `/run`, `/attach`, `/portforward`.\n\n"+
+		Description: fmt.Sprintf("Subject %s can `get` `nodes/proxy` via %s → %s. Despite the read-only-sounding `get` verb, this permission lets the holder execute arbitrary commands inside any pod on any node by tunneling through the API server to the kubelet's internal HTTP API — `/exec`, `/run`, `/attach`, `/portforward`.\n\n"+
 			"The technical root cause: pod exec uses an HTTP-to-WebSocket upgrade. The API server authorizes the upgrade based on the initial GET against the proxy subresource — not against `pods/exec`. So a subject with `get nodes/proxy` can issue `kubectl get --raw '/api/v1/nodes/<node>/proxy/exec/...'` and end up with an interactive shell in any container, even with no `pods/exec` permission anywhere.\n\n"+
 			"Worse, the resulting commands execute over a direct API-server-to-kubelet WebSocket and are NOT recorded in apiserver audit logs at the `objectRef/verb` granularity — the audit log shows only the proxy GET. Detection requires node-level eBPF/process monitoring (Falco, Tetragon, KubeArmor), not API-server logs alone. Kubernetes issue #119640 and Stream Security have published proof-of-concept exploits.",
 			subjectKey(subject), sourceBinding, sourceRole),
@@ -471,7 +492,7 @@ func contentPrivesc014(ruleNamespace string, subject models.SubjectRef, sourceBi
 	return ruleContent{
 		Title: fmt.Sprintf("%s `create serviceaccounts/token` — token minting (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `create` on the `serviceaccounts/token` subresource via `%s` → `%s`. %s.\n\n"+
+		Description: fmt.Sprintf("Subject %s can `create` on the `serviceaccounts/token` subresource via %s → %s. %s.\n\n"+
 			"The TokenRequest API (Kubernetes 1.22+) is the canonical way to mint a JWT ServiceAccount token, and its `create` verb is gated by RBAC on the `serviceaccounts/token` subresource. Anyone holding this verb on a ServiceAccount can mint a token authenticated as that ServiceAccount.\n\n"+
 			"Datadog Security Labs published a write-up on its abuse for persistence: an attacker mints a long-lived token for the highest-privileged ServiceAccount they can reach (commonly `kube-system/clusterrole-aggregation-controller`, which holds `escalate` on ClusterRoles), and uses that token as a backdoor that survives the original RBAC binding being removed. Crucially, this verb is NOT covered by 'list secrets' detections — TokenRequest tokens are NOT stored as Secret objects; they're issued live by the apiserver and never leave a footprint on disk.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -39,7 +39,7 @@
        overrides further down may bump this up but should not dim it. Block-level <pre><code>
        overrides this back to transparent (see .kp-cmd pre code, etc.). */
     code { background: rgba(255,255,255,0.10); border: 1px solid rgba(255,255,255,0.06);
-           padding: 1px 4px; border-radius: 4px; }
+           padding: 1px 2px; border-radius: 4px; }
     pre { margin: 0; background: #0b1120; color: #c1cde3; border: 1px solid var(--border-soft);
           border-radius: 10px; padding: 12px 14px; overflow-x: auto; line-height: 1.6; }
     pre code { background: transparent; border: 0; padding: 0; }
@@ -94,12 +94,12 @@
     .hero { display: grid; grid-template-columns: 1.6fr 1fr; gap: 16px; }
     .hero .cluster-line { color: var(--text-mut); font-size: 13.5px; margin: 10px 0 0; }
     .hero .cluster-line strong { color: var(--text); font-weight: 500; }
-    .hero .cluster-line code { color: var(--accent); background: rgba(106,183,255,0.08); padding: 2px 6px; border-radius: 6px; }
+    .hero .cluster-line code { color: var(--accent); background: rgba(106,183,255,0.08); padding: 2px 4px; border-radius: 6px; }
     .tldr { margin-top: 14px; font-size: 15.5px; line-height: 1.62; color: var(--text-mut);
       padding: 14px 16px; border-left: 2px solid var(--critical);
       background: linear-gradient(90deg, var(--critical-soft), transparent 80%); border-radius: 0 10px 10px 0; }
     .tldr strong { color: var(--text); font-weight: 600; }
-    .tldr code { color: #ffdbe0; background: rgba(255,85,104,0.12); padding: 1px 4px; border-radius: 4px; }
+    .tldr code { color: #ffdbe0; background: rgba(255,85,104,0.12); padding: 1px 2px; border-radius: 4px; }
 
     .sev-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-top: 16px; }
     .sev-tile { border: 1px solid var(--border); border-radius: 12px; padding: 12px 14px 12px 22px;
@@ -134,7 +134,7 @@
     .graph-intro .kp-hint { display: inline-block; margin-left: 4px; color: var(--accent); font-size: 12.5px; }
     .graph-truncated-notice { color: var(--text-mut); font-size: 12.5px; flex: 1 1 360px; min-width: 280px; padding: 8px 12px; background: rgba(255,154,60,0.06); border-left: 2px solid rgba(255,154,60,0.55); border-radius: 4px; line-height: 1.5; }
     .graph-truncated-notice strong { color: var(--text); }
-    .graph-truncated-badge { display: inline-block; font-weight: 600; color: var(--text); margin-right: 6px; padding: 1px 4px; background: rgba(255,154,60,0.18); border-radius: 3px; font-size: 11.5px; letter-spacing: 0.02em; }
+    .graph-truncated-badge { display: inline-block; font-weight: 600; color: var(--text); margin-right: 6px; padding: 1px 2px; background: rgba(255,154,60,0.18); border-radius: 3px; font-size: 11.5px; letter-spacing: 0.02em; }
     .graph-wrap { margin-top: 10px; overflow-x: auto; }
     .kp-graph-card { position: relative; }
     .attack-svg { width: 100%; min-width: 1080px; height: auto; display: block; }
@@ -212,7 +212,7 @@
     .kp-prose { color: var(--text); font-size: 13.5px; line-height: 1.6; margin: 0; }
     .kp-prose p { margin: 0 0 8px; }
     .kp-prose p:last-child { margin-bottom: 0; }
-    .kp-prose code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 12.5px; }
+    .kp-prose code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 12.5px; }
     .kp-prose strong { color: var(--text); }
     .kp-prose em { color: #ffdbe0; font-style: normal; }
     .kp-prose ul, .kp-prose ol { margin: 6px 0 0; padding-left: 20px; }
@@ -230,7 +230,7 @@
     .kp-step-note { color: var(--text); font-size: 12.5px; margin: 8px 2px; line-height: 1.55; }
     .kp-fix { background: rgba(106,183,255,0.05); border: 1px solid rgba(106,183,255,0.18); border-radius: 10px; padding: 10px 12px; margin-top: 16px; }
     .kp-fix h4 { color: var(--accent); margin-bottom: 4px; }
-    .kp-fix .kp-prose code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 12px; }
+    .kp-fix .kp-prose code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 12px; }
     .kp-refs { margin: 0; padding-left: 18px; font-size: 12.5px; color: var(--text-mut); }
     .kp-refs li { margin: 3px 0; }
     .kp-refs a { word-break: break-all; }
@@ -259,10 +259,10 @@
     .kp-tt-body { font-size: 12px; color: var(--text-mut); margin-top: 4px; line-height: 1.5; }
     .kp-tt-prose { margin-top: 4px; }
     .kp-tt-prose p { margin: 0 0 4px; }
-    .kp-tt-prose code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; }
+    .kp-tt-prose code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; }
     .kp-tt-sub { color: var(--text-dim); font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; word-break: break-all; margin-bottom: 4px; }
     .kp-tt-why { margin-top: 5px; color: var(--text-mut); }
-    .kp-tt-tag { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; padding: 1px 4px; margin-right: 5px; border-radius: 999px; background: rgba(106,183,255,0.12); color: var(--accent); border: 1px solid rgba(106,183,255,0.25); vertical-align: middle; }
+    .kp-tt-tag { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; padding: 1px 2px; margin-right: 5px; border-radius: 999px; background: rgba(106,183,255,0.12); color: var(--accent); border: 1px solid rgba(106,183,255,0.25); vertical-align: middle; }
     .kp-tt-hint { margin-top: 6px; color: var(--accent); font-size: 11px; opacity: 0.8; }
 
     @media (max-width: 1180px) {
@@ -339,7 +339,7 @@
     .heat-cell-clickable { cursor: pointer; border-left: 0; border-right: 0; border-bottom: 0; transition: filter 0.15s ease, transform 0.1s ease; font: inherit; padding: 0; }
     .heat-cell-clickable:hover { filter: brightness(1.25); }
     .heat-cell-clickable:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-    .heat-res .heat-sev { font-size: 10px; font-weight: 700; padding: 1px 4px; border-radius: 4px; letter-spacing: 0.04em; flex-shrink: 0; }
+    .heat-res .heat-sev { font-size: 10px; font-weight: 700; padding: 1px 2px; border-radius: 4px; letter-spacing: 0.04em; flex-shrink: 0; }
     .heat-sev.crit { color: #ffb4be; background: var(--critical-soft); border: 1px solid var(--critical-edge); }
     .heat-sev.high { color: #ffc89a; background: var(--high-soft); border: 1px solid var(--high-edge); }
     .heat-sev.med  { color: #ffe9a1; background: var(--medium-soft); border: 1px solid var(--medium-edge); }
@@ -463,7 +463,7 @@
     .rule-group.low  { border-left-color: var(--low); border-color: var(--border-soft); }
     .rule-hd { display: flex; align-items: center; gap: 10px 14px; flex-wrap: wrap; }
     .rule-hd .rule-title { flex: 1 1 320px; font-size: 16.5px; line-height: 1.35; letter-spacing: -0.01em; }
-    .rule-hd .rule-title code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 12.5px; }
+    .rule-hd .rule-title code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 12.5px; }
     .rule-meta-pills { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-left: auto; }
     .rule-group .rule { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); letter-spacing: 0.02em; }
     .rule-group .score-lbl { font-size: 12px; color: var(--text-mut); }
@@ -491,7 +491,7 @@
     .instance.finding > .instance-hd:hover { background: rgba(255,255,255,0.025); }
     .instance.finding > .instance-hd:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; border-radius: 10px; }
     .instance-title { flex: 1 1 240px; min-width: 0; font-size: 13.5px; color: var(--text); overflow: hidden; text-overflow: ellipsis; }
-    .instance-title code { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 12.5px; background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; color: var(--text); }
+    .instance-title code { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 12.5px; background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; color: var(--text); }
     .instance-scope { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-mut); padding: 2px 7px; border: 1px solid var(--border-soft); border-radius: 999px; background: rgba(255,255,255,0.02); }
     .instance-score { font-size: 12px; color: var(--text-mut); font-variant-numeric: tabular-nums; }
     .instance-body { padding: 4px 16px 14px; border-top: 1px solid var(--border-soft); }
@@ -511,10 +511,10 @@
     .finding .scope-chip.workload { color: #a89cf6; border-color: rgba(168,156,246,0.4); background: rgba(168,156,246,0.08); }
     .finding .scope-chip.object { color: #88d49f; border-color: rgba(136,212,159,0.4); background: rgba(136,212,159,0.08); }
     .finding .scope-detail { color: var(--text); font-size: 13px; font-weight: 500; }
-    .finding .scope-detail code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 12px; }
+    .finding .scope-detail code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 12px; }
     .finding .meta { display: flex; flex-wrap: wrap; gap: 8px 14px; margin: 10px 0; color: var(--text-mut); font-size: 12.5px; }
     .finding .meta .k { color: var(--text-dim); }
-    .finding .meta code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; color: var(--text); }
+    .finding .meta code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; color: var(--text); }
     .finding .desc { margin: 6px 0 12px; color: #cfd6e5; font-size: 14px; line-height: 1.58; }
     .finding .desc p { margin-bottom: 8px; }
     .finding .desc p:last-child { margin-bottom: 0; }
@@ -536,12 +536,12 @@
     .finding .education .edu-cards { display: grid; gap: 8px; }
     .finding .education .edu-card { padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); }
     .finding .education .edu-hd { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; margin-bottom: 4px; }
-    .finding .education .edu-label { font-size: 10.5px; color: var(--text-dim); font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; padding: 1px 4px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.03); }
+    .finding .education .edu-label { font-size: 10.5px; color: var(--text-dim); font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; padding: 1px 2px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.03); }
     .finding .education .edu-title { color: var(--text); font-weight: 600; font-size: 13px; }
     .finding .education .edu-body { color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
     .finding .education .edu-body p { margin: 0 0 6px; }
     .finding .education .edu-body p:last-child { margin-bottom: 0; }
-    .finding .education .edu-body code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
+    .finding .education .edu-body code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
     .finding .education .edu-body strong { color: var(--text); font-weight: 600; }
     .finding .education .edu-body em { color: var(--text); font-style: italic; }
     .finding .education .edu-body ul { margin: 4px 0 6px; padding-left: 18px; }
@@ -554,11 +554,11 @@
     .finding .rem ol { margin: 0; padding-left: 20px; color: var(--text); font-size: 13px; line-height: 1.6; }
     .finding .rem ol li { margin-bottom: 4px; }
     .finding .rem ol li:last-child { margin-bottom: 0; }
-    .finding .rem code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 12px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
+    .finding .rem code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 12px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; }
     .finding details.refs { margin-top: 10px; font-size: 13px; color: var(--text-mut); }
     .finding details.refs summary { cursor: pointer; user-select: none; font-size: 12px; color: var(--text-mut); padding: 6px 10px; border: 1px dashed var(--border); border-radius: 8px; display: inline-flex; align-items: center; gap: 6px; letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600; }
     .finding details.refs[open] summary { color: var(--accent); border-color: var(--border-strong); border-style: solid; }
-    .finding details.refs summary .ref-count { font-size: 10.5px; color: var(--text-dim); background: rgba(255,255,255,0.06); padding: 1px 4px; border-radius: 999px; letter-spacing: 0; text-transform: none; font-weight: 600; }
+    .finding details.refs summary .ref-count { font-size: 10.5px; color: var(--text-dim); background: rgba(255,255,255,0.06); padding: 1px 2px; border-radius: 999px; letter-spacing: 0; text-transform: none; font-weight: 600; }
     .finding details.refs[open] summary .ref-count { color: var(--accent); background: rgba(106,183,255,0.12); }
     .finding details.refs a { word-break: break-all; }
     .finding details.refs ul { list-style: none; padding-left: 0; margin: 8px 0 0; display: grid; gap: 4px; }
@@ -610,14 +610,14 @@
     .finding .scenario .step-explainer { margin: 4px 0 8px; color: var(--text-mut); font-size: 12.5px; line-height: 1.55; }
     .finding .scenario .step-explainer p { margin: 0 0 6px; }
     .finding .scenario .step-explainer p:last-child { margin-bottom: 0; }
-    .finding .scenario .step-explainer code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
+    .finding .scenario .step-explainer code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); }
     .finding .scenario .step-explainer strong { color: var(--text); font-weight: 600; }
     .finding .scenario .step-explainer em { color: var(--text); font-style: italic; }
     .finding .scenario .step-edge { color: var(--text-mut); margin-bottom: 4px; font-size: 13px; }
-    .finding .scenario .step-edge code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text); }
+    .finding .scenario .step-edge code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 11.5px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; color: var(--text); }
     .finding .scenario .step-meta { font-size: 12.5px; color: var(--text-mut); margin-top: 2px; }
     .finding .scenario .step-meta .k { display: inline; color: var(--text-dim); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 6px; }
-    .finding .scenario .step-meta code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .finding .scenario .step-meta code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; }
 
     /* Humanized Evidence section */
     .finding .evidence { margin-top: 12px; padding: 10px 12px; background: rgba(255,255,255,0.02); border: 1px solid var(--border); border-radius: 10px; }
@@ -629,15 +629,15 @@
     .finding .ev-key { color: var(--text-dim); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; white-space: nowrap; }
     .finding .ev-val { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; min-width: 0; }
     .finding .ev-val.ev-stack { flex-direction: column; align-items: stretch; gap: 6px; }
-    .finding .ev-val code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); word-break: break-all; }
+    .finding .ev-val code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); word-break: break-all; }
     .finding .ev-chip { display: inline-flex; padding: 1px 7px; border: 1px solid var(--border); border-radius: 6px; font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text); background: rgba(255,255,255,0.03); }
     .finding .ev-chip.danger { border-color: rgba(255,154,60,0.5); color: #ffb060; background: rgba(255,154,60,0.08); }
     .finding .ev-chip.wild { border-color: rgba(255,90,90,0.5); color: #ff7777; background: rgba(255,90,90,0.1); font-weight: 700; }
     .finding .ev-hints { grid-column: 2; display: grid; gap: 1px; margin-top: 2px; }
     .finding .ev-hint { font-size: 11.5px; color: var(--text-mut); padding-left: 0; }
-    .finding .ev-hint code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 11px; }
+    .finding .ev-hint code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 11px; }
     .finding .ev-sentence { font-size: 12.5px; color: var(--text); }
-    .finding .ev-sentence code { background: rgba(255,255,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 11px; }
+    .finding .ev-sentence code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 11px; }
     .finding .ev-rule { padding: 6px 8px; border: 1px solid var(--border); border-radius: 8px; background: rgba(255,255,255,0.02); display: grid; gap: 3px; }
     .finding .ev-rule-head { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; font-size: 12.5px; color: var(--text); }
     .finding .ev-rule-meta { font-size: 11.5px; color: var(--text-mut); }


### PR DESCRIPTION
## Summary

- Finding descriptions now render binding/role references with their resource Kind. The user's example — `via \`crb-nodes-proxy\` → \`cr-nodes-proxy\`` — becomes `via ClusterRoleBinding \`crb-nodes-proxy\` → ClusterRole \`cr-nodes-proxy\``, so a first-time reader can recognize the noun and `kubectl get` it directly. Namespace-scoped variants render as `RoleBinding \`team-a/rb-foo\` → Role \`team-a/r-foo\``.
- Touches the rbac analyzer only (`effectiveRule` gains four Kind/Namespace fields; new `formatBindingRef` / `formatRoleRef` helpers; nine description format strings drop their now-redundant backticks and "binding"/"role" filler). Evidence JSON is unchanged — `source_role` / `source_binding` still carry raw names for machine consumers.
- CSS pass on the embedded HTML report: inline `<code>` horizontal padding tightened from `1px 4px` to `1px 2px` (hero cluster-name `2px 6px` → `2px 4px`) so tokens like `create/update/patch` read as a single span instead of floating with visible whitespace.

## Test plan

- [x] `make test` — all packages green; new tests `TestFormatHelpersRenderKindAndNamespace` (table-driven, four Kind/namespace shapes) and `TestDescriptionsQualifyBindingAndRoleByKind` (end-to-end through `Analyze`) pass.
- [x] `make lint` — gofmt + `go vet` clean.
- [x] Built CLI, ran `kubesplaining scan --input-file testdata/snapshots/minimal-risky.json`, eyeballed `findings.json` and `report.html`. Descriptions now show `ClusterRoleBinding \`reader-role\` → ClusterRole \`reader-role\`` and the rendered HTML uses the new tighter `padding: 1px 2px` (22 occurrences, 0 of the old).
- [x] `make e2e` — not run locally (requires Docker). The e2e script greps rule IDs only, so this change shouldn't affect its assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)