### PR TITLE
Expand unit-test coverage across analyzer engine, models, and helpers

### DIFF
--- a/internal/analyzer/admission/extra_test.go
+++ b/internal/analyzer/admission/extra_test.go
@@ -1,0 +1,322 @@
+package admission
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/models"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNameReturnsModuleIdentifier(t *testing.T) {
+	t.Parallel()
+	if New().Name() != "admission" {
+		t.Errorf("Name() = %q, want admission", New().Name())
+	}
+}
+
+func TestAnalyzerEmptySnapshotProducesNoFindings(t *testing.T) {
+	t.Parallel()
+
+	got, err := New().Analyze(context.Background(), models.Snapshot{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no findings, got %v", got)
+	}
+}
+
+func TestAnalyzerValidatingWebhookFlagsSameRisks(t *testing.T) {
+	t.Parallel()
+
+	ignore := admissionregistrationv1.Ignore
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			ValidatingWebhookConfigs: []admissionregistrationv1.ValidatingWebhookConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "validator"},
+					Webhooks: []admissionregistrationv1.ValidatingWebhook{
+						{
+							Name:          "v.example",
+							FailurePolicy: &ignore,
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{""}, APIVersions: []string{"v1"},
+										Resources: []string{"pods"},
+									},
+								},
+							},
+							ObjectSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"audit": "yes"},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	mustRule(t, got, "KUBE-ADMISSION-001")
+	mustRule(t, got, "KUBE-ADMISSION-002")
+	mustRule(t, got, "KUBE-ADMISSION-003")
+}
+
+func TestAnalyzerSafeWebhookProducesNothing(t *testing.T) {
+	t.Parallel()
+
+	fail := admissionregistrationv1.Fail
+	// Webhook with FailurePolicy=Fail, no object selector, and no sensitive-namespace exemption
+	// should produce zero findings.
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			MutatingWebhookConfigs: []admissionregistrationv1.MutatingWebhookConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "safe"},
+					Webhooks: []admissionregistrationv1.MutatingWebhook{
+						{
+							Name:          "safe.example",
+							FailurePolicy: &fail,
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{""}, APIVersions: []string{"v1"},
+										Resources: []string{"pods"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no findings, got %#v", got)
+	}
+}
+
+func TestInterceptsSecurityCriticalResources(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		rules []admissionregistrationv1.RuleWithOperations
+		want  bool
+	}{
+		{
+			name: "create pods",
+			rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{Resources: []string{"pods"}}},
+			},
+			want: true,
+		},
+		{
+			name: "update deployments",
+			rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Update},
+					Rule: admissionregistrationv1.Rule{Resources: []string{"deployments"}}},
+			},
+			want: true,
+		},
+		{
+			name: "wildcard operation",
+			rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+					Rule: admissionregistrationv1.Rule{Resources: []string{"pods"}}},
+			},
+			want: true,
+		},
+		{
+			name: "wildcard resources",
+			rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{Resources: []string{"*"}}},
+			},
+			want: true,
+		},
+		{
+			name: "delete only — not security-critical for fail-open",
+			rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Delete},
+					Rule: admissionregistrationv1.Rule{Resources: []string{"pods"}}},
+			},
+			want: false,
+		},
+		{
+			name: "non-security resource",
+			rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{Resources: []string{"configmaps"}}},
+			},
+			want: false,
+		},
+		{
+			name:  "no rules",
+			rules: nil,
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := interceptsSecurityCriticalResources(tc.rules); got != tc.want {
+				t.Errorf("interceptsSecurityCriticalResources(%v) = %v, want %v", tc.rules, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectorHasBypassableObjectMatch(t *testing.T) {
+	t.Parallel()
+
+	if selectorHasBypassableObjectMatch(nil) {
+		t.Error("nil selector should be safe")
+	}
+	if selectorHasBypassableObjectMatch(&metav1.LabelSelector{}) {
+		t.Error("empty selector should be safe")
+	}
+	if !selectorHasBypassableObjectMatch(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "x"},
+	}) {
+		t.Error("matchLabels-based selector is bypassable")
+	}
+	if !selectorHasBypassableObjectMatch(&metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "k", Operator: metav1.LabelSelectorOpExists}},
+	}) {
+		t.Error("matchExpressions-based selector is bypassable")
+	}
+}
+
+func TestSelectorExcludesSensitiveNamespaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil selector", func(t *testing.T) {
+		if selectorExcludesSensitiveNamespaces(nil) {
+			t.Error("nil selector should not exclude system namespaces")
+		}
+	})
+
+	t.Run("NotIn kube-system", func(t *testing.T) {
+		got := selectorExcludesSensitiveNamespaces(&metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn,
+				Values: []string{"kube-system"},
+			}},
+		})
+		if !got {
+			t.Error("NotIn kube-system should be flagged")
+		}
+	})
+
+	t.Run("NotIn -system suffix", func(t *testing.T) {
+		got := selectorExcludesSensitiveNamespaces(&metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn,
+				Values: []string{"tigera-system"},
+			}},
+		})
+		if !got {
+			t.Error("-system suffix should be flagged")
+		}
+	})
+
+	t.Run("DoesNotExist", func(t *testing.T) {
+		got := selectorExcludesSensitiveNamespaces(&metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpDoesNotExist,
+			}},
+		})
+		if !got {
+			t.Error("DoesNotExist on metadata.name should be flagged")
+		}
+	})
+
+	t.Run("unrelated key", func(t *testing.T) {
+		got := selectorExcludesSensitiveNamespaces(&metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "team", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"},
+			}},
+		})
+		if got {
+			t.Error("non-metadata.name key should not be flagged")
+		}
+	})
+
+	t.Run("In operator does not exclude", func(t *testing.T) {
+		got := selectorExcludesSensitiveNamespaces(&metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn,
+				Values: []string{"kube-system"},
+			}},
+		})
+		if got {
+			t.Error("In operator INCLUDES kube-system, must not be flagged")
+		}
+	})
+}
+
+func TestAnalyzerDedupesRepeatedWebhookEntries(t *testing.T) {
+	t.Parallel()
+
+	ignore := admissionregistrationv1.Ignore
+	hook := admissionregistrationv1.MutatingWebhook{
+		Name: "dup.example", FailurePolicy: &ignore,
+		Rules: []admissionregistrationv1.RuleWithOperations{
+			{Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				Rule: admissionregistrationv1.Rule{Resources: []string{"pods"}}},
+		},
+	}
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			MutatingWebhookConfigs: []admissionregistrationv1.MutatingWebhookConfiguration{
+				{ObjectMeta: metav1.ObjectMeta{Name: "dup"}, Webhooks: []admissionregistrationv1.MutatingWebhook{hook, hook}},
+			},
+		},
+	}
+
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	count := 0
+	for _, f := range got {
+		if f.RuleID == "KUBE-ADMISSION-001" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicate webhooks should produce one finding, got %d", count)
+	}
+}
+
+func mustRule(t *testing.T, findings []models.Finding, ruleID string) {
+	t.Helper()
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return
+		}
+	}
+	t.Fatalf("expected rule %s, findings=%v", ruleID, findings)
+}

--- a/internal/analyzer/engine_test.go
+++ b/internal/analyzer/engine_test.go
@@ -1,0 +1,278 @@
+package analyzer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/models"
+)
+
+// stubModule lets tests construct an Engine with a known finding set and predictable behavior.
+type stubModule struct {
+	name     string
+	findings []models.Finding
+	err      error
+}
+
+func (s *stubModule) Name() string { return s.name }
+func (s *stubModule) Analyze(_ context.Context, _ models.Snapshot) ([]models.Finding, error) {
+	return s.findings, s.err
+}
+
+// engineWith builds an Engine wired with the given modules instead of the default registration.
+func engineWith(mods ...Module) *Engine {
+	return &Engine{modules: mods}
+}
+
+func TestEngineAnalyzeRunsAllModulesAndSortsBySeverity(t *testing.T) {
+	t.Parallel()
+
+	// Module A returns a Medium finding, module B a Critical one — Critical must come first.
+	a := &stubModule{
+		name: "a",
+		findings: []models.Finding{
+			{ID: "a1", RuleID: "RULE-A", Severity: models.SeverityMedium, Score: 5.0},
+		},
+	}
+	b := &stubModule{
+		name: "b",
+		findings: []models.Finding{
+			{ID: "b1", RuleID: "RULE-B", Severity: models.SeverityCritical, Score: 9.5},
+		},
+	}
+
+	got, err := engineWith(a, b).Analyze(context.Background(), models.Snapshot{}, Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d findings, want 2", len(got))
+	}
+	if got[0].Severity != models.SeverityCritical {
+		t.Errorf("expected Critical first, got %s", got[0].Severity)
+	}
+}
+
+func TestEngineSortBreaksTiesByScoreThenRuleIDThenTitle(t *testing.T) {
+	t.Parallel()
+
+	mod := &stubModule{
+		name: "mod",
+		findings: []models.Finding{
+			{ID: "1", RuleID: "RULE-Z", Title: "z", Severity: models.SeverityHigh, Score: 7.0},
+			{ID: "2", RuleID: "RULE-A", Title: "a", Severity: models.SeverityHigh, Score: 7.0},
+			{ID: "3", RuleID: "RULE-A", Title: "a-aaa", Severity: models.SeverityHigh, Score: 7.5},
+		},
+	}
+
+	got, err := engineWith(mod).Analyze(context.Background(), models.Snapshot{}, Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	// Highest score first, then RuleID asc, then Title asc.
+	if got[0].ID != "3" || got[1].ID != "2" || got[2].ID != "1" {
+		t.Errorf("sort order wrong: got %v", []string{got[0].ID, got[1].ID, got[2].ID})
+	}
+}
+
+func TestEngineThresholdFiltersBelowSeverity(t *testing.T) {
+	t.Parallel()
+
+	mod := &stubModule{
+		name: "mod",
+		findings: []models.Finding{
+			{ID: "low", RuleID: "R-LOW", Severity: models.SeverityLow},
+			{ID: "med", RuleID: "R-MED", Severity: models.SeverityMedium},
+			{ID: "high", RuleID: "R-HIGH", Severity: models.SeverityHigh},
+		},
+	}
+
+	got, err := engineWith(mod).Analyze(context.Background(), models.Snapshot{}, Options{Threshold: models.SeverityMedium})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 findings (medium+high), got %d", len(got))
+	}
+	for _, f := range got {
+		if f.Severity == models.SeverityLow {
+			t.Errorf("low severity finding %q should be filtered out", f.ID)
+		}
+	}
+}
+
+func TestEngineOnlyModulesSelectsSubset(t *testing.T) {
+	t.Parallel()
+
+	a := &stubModule{name: "a", findings: []models.Finding{{ID: "a1", RuleID: "A", Severity: models.SeverityHigh}}}
+	b := &stubModule{name: "b", findings: []models.Finding{{ID: "b1", RuleID: "B", Severity: models.SeverityHigh}}}
+
+	got, err := engineWith(a, b).Analyze(context.Background(), models.Snapshot{}, Options{OnlyModules: []string{"a"}})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "a1" {
+		t.Fatalf("OnlyModules=[a] should keep only module a, got %#v", got)
+	}
+}
+
+func TestEngineSkipModulesExcludesSubset(t *testing.T) {
+	t.Parallel()
+
+	a := &stubModule{name: "a", findings: []models.Finding{{ID: "a1", RuleID: "A", Severity: models.SeverityHigh}}}
+	b := &stubModule{name: "b", findings: []models.Finding{{ID: "b1", RuleID: "B", Severity: models.SeverityHigh}}}
+
+	got, err := engineWith(a, b).Analyze(context.Background(), models.Snapshot{}, Options{SkipModules: []string{"b"}})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "a1" {
+		t.Fatalf("SkipModules=[b] should drop module b, got %#v", got)
+	}
+}
+
+func TestEngineNoSelectedModulesReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &stubModule{name: "a"}
+	_, err := engineWith(a).Analyze(context.Background(), models.Snapshot{}, Options{OnlyModules: []string{"nonexistent"}})
+	if err == nil {
+		t.Fatal("expected error when no modules are selected")
+	}
+	if !strings.Contains(err.Error(), "no analysis modules selected") {
+		t.Errorf("error message = %q, want it to mention no modules", err.Error())
+	}
+}
+
+func TestEngineSurfacesFirstModuleError(t *testing.T) {
+	t.Parallel()
+
+	// Engine still returns findings from the healthy modules but reports the first error.
+	a := &stubModule{name: "a", err: errors.New("a-broke")}
+	b := &stubModule{name: "b", findings: []models.Finding{{ID: "b1", RuleID: "B", Severity: models.SeverityHigh}}}
+
+	got, err := engineWith(a, b).Analyze(context.Background(), models.Snapshot{}, Options{})
+	if err == nil {
+		t.Fatal("expected first-module error to surface")
+	}
+	if !strings.Contains(err.Error(), "a-broke") {
+		t.Errorf("error %q should wrap module's error", err.Error())
+	}
+	if len(got) != 1 || got[0].ID != "b1" {
+		t.Errorf("healthy module's findings should still surface: %#v", got)
+	}
+}
+
+func TestEngineDedupesAcrossModulesAndKeepsHigherScore(t *testing.T) {
+	t.Parallel()
+
+	subject := &models.SubjectRef{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"}
+	resource := &models.ResourceRef{Kind: "RBACRule", Name: "danger"}
+
+	// Both modules emit the same logical finding; dedupe should keep the higher score and union tags.
+	a := &stubModule{name: "a", findings: []models.Finding{
+		{ID: "a", RuleID: "DUP", Severity: models.SeverityHigh, Score: 7.0, Subject: subject, Resource: resource, Tags: []string{"module:a"}},
+	}}
+	b := &stubModule{name: "b", findings: []models.Finding{
+		{ID: "b", RuleID: "DUP", Severity: models.SeverityHigh, Score: 8.5, Subject: subject, Resource: resource, Tags: []string{"module:b"}},
+	}}
+
+	got, err := engineWith(a, b).Analyze(context.Background(), models.Snapshot{}, Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding after dedupe, got %d", len(got))
+	}
+	if got[0].Score != 8.5 {
+		t.Errorf("expected highest score kept, got %v", got[0].Score)
+	}
+	tags := got[0].Tags
+	hasA, hasB := false, false
+	for _, tag := range tags {
+		if tag == "module:a" {
+			hasA = true
+		}
+		if tag == "module:b" {
+			hasB = true
+		}
+	}
+	if !hasA || !hasB {
+		t.Errorf("expected merged tags, got %v", tags)
+	}
+}
+
+func TestEngineCorrelatesPrivescChainsIntoOtherFindings(t *testing.T) {
+	t.Parallel()
+
+	subject := &models.SubjectRef{Kind: "ServiceAccount", Namespace: "ns", Name: "bad"}
+
+	// privesc module emits a CRITICAL chain finding; rbac module emits a HIGH-score finding for the same subject.
+	// After correlate(), the rbac finding should pick up a +2.0 chain bump and the chain:amplified tag.
+	privesc := &stubModule{name: "privesc", findings: []models.Finding{
+		{
+			ID: "p", RuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity:       models.SeverityCritical,
+			Score:          9.5,
+			Subject:        subject,
+			EscalationPath: []models.EscalationHop{{Step: 1, Action: "wildcard"}},
+		},
+	}}
+	rbac := &stubModule{name: "rbac", findings: []models.Finding{
+		{ID: "r", RuleID: "KUBE-RBAC-OVERBROAD-001", Severity: models.SeverityHigh, Score: 7.0, Subject: subject},
+	}}
+
+	got, err := engineWith(privesc, rbac).Analyze(context.Background(), models.Snapshot{}, Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	var amplified *models.Finding
+	for i := range got {
+		if got[i].ID == "r" {
+			amplified = &got[i]
+		}
+	}
+	if amplified == nil {
+		t.Fatal("expected the rbac finding to survive the engine pipeline")
+	}
+	if amplified.Score != 9.0 {
+		t.Errorf("expected +2.0 chain bump from CRITICAL sink (7.0 → 9.0), got %v", amplified.Score)
+	}
+	hasChainTag := false
+	for _, tag := range amplified.Tags {
+		if tag == "chain:amplified" {
+			hasChainTag = true
+		}
+	}
+	if !hasChainTag {
+		t.Errorf("expected chain:amplified tag, got %v", amplified.Tags)
+	}
+}
+
+func TestNewWithConfigOverridesPrivescDepth(t *testing.T) {
+	t.Parallel()
+
+	eng := NewWithConfig(Config{MaxPrivescDepth: 9})
+
+	// Confirm the default registration includes a privesc module and that its MaxDepth has been applied.
+	found := false
+	for _, mod := range eng.modules {
+		if mod.Name() == "privesc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("default engine missing privesc module")
+	}
+}
+
+func TestNewReturnsNonNilEngine(t *testing.T) {
+	t.Parallel()
+	if New() == nil {
+		t.Fatal("New() returned nil")
+	}
+}

--- a/internal/analyzer/podsec/extra_test.go
+++ b/internal/analyzer/podsec/extra_test.go
@@ -1,0 +1,418 @@
+package podsec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/models"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNameReturnsModuleIdentifier(t *testing.T) {
+	t.Parallel()
+	if New().Name() != "podsec" {
+		t.Errorf("Name() = %q, want podsec", New().Name())
+	}
+}
+
+func TestSeverityForScoreBuckets(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		score float64
+		want  models.Severity
+	}{
+		{10, models.SeverityCritical},
+		{9.0, models.SeverityCritical},
+		{8.5, models.SeverityHigh},
+		{7.0, models.SeverityHigh},
+		{6.0, models.SeverityMedium},
+		{4.0, models.SeverityMedium},
+		{3.5, models.SeverityLow},
+		{2.0, models.SeverityLow},
+		{1.0, models.SeverityInfo},
+		{0, models.SeverityInfo},
+	}
+	for _, tc := range cases {
+		if got := severityForScore(tc.score); got != tc.want {
+			t.Errorf("severityForScore(%v) = %v, want %v", tc.score, got, tc.want)
+		}
+	}
+}
+
+func TestResourceAPIGroupForKnownKinds(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"Deployment":  appsv1.GroupName,
+		"DaemonSet":   appsv1.GroupName,
+		"StatefulSet": appsv1.GroupName,
+		"Job":         batchv1.GroupName,
+		"CronJob":     batchv1.GroupName,
+		"Pod":         "",
+		"Unknown":     "",
+	}
+	for kind, want := range cases {
+		if got := resourceAPIGroup(kind); got != want {
+			t.Errorf("resourceAPIGroup(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestUsesLatestTagVariants(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"nginx", true},                  // no tag
+		{"nginx:latest", true},           // explicit latest
+		{"nginx:1.25", false},            // pinned tag
+		{"nginx@sha256:deadbeef", false}, // digest
+		{"registry.io/nginx:1", false},
+		{"registry.io/nginx:latest", true},
+	}
+	for _, tc := range cases {
+		if got := usesLatestTag(tc.image); got != tc.want {
+			t.Errorf("usesLatestTag(%q) = %v, want %v", tc.image, got, tc.want)
+		}
+	}
+}
+
+func TestRunsAsRootDetectsPodAndContainerSettings(t *testing.T) {
+	t.Parallel()
+
+	zero := int64(0)
+	nonzero := int64(1000)
+	falseVal := false
+	trueVal := true
+
+	t.Run("container UID 0", func(t *testing.T) {
+		got := runsAsRoot(corev1.PodSpec{}, corev1.Container{
+			SecurityContext: &corev1.SecurityContext{RunAsUser: &zero},
+		})
+		if !got {
+			t.Error("RunAsUser=0 should be detected as root")
+		}
+	})
+
+	t.Run("container RunAsNonRoot=false", func(t *testing.T) {
+		got := runsAsRoot(corev1.PodSpec{}, corev1.Container{
+			SecurityContext: &corev1.SecurityContext{RunAsNonRoot: &falseVal},
+		})
+		if !got {
+			t.Error("container.RunAsNonRoot=false should be detected as root")
+		}
+	})
+
+	t.Run("pod-level UID 0 propagates", func(t *testing.T) {
+		got := runsAsRoot(corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{RunAsUser: &zero},
+		}, corev1.Container{})
+		if !got {
+			t.Error("pod-level RunAsUser=0 should be detected as root")
+		}
+	})
+
+	t.Run("pod-level RunAsNonRoot=false", func(t *testing.T) {
+		got := runsAsRoot(corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: &falseVal},
+		}, corev1.Container{})
+		if !got {
+			t.Error("pod-level RunAsNonRoot=false should be detected as root")
+		}
+	})
+
+	t.Run("non-root explicit", func(t *testing.T) {
+		got := runsAsRoot(corev1.PodSpec{}, corev1.Container{
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:    &nonzero,
+				RunAsNonRoot: &trueVal,
+			},
+		})
+		if got {
+			t.Error("UID 1000 + RunAsNonRoot=true should not be flagged as root")
+		}
+	})
+}
+
+func TestIsControlledPodDetectsOwnerReferences(t *testing.T) {
+	t.Parallel()
+
+	yes := true
+	no := false
+
+	if !isControlledPod(metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Name: "rs", Controller: &yes}},
+	}) {
+		t.Error("expected controller-owned pod to be detected")
+	}
+
+	if isControlledPod(metav1.ObjectMeta{}) {
+		t.Error("bare pod should not be detected as controlled")
+	}
+
+	// Owner reference with Controller=false should not count.
+	if isControlledPod(metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Controller: &no}},
+	}) {
+		t.Error("non-controller OwnerReference should not count")
+	}
+}
+
+func TestAnalyzerSkipsControllerOwnedPodsToAvoidDoubleCounting(t *testing.T) {
+	t.Parallel()
+
+	yes := true
+	privileged := true
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "owned", Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Controller: &yes}},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "nginx@sha256:abc",
+								SecurityContext: &corev1.SecurityContext{Privileged: &privileged}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	for _, f := range findings {
+		if f.RuleID == "KUBE-ESCAPE-001" {
+			t.Errorf("controller-owned pod should be skipped; got privileged finding %#v", f)
+		}
+	}
+}
+
+func TestAnalyzerEmitsHostPIDAndHostIPC(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "shared-ns", Namespace: "default"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								HostPID:            true,
+								HostIPC:            true,
+								ServiceAccountName: "custom",
+								Containers: []corev1.Container{
+									{Name: "c", Image: "nginx@sha256:abc",
+										SecurityContext: &corev1.SecurityContext{
+											AllowPrivilegeEscalation: ptrBool(false),
+											RunAsNonRoot:             ptrBool(true),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	mustHaveRule(t, got, "KUBE-ESCAPE-002") // hostPID
+	mustHaveRule(t, got, "KUBE-ESCAPE-004") // hostIPC
+}
+
+func TestAnalyzerHostPathVariants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		path   string
+		ruleID string
+	}{
+		{"/var/run/docker.sock", "KUBE-ESCAPE-005"},
+		{"/var/run/containerd/containerd.sock", "KUBE-CONTAINERD-SOCKET-001"},
+		{"/var/log", "KUBE-ESCAPE-008"},
+		{"/etc/kubernetes", "KUBE-HOSTPATH-001"}, // generic path
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			snapshot := models.Snapshot{
+				Resources: models.SnapshotResources{
+					Pods: []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+							Spec: corev1.PodSpec{
+								ServiceAccountName: "custom",
+								Containers: []corev1.Container{
+									{Name: "c", Image: "nginx@sha256:abc",
+										SecurityContext: &corev1.SecurityContext{
+											AllowPrivilegeEscalation: ptrBool(false),
+											RunAsNonRoot:             ptrBool(true),
+										}},
+								},
+								Volumes: []corev1.Volume{
+									{Name: "v", VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{Path: tc.path},
+									}},
+								},
+							},
+						},
+					},
+				},
+			}
+			got, err := New().Analyze(context.Background(), snapshot)
+			if err != nil {
+				t.Fatalf("Analyze: %v", err)
+			}
+			mustHaveRule(t, got, tc.ruleID)
+		})
+	}
+}
+
+func TestAnalyzerEmitsRunAsRootForRoot(t *testing.T) {
+	t.Parallel()
+
+	zero := int64(0)
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rooty", Namespace: "ns"},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "custom",
+						Containers: []corev1.Container{
+							{Name: "c", Image: "nginx@sha256:abc",
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptrBool(false),
+									RunAsUser:                &zero,
+								}},
+						},
+					},
+				},
+			},
+		},
+	}
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	mustHaveRule(t, got, "KUBE-PODSEC-ROOT-001")
+}
+
+func TestAnalyzerSkipsDefaultSAFinding_ForKubeNamespace(t *testing.T) {
+	t.Parallel()
+
+	// Pods using "default" SA inside a kube- namespace should not produce KUBE-SA-DEFAULT-001
+	// (system pods routinely use the default SA and the rule explicitly excludes them).
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube-pod", Namespace: "kube-system"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "nginx@sha256:abc",
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptrBool(false),
+									RunAsNonRoot:             ptrBool(true),
+								}},
+						},
+					},
+				},
+			},
+		},
+	}
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	for _, f := range got {
+		if f.RuleID == "KUBE-SA-DEFAULT-001" {
+			t.Error("expected KUBE-SA-DEFAULT-001 to be suppressed in kube-system namespace")
+		}
+	}
+}
+
+func TestAnalyzerCoversAllWorkloadKinds(t *testing.T) {
+	t.Parallel()
+
+	// One privileged container per workload kind. Each should produce its own KUBE-ESCAPE-001 finding.
+	priv := true
+	pod := corev1.PodSpec{
+		ServiceAccountName: "custom",
+		Containers: []corev1.Container{
+			{Name: "c", Image: "nginx@sha256:abc",
+				SecurityContext: &corev1.SecurityContext{Privileged: &priv}},
+		},
+	}
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Deployments: []appsv1.Deployment{
+				{ObjectMeta: metav1.ObjectMeta{Name: "d", Namespace: "ns"},
+					Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: pod}}},
+			},
+			DaemonSets: []appsv1.DaemonSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ds", Namespace: "ns"},
+					Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: pod}}},
+			},
+			StatefulSets: []appsv1.StatefulSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "sts", Namespace: "ns"},
+					Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: pod}}},
+			},
+			Jobs: []batchv1.Job{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "ns"},
+					Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: pod}}},
+			},
+			CronJobs: []batchv1.CronJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "cj", Namespace: "ns"},
+					Spec: batchv1.CronJobSpec{
+						JobTemplate: batchv1.JobTemplateSpec{
+							Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: pod}},
+						},
+					}},
+			},
+		},
+	}
+
+	got, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	count := 0
+	for _, f := range got {
+		if f.RuleID == "KUBE-ESCAPE-001" {
+			count++
+		}
+	}
+	if count != 5 {
+		t.Errorf("expected 5 KUBE-ESCAPE-001 findings (one per workload kind), got %d", count)
+	}
+}
+
+func ptrBool(v bool) *bool { return &v }
+
+func mustHaveRule(t *testing.T, findings []models.Finding, ruleID string) {
+	t.Helper()
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return
+		}
+	}
+	t.Fatalf("expected rule %s, findings=%v", ruleID, findings)
+}

--- a/internal/collector/io_test.go
+++ b/internal/collector/io_test.go
@@ -1,0 +1,92 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWriteAndReadSnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "snapshot.json")
+
+	snap := models.NewSnapshot()
+	snap.Metadata.ClusterName = "test-cluster"
+	snap.Metadata.CollectionWarnings = []string{"limited list permissions"}
+	snap.Resources.Namespaces = []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+	}
+	snap.Resources.Roles = []rbacv1.Role{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "reader", Namespace: "default"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+			},
+		},
+	}
+	snap.Resources.SecretsMetadata = []models.SecretMetadata{
+		{Name: "tls", Namespace: "default", Type: corev1.SecretTypeTLS},
+	}
+
+	if err := WriteSnapshot(path, snap); err != nil {
+		t.Fatalf("WriteSnapshot: %v", err)
+	}
+
+	// File exists and parent dirs were created.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("snapshot file not written: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("snapshot file is empty")
+	}
+
+	got, err := ReadSnapshot(path)
+	if err != nil {
+		t.Fatalf("ReadSnapshot: %v", err)
+	}
+	if got.Metadata.ClusterName != "test-cluster" {
+		t.Errorf("cluster name not preserved: %q", got.Metadata.ClusterName)
+	}
+	if len(got.Resources.Namespaces) != 2 {
+		t.Errorf("namespaces count = %d, want 2", len(got.Resources.Namespaces))
+	}
+	if len(got.Resources.Roles) != 1 || got.Resources.Roles[0].Rules[0].Resources[0] != "pods" {
+		t.Errorf("roles not preserved: %#v", got.Resources.Roles)
+	}
+	if len(got.Resources.SecretsMetadata) != 1 || got.Resources.SecretsMetadata[0].Type != corev1.SecretTypeTLS {
+		t.Errorf("secret metadata not preserved: %#v", got.Resources.SecretsMetadata)
+	}
+}
+
+func TestReadSnapshotMissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := ReadSnapshot(filepath.Join(t.TempDir(), "nope.json"))
+	if err == nil {
+		t.Fatal("expected error for missing snapshot file")
+	}
+}
+
+func TestReadSnapshotInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("seed broken file: %v", err)
+	}
+
+	_, err := ReadSnapshot(path)
+	if err == nil {
+		t.Fatal("expected decode error for malformed JSON")
+	}
+}

--- a/internal/exclusions/extra_test.go
+++ b/internal/exclusions/extra_test.go
@@ -1,0 +1,385 @@
+package exclusions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/collector"
+	"github.com/hardik/kubesplaining/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPresetMinimal(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Preset("minimal")
+	if err != nil {
+		t.Fatalf("Preset(minimal): %v", err)
+	}
+	if len(cfg.Global.ExcludeNamespaces) == 0 {
+		t.Error("minimal preset should still exclude some namespaces")
+	}
+	// Minimal must not include kube-system (the standard preset's broader sweep).
+	for _, ns := range cfg.Global.ExcludeNamespaces {
+		if ns == "kube-system" {
+			t.Errorf("minimal preset should not exclude kube-system, got %v", cfg.Global.ExcludeNamespaces)
+		}
+	}
+}
+
+func TestPresetUnsupportedReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := Preset("aggressive")
+	if err == nil {
+		t.Fatal("expected error for unsupported preset")
+	}
+	if !strings.Contains(err.Error(), "aggressive") {
+		t.Errorf("error should name the bad preset, got %q", err.Error())
+	}
+}
+
+func TestLoadAndWriteRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "exclusions.yaml")
+
+	original := Config{
+		Global: GlobalConfig{
+			ExcludeNamespaces: []string{"team-a", "team-b"},
+			ExcludeFindingIDs: []string{"KUBE-NETPOL-*"},
+			ExcludeSubjects: []SubjectExclusion{
+				{Kind: "ServiceAccount", Namespace: "platform", Name: "controller", Reason: "owned by platform"},
+			},
+		},
+		PodSecurity: PodSecurityConfig{
+			ExcludeChecks: []CheckExclusion{
+				{Check: "hostNetwork", Namespace: "monitoring"},
+			},
+		},
+	}
+
+	if err := Write(path, original); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(got.Global.ExcludeNamespaces) != 2 || got.Global.ExcludeNamespaces[0] != "team-a" {
+		t.Errorf("ExcludeNamespaces not round-tripped: %#v", got.Global.ExcludeNamespaces)
+	}
+	if len(got.Global.ExcludeSubjects) != 1 || got.Global.ExcludeSubjects[0].Reason != "owned by platform" {
+		t.Errorf("ExcludeSubjects not round-tripped: %#v", got.Global.ExcludeSubjects)
+	}
+	if len(got.PodSecurity.ExcludeChecks) != 1 || got.PodSecurity.ExcludeChecks[0].Check != "hostNetwork" {
+		t.Errorf("ExcludeChecks not round-tripped: %#v", got.PodSecurity.ExcludeChecks)
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadInvalidYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte("global: [not-a-map"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected parse error for malformed YAML")
+	}
+}
+
+func TestEnrichFromSnapshotAddsSystemNamespaces(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snap.json")
+
+	snap := models.NewSnapshot()
+	snap.Resources.Namespaces = []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},    // already excluded; should dedupe
+		{ObjectMeta: metav1.ObjectMeta{Name: "kube-flannel"}},   // kube- prefix → auto-add
+		{ObjectMeta: metav1.ObjectMeta{Name: "tigera-system"}},  // -system suffix → auto-add
+		{ObjectMeta: metav1.ObjectMeta{Name: "user-namespace"}}, // neither → leave alone
+	}
+	if err := collector.WriteSnapshot(path, snap); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	cfg, err := Preset("standard")
+	if err != nil {
+		t.Fatalf("Preset(standard): %v", err)
+	}
+	enriched, err := EnrichFromSnapshot(cfg, path)
+	if err != nil {
+		t.Fatalf("EnrichFromSnapshot: %v", err)
+	}
+
+	mustContain(t, enriched.Global.ExcludeNamespaces, "kube-flannel")
+	mustContain(t, enriched.Global.ExcludeNamespaces, "tigera-system")
+	mustNotContain(t, enriched.Global.ExcludeNamespaces, "user-namespace")
+	mustNotContain(t, enriched.Global.ExcludeNamespaces, "default")
+
+	// kube-system was already there and should not be duplicated.
+	count := 0
+	for _, ns := range enriched.Global.ExcludeNamespaces {
+		if ns == "kube-system" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("kube-system should appear exactly once, got %d (%v)", count, enriched.Global.ExcludeNamespaces)
+	}
+}
+
+func TestEnrichFromSnapshotEmptyPathIsNoop(t *testing.T) {
+	t.Parallel()
+
+	cfg, _ := Preset("standard")
+	got, err := EnrichFromSnapshot(cfg, "")
+	if err != nil {
+		t.Fatalf("EnrichFromSnapshot(\"\"): %v", err)
+	}
+	if len(got.Global.ExcludeNamespaces) != len(cfg.Global.ExcludeNamespaces) {
+		t.Errorf("empty path should leave config unchanged")
+	}
+}
+
+func TestEnrichFromSnapshotMissingFileError(t *testing.T) {
+	t.Parallel()
+
+	cfg, _ := Preset("standard")
+	_, err := EnrichFromSnapshot(cfg, filepath.Join(t.TempDir(), "missing.json"))
+	if err == nil {
+		t.Fatal("expected error for missing snapshot")
+	}
+}
+
+func TestMatchRBACSubjectScopedToModule(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		RBAC: RBACConfig{
+			ExcludeSubjects: []SubjectExclusion{
+				{Kind: "ServiceAccount", Namespace: "kube-*", Name: "*", Reason: "system SAs"},
+			},
+		},
+	}
+
+	// Match: tagged module:rbac and matches the subject pattern.
+	matched := models.Finding{
+		ID: "f", RuleID: "KUBE-RBAC-OVERBROAD-001",
+		Subject: &models.SubjectRef{Kind: "ServiceAccount", Namespace: "kube-system", Name: "controller"},
+		Tags:    []string{"module:rbac"},
+	}
+	got := Match(cfg, matched)
+	if !got.Matched {
+		t.Errorf("expected match for module:rbac subject, got reason=%q", got.Reason)
+	}
+	if got.Reason != "system SAs" {
+		t.Errorf("reason = %q, want 'system SAs'", got.Reason)
+	}
+
+	// Skipped: not tagged module:rbac → matchesRBAC must short-circuit.
+	other := matched
+	other.Tags = []string{"module:secrets"}
+	if Match(cfg, other).Matched {
+		t.Error("non-rbac module finding should not be matched by RBACConfig")
+	}
+
+	// Mismatched namespace → no match.
+	wrongNs := matched
+	wrongNs.Subject = &models.SubjectRef{Kind: "ServiceAccount", Namespace: "team-a", Name: "controller"}
+	if Match(cfg, wrongNs).Matched {
+		t.Error("wrong namespace should not match RBAC pattern")
+	}
+}
+
+func TestMatchRBACDefaultReason(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		RBAC: RBACConfig{
+			ExcludeSubjects: []SubjectExclusion{
+				{Kind: "User", Name: "alice"}, // no Reason — falls back to default.
+			},
+		},
+	}
+	finding := models.Finding{
+		ID: "f", RuleID: "KUBE-RBAC-OVERBROAD-001",
+		Subject: &models.SubjectRef{Kind: "User", Name: "alice"},
+		Tags:    []string{"module:rbac"},
+	}
+
+	got := Match(cfg, finding)
+	if got.Reason != "matched rbac.exclude_subjects" {
+		t.Errorf("expected default reason, got %q", got.Reason)
+	}
+}
+
+func TestMatchPodSecurityWorkloadByPattern(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		PodSecurity: PodSecurityConfig{
+			ExcludeWorkloads: []WorkloadExclusion{
+				{Kind: "Deployment", Namespace: "monitoring", NamePattern: "prometheus-*", Reason: "monitoring exception"},
+			},
+		},
+	}
+
+	finding := models.Finding{
+		ID: "f", RuleID: "KUBE-ESCAPE-003",
+		Resource: &models.ResourceRef{Kind: "Deployment", Namespace: "monitoring", Name: "prometheus-server"},
+		Tags:     []string{"module:pod_security"},
+	}
+
+	got := Match(cfg, finding)
+	if !got.Matched {
+		t.Fatalf("expected workload pattern match, reason=%q", got.Reason)
+	}
+	if got.Reason != "monitoring exception" {
+		t.Errorf("reason = %q", got.Reason)
+	}
+}
+
+func TestMatchPodSecurityWorkloadKindMismatch(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		PodSecurity: PodSecurityConfig{
+			ExcludeWorkloads: []WorkloadExclusion{
+				{Kind: "Deployment", Name: "prometheus"},
+			},
+		},
+	}
+	finding := models.Finding{
+		ID: "f", RuleID: "KUBE-ESCAPE-003",
+		Resource: &models.ResourceRef{Kind: "DaemonSet", Name: "prometheus"},
+		Tags:     []string{"module:pod_security"},
+	}
+
+	if Match(cfg, finding).Matched {
+		t.Error("DaemonSet should not be matched by Deployment-scoped exclusion")
+	}
+}
+
+func TestMatchPodSecurityCheckByRuleID(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		PodSecurity: PodSecurityConfig{
+			ExcludeChecks: []CheckExclusion{
+				{Check: "KUBE-ESCAPE-003", Namespace: "monitoring", Reason: "host net OK in monitoring"},
+			},
+		},
+	}
+	finding := models.Finding{
+		ID: "f", RuleID: "KUBE-ESCAPE-003", Namespace: "monitoring",
+		Tags: []string{"module:pod_security"},
+	}
+
+	got := Match(cfg, finding)
+	if !got.Matched || got.Reason != "host net OK in monitoring" {
+		t.Errorf("expected RuleID-based check match, got matched=%v reason=%q", got.Matched, got.Reason)
+	}
+}
+
+func TestMatchNetworkPolicyByNamespace(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		NetworkPolicy: NetworkPolicyConfig{
+			ExcludeNamespaces: []string{"team-*"},
+		},
+	}
+
+	matched := models.Finding{
+		ID: "f", RuleID: "KUBE-NETPOL-COVERAGE-001",
+		Namespace: "team-a",
+		Tags:      []string{"module:network_policy"},
+	}
+	if !Match(cfg, matched).Matched {
+		t.Error("expected network namespace match")
+	}
+
+	// Wrong module tag → must not be matched by NetworkPolicyConfig.
+	notNetwork := matched
+	notNetwork.Tags = []string{"module:rbac"}
+	if Match(cfg, notNetwork).Matched {
+		t.Error("non-network module should not be matched by NetworkPolicyConfig")
+	}
+}
+
+func TestMatchPodSecurityCheckEmptyCheckSkipped(t *testing.T) {
+	t.Parallel()
+
+	// An empty Check field is treated as "no check" and must not produce false positives.
+	cfg := Config{
+		PodSecurity: PodSecurityConfig{
+			ExcludeChecks: []CheckExclusion{{Namespace: "default"}},
+		},
+	}
+	finding := models.Finding{
+		ID: "f", RuleID: "KUBE-ESCAPE-003", Namespace: "default",
+		Tags: []string{"module:pod_security"},
+	}
+	if Match(cfg, finding).Matched {
+		t.Error("empty Check should not match anything")
+	}
+}
+
+func TestMatchesPatternEmptyOperands(t *testing.T) {
+	t.Parallel()
+
+	// Both operands matter; the matcher must reject empty strings on either side.
+	if matchesPattern("", "anything") {
+		t.Error("empty pattern should never match")
+	}
+	if matchesPattern("anything", "") {
+		t.Error("empty candidate should never match")
+	}
+	if !matchesPattern("foo", "foo") {
+		t.Error("exact equality should match")
+	}
+	if !matchesPattern("foo-*", "foo-bar") {
+		t.Error("glob should match")
+	}
+}
+
+func mustContain(t *testing.T, haystack []string, needle string) {
+	t.Helper()
+	for _, x := range haystack {
+		if x == needle {
+			return
+		}
+	}
+	t.Errorf("expected %q in %v", needle, haystack)
+}
+
+func mustNotContain(t *testing.T, haystack []string, needle string) {
+	t.Helper()
+	for _, x := range haystack {
+		if x == needle {
+			t.Errorf("did not expect %q in %v", needle, haystack)
+			return
+		}
+	}
+}

--- a/internal/manifest/loader_test.go
+++ b/internal/manifest/loader_test.go
@@ -1,6 +1,10 @@
 package manifest
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestLoadSnapshotFromManifestFile(t *testing.T) {
 	t.Parallel()
@@ -22,4 +26,233 @@ func TestLoadSnapshotFromManifestFile(t *testing.T) {
 	if len(snapshot.Resources.MutatingWebhookConfigs) != 1 {
 		t.Fatalf("expected 1 mutating webhook config, got %d", len(snapshot.Resources.MutatingWebhookConfigs))
 	}
+}
+
+func TestLoadSnapshotMultiDocumentYAML(t *testing.T) {
+	t.Parallel()
+
+	doc := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployer
+  namespace: team-a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader
+  namespace: team-a
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rb
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: deployer
+    namespace: team-a
+---
+# A blank document and pure-comment document should be tolerated.
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+  namespace: team-a
+spec:
+  containers:
+    - name: c
+      image: nginx:latest
+`
+	path := writeTemp(t, "multi.yaml", doc)
+	snap, err := LoadSnapshot(path, "")
+	if err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+
+	if len(snap.Resources.Namespaces) != 1 {
+		t.Errorf("namespaces = %d, want 1", len(snap.Resources.Namespaces))
+	}
+	if len(snap.Resources.ServiceAccounts) != 1 {
+		t.Errorf("service_accounts = %d, want 1", len(snap.Resources.ServiceAccounts))
+	}
+	if len(snap.Resources.Roles) != 1 {
+		t.Errorf("roles = %d, want 1", len(snap.Resources.Roles))
+	}
+	if len(snap.Resources.RoleBindings) != 1 {
+		t.Errorf("role_bindings = %d, want 1", len(snap.Resources.RoleBindings))
+	}
+	if len(snap.Resources.Pods) != 1 {
+		t.Errorf("pods = %d, want 1", len(snap.Resources.Pods))
+	}
+	if snap.Metadata.ClusterName != "manifest-scan" {
+		t.Errorf("ClusterName = %q, want manifest-scan", snap.Metadata.ClusterName)
+	}
+}
+
+func TestLoadSnapshotListWrapper(t *testing.T) {
+	t.Parallel()
+
+	doc := `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-1
+      namespace: default
+    data:
+      foo: bar
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tls
+      namespace: default
+      labels:
+        app: web
+    type: kubernetes.io/tls
+`
+	path := writeTemp(t, "list.yaml", doc)
+	snap, err := LoadSnapshot(path, "")
+	if err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+
+	if len(snap.Resources.ConfigMaps) != 1 || snap.Resources.ConfigMaps[0].Data["foo"] != "bar" {
+		t.Errorf("ConfigMap data not preserved: %#v", snap.Resources.ConfigMaps)
+	}
+	if len(snap.Resources.SecretsMetadata) != 1 {
+		t.Fatalf("secrets metadata = %d, want 1", len(snap.Resources.SecretsMetadata))
+	}
+	sec := snap.Resources.SecretsMetadata[0]
+	if sec.Labels["app"] != "web" {
+		t.Errorf("secret labels not preserved: %#v", sec.Labels)
+	}
+	if string(sec.Type) != "kubernetes.io/tls" {
+		t.Errorf("secret type not preserved: %q", sec.Type)
+	}
+}
+
+func TestLoadSnapshotResourceTypeHint(t *testing.T) {
+	t.Parallel()
+
+	// A bare manifest with no `kind` field should be classified using the hint.
+	doc := `apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-admin-clone
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+`
+	path := writeTemp(t, "bare.yaml", doc)
+	snap, err := LoadSnapshot(path, "ClusterRole")
+	if err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+	if len(snap.Resources.ClusterRoles) != 1 {
+		t.Errorf("hint should classify as ClusterRole, got %#v", snap.Resources.ClusterRoles)
+	}
+}
+
+func TestLoadSnapshotUnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	doc := `apiVersion: example.com/v1
+kind: Frobnicator
+metadata:
+  name: x
+`
+	path := writeTemp(t, "frob.yaml", doc)
+	_, err := LoadSnapshot(path, "")
+	if err == nil {
+		t.Fatal("expected error for unsupported kind")
+	}
+}
+
+func TestLoadSnapshotMissingKindWithoutHint(t *testing.T) {
+	t.Parallel()
+
+	doc := `apiVersion: v1
+metadata:
+  name: anonymous
+`
+	path := writeTemp(t, "headerless.yaml", doc)
+	_, err := LoadSnapshot(path, "")
+	if err == nil {
+		t.Fatal("expected error when no kind and no hint")
+	}
+}
+
+func TestLoadSnapshotFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadSnapshot(filepath.Join(t.TempDir(), "no.yaml"), "")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadSnapshotInvalidYAML(t *testing.T) {
+	t.Parallel()
+
+	path := writeTemp(t, "bad.yaml", "kind: Pod\nmetadata: { not-balanced")
+	_, err := LoadSnapshot(path, "")
+	if err == nil {
+		t.Fatal("expected decode error for malformed YAML")
+	}
+}
+
+func TestKindFromHintCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"role":                           "Role",
+		"ClusterRole":                    "ClusterRole",
+		"ROLEBINDING":                    "RoleBinding",
+		"clusterrolebinding":             "ClusterRoleBinding",
+		"pod":                            "Pod",
+		"service":                        "Service",
+		"deployment":                     "Deployment",
+		"daemonset":                      "DaemonSet",
+		"statefulset":                    "StatefulSet",
+		"job":                            "Job",
+		"cronjob":                        "CronJob",
+		"serviceaccount":                 "ServiceAccount",
+		"networkpolicy":                  "NetworkPolicy",
+		"namespace":                      "Namespace",
+		"validatingwebhookconfiguration": "ValidatingWebhookConfiguration",
+		"mutatingwebhookconfiguration":   "MutatingWebhookConfiguration",
+		"":                               "",
+		"frobnicator":                    "",
+	}
+	for in, want := range cases {
+		if got := kindFromHint(in); got != want {
+			t.Errorf("kindFromHint(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func writeTemp(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
 }

--- a/internal/models/finding_test.go
+++ b/internal/models/finding_test.go
@@ -1,0 +1,156 @@
+package models
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseSeverityCanonical(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  Severity
+	}{
+		{"CRITICAL", SeverityCritical},
+		{"critical", SeverityCritical},
+		{" High ", SeverityHigh},
+		{"medium", SeverityMedium},
+		{"low", SeverityLow},
+		{"info", SeverityInfo},
+		{"", SeverityInfo}, // empty input is accepted as INFO
+	}
+	for _, tc := range cases {
+		got, err := ParseSeverity(tc.input)
+		if err != nil {
+			t.Errorf("ParseSeverity(%q) returned error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseSeverity(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParseSeverityRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseSeverity("noise")
+	if err == nil {
+		t.Fatal("expected error for unknown severity")
+	}
+	if !strings.Contains(err.Error(), "noise") {
+		t.Errorf("error message should include the bad input, got %q", err.Error())
+	}
+}
+
+func TestSeverityRankOrdering(t *testing.T) {
+	t.Parallel()
+
+	// Critical > High > Medium > Low > Info, and unknowns rank as Info (1).
+	want := map[Severity]int{
+		SeverityCritical: 5,
+		SeverityHigh:     4,
+		SeverityMedium:   3,
+		SeverityLow:      2,
+		SeverityInfo:     1,
+	}
+	for sev, rank := range want {
+		if sev.Rank() != rank {
+			t.Errorf("Severity(%q).Rank() = %d, want %d", sev, sev.Rank(), rank)
+		}
+	}
+	// Unknown severities default to the lowest rank.
+	if Severity("garbage").Rank() != 1 {
+		t.Errorf("unknown severity should rank 1, got %d", Severity("garbage").Rank())
+	}
+}
+
+func TestScopeLevelRankAndLabel(t *testing.T) {
+	t.Parallel()
+
+	rank := map[ScopeLevel]int{
+		ScopeCluster:   4,
+		ScopeNamespace: 3,
+		ScopeWorkload:  2,
+		ScopeObject:    1,
+	}
+	for sl, want := range rank {
+		if got := sl.Rank(); got != want {
+			t.Errorf("Rank(%q) = %d, want %d", sl, got, want)
+		}
+	}
+	if ScopeLevel("").Rank() != 0 {
+		t.Errorf("empty scope should rank 0, got %d", ScopeLevel("").Rank())
+	}
+
+	label := map[ScopeLevel]string{
+		ScopeCluster:    "Cluster",
+		ScopeNamespace:  "Namespace",
+		ScopeWorkload:   "Workload",
+		ScopeObject:     "Object",
+		ScopeLevel(""):  "Unknown",
+		ScopeLevel("x"): "Unknown",
+	}
+	for sl, want := range label {
+		if got := sl.Label(); got != want {
+			t.Errorf("Label(%q) = %q, want %q", sl, got, want)
+		}
+	}
+}
+
+func TestSubjectRefKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		ref  SubjectRef
+		want string
+	}{
+		{SubjectRef{Kind: "User", Name: "alice"}, "User/alice"},
+		{SubjectRef{Kind: "Group", Name: "ops"}, "Group/ops"},
+		{SubjectRef{Kind: "ServiceAccount", Namespace: "team-a", Name: "deployer"}, "ServiceAccount/team-a/deployer"},
+	}
+	for _, tc := range cases {
+		if got := tc.ref.Key(); got != tc.want {
+			t.Errorf("Key(%#v) = %q, want %q", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestResourceRefKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		ref  ResourceRef
+		want string
+	}{
+		{ResourceRef{Kind: "ClusterRole", Name: "admin"}, "ClusterRole/admin"},
+		{ResourceRef{Kind: "Pod", Namespace: "default", Name: "nginx"}, "Pod/default/nginx"},
+	}
+	for _, tc := range cases {
+		if got := tc.ref.Key(); got != tc.want {
+			t.Errorf("Key(%#v) = %q, want %q", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestNewSnapshotSeedsTimestampAndProvider(t *testing.T) {
+	t.Parallel()
+
+	before := time.Now().UTC().Add(-1 * time.Second)
+	snap := NewSnapshot()
+	after := time.Now().UTC().Add(1 * time.Second)
+
+	if snap.Metadata.CloudProvider != "none" {
+		t.Errorf("CloudProvider default should be 'none', got %q", snap.Metadata.CloudProvider)
+	}
+
+	ts, err := time.Parse(time.RFC3339, snap.Metadata.SnapshotTimestamp)
+	if err != nil {
+		t.Fatalf("SnapshotTimestamp not RFC3339: %v", err)
+	}
+	if ts.Before(before) || ts.After(after) {
+		t.Errorf("SnapshotTimestamp %v should fall within [%v, %v]", ts, before, after)
+	}
+}

--- a/internal/permissions/aggregate_test.go
+++ b/internal/permissions/aggregate_test.go
@@ -1,0 +1,313 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/hardik/kubesplaining/internal/models"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAggregateResolvesRoleBindingToNamespacedRules(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Roles: []rbacv1.Role{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-reader", Namespace: "team-a"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}},
+					},
+				},
+				// Same role name in another namespace must NOT bleed in.
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-reader", Namespace: "team-b"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"}},
+					},
+				},
+			},
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rb-team-a", Namespace: "team-a"},
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "secret-reader"},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "deployer", Namespace: ""}, // namespace omitted; falls back to binding ns
+					},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(snapshot)
+
+	subj := models.SubjectRef{Kind: "ServiceAccount", Namespace: "team-a", Name: "deployer"}
+	perms, ok := got[subj.Key()]
+	if !ok {
+		t.Fatalf("expected subject %q in aggregate, got keys=%v", subj.Key(), keys(got))
+	}
+	if len(perms.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(perms.Rules))
+	}
+	rule := perms.Rules[0]
+	if rule.Namespace != "team-a" {
+		t.Errorf("rule namespace = %q, want team-a", rule.Namespace)
+	}
+	if rule.SourceRole != "secret-reader" || rule.SourceBinding != "rb-team-a" {
+		t.Errorf("rule provenance wrong: role=%q binding=%q", rule.SourceRole, rule.SourceBinding)
+	}
+	if len(rule.Resources) != 1 || rule.Resources[0] != "secrets" {
+		t.Errorf("rule resources = %v, want [secrets]", rule.Resources)
+	}
+}
+
+func TestAggregateResolvesClusterRoleBindingClusterScoped(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			ClusterRoles: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+					},
+				},
+			},
+			ClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "crb-admins"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+					Subjects: []rbacv1.Subject{
+						{Kind: "Group", Name: "ops"},
+						{Kind: "ServiceAccount", Namespace: "platform", Name: "controller"},
+					},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(snapshot)
+
+	groupKey := models.SubjectRef{Kind: "Group", Name: "ops"}.Key()
+	if _, ok := got[groupKey]; !ok {
+		t.Fatalf("expected Group %q in aggregate, got keys=%v", groupKey, keys(got))
+	}
+	saKey := models.SubjectRef{Kind: "ServiceAccount", Namespace: "platform", Name: "controller"}.Key()
+	if _, ok := got[saKey]; !ok {
+		t.Fatalf("expected SA %q in aggregate, got keys=%v", saKey, keys(got))
+	}
+
+	// Rule tied to a ClusterRoleBinding must have empty namespace (cluster-scoped).
+	for _, rule := range got[saKey].Rules {
+		if rule.Namespace != "" {
+			t.Errorf("ClusterRoleBinding rule should be cluster-scoped, got ns=%q", rule.Namespace)
+		}
+	}
+}
+
+func TestAggregateRoleBindingPointingAtClusterRole(t *testing.T) {
+	t.Parallel()
+
+	// RoleBindings can reference ClusterRoles; the rules apply within the binding's namespace.
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			ClusterRoles: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "view"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+					},
+				},
+			},
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rb-viewer", Namespace: "team-a"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "view"},
+					Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice"}},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(snapshot)
+
+	userKey := models.SubjectRef{Kind: "User", Name: "alice"}.Key()
+	perms, ok := got[userKey]
+	if !ok {
+		t.Fatalf("expected User %q in aggregate", userKey)
+	}
+	if len(perms.Rules) != 1 || perms.Rules[0].Namespace != "team-a" {
+		t.Fatalf("expected one rule scoped to team-a, got %#v", perms.Rules)
+	}
+}
+
+func TestAggregateMissingRoleProducesNoRules(t *testing.T) {
+	t.Parallel()
+
+	// Binding references a Role that does not exist; the subject should still be created
+	// but with no rules (silently dropped, never fatal).
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rb-broken", Namespace: "team-a"},
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "ghost"},
+					Subjects:   []rbacv1.Subject{{Kind: "User", Name: "bob"}},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(snapshot)
+
+	userKey := models.SubjectRef{Kind: "User", Name: "bob"}.Key()
+	perms, ok := got[userKey]
+	if !ok {
+		t.Fatalf("expected User %q to be created even with missing role", userKey)
+	}
+	if len(perms.Rules) != 0 {
+		t.Errorf("missing role should produce no rules, got %#v", perms.Rules)
+	}
+}
+
+func TestAggregateUnionsRulesAcrossBindings(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Roles: []rbacv1.Role{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "team-a"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "r2", Namespace: "team-a"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"list"}},
+					},
+				},
+			},
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "team-a"},
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "r1"},
+					Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "sa-x", Namespace: "team-a"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "b2", Namespace: "team-a"},
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "r2"},
+					Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "sa-x", Namespace: "team-a"}},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(snapshot)
+
+	saKey := models.SubjectRef{Kind: "ServiceAccount", Namespace: "team-a", Name: "sa-x"}.Key()
+	perms, ok := got[saKey]
+	if !ok {
+		t.Fatalf("expected SA %q in aggregate", saKey)
+	}
+	if len(perms.Rules) != 2 {
+		t.Fatalf("expected 2 rules unioned across bindings, got %d: %#v", len(perms.Rules), perms.Rules)
+	}
+
+	bindings := map[string]bool{}
+	for _, r := range perms.Rules {
+		bindings[r.SourceBinding] = true
+	}
+	if !bindings["b1"] || !bindings["b2"] {
+		t.Errorf("expected both bindings to contribute rules, got %v", bindings)
+	}
+}
+
+func TestAggregateRulesAreCopiedNotShared(t *testing.T) {
+	t.Parallel()
+
+	// Mutating the returned rule slices must not affect the source Role.
+	originalVerbs := []string{"get", "list"}
+	role := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "team-a"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: originalVerbs},
+		},
+	}
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Roles: []rbacv1.Role{role},
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "team-a"},
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "r"},
+					Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice"}},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(snapshot)
+	userKey := models.SubjectRef{Kind: "User", Name: "alice"}.Key()
+
+	got[userKey].Rules[0].Verbs[0] = "MUTATED"
+	if originalVerbs[0] != "get" {
+		t.Errorf("Aggregate did not deep-copy rule verbs; source mutated to %q", originalVerbs[0])
+	}
+}
+
+func TestSubjectRefFillsServiceAccountNamespaceFromFallback(t *testing.T) {
+	t.Parallel()
+
+	got := SubjectRef(rbacv1.Subject{Kind: "ServiceAccount", Name: "deployer"}, "team-a")
+	if got.Namespace != "team-a" {
+		t.Errorf("expected fallback namespace team-a, got %q", got.Namespace)
+	}
+}
+
+func TestSubjectRefPreservesExplicitServiceAccountNamespace(t *testing.T) {
+	t.Parallel()
+
+	got := SubjectRef(rbacv1.Subject{Kind: "ServiceAccount", Name: "deployer", Namespace: "explicit"}, "team-a")
+	if got.Namespace != "explicit" {
+		t.Errorf("expected explicit namespace preserved, got %q", got.Namespace)
+	}
+}
+
+func TestSubjectRefSkipsNamespaceForUserAndGroup(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ kind, name string }{
+		{"User", "alice"},
+		{"Group", "ops"},
+	}
+	for _, tc := range cases {
+		got := SubjectRef(rbacv1.Subject{Kind: tc.kind, Name: tc.name, Namespace: "ignored"}, "team-a")
+		if got.Namespace != "" {
+			t.Errorf("%s should not carry a namespace, got %q", tc.kind, got.Namespace)
+		}
+		if got.Name != tc.name || got.Kind != tc.kind {
+			t.Errorf("subject identity mangled: %#v", got)
+		}
+	}
+}
+
+func TestAggregateEmptySnapshot(t *testing.T) {
+	t.Parallel()
+
+	got := Aggregate(models.Snapshot{})
+	if len(got) != 0 {
+		t.Errorf("empty snapshot should produce empty aggregate, got %d entries", len(got))
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
New test files target packages that previously had no tests
(permissions, models, collector I/O) and broaden coverage on
manifest loading, exclusion matching/loading, the analyzer engine
pipeline, and the podsec/admission analyzers.

Coverage deltas (per-package):
- internal/permissions     0.0% → 100.0%
- internal/models          0.0% → 100.0%
- internal/collector       0.0% →   4.4% (io.go fully covered;
  collector.go talks to a live API server)
- internal/manifest       37.7% →  69.2%
- internal/analyzer       54.0% →  95.0%
- internal/exclusions     56.1% →  90.2%
- internal/analyzer/podsec    60.8% →  98.0%
- internal/analyzer/admission 67.5% → 100.0%