### PR TITLE
ci: add lint + test workflow with shared commit-msg regex

### DIFF
--- a/.githooks/_conventional_commits_pattern.txt
+++ b/.githooks/_conventional_commits_pattern.txt
@@ -1,0 +1,1 @@
+^(feat|fix|docs|refactor|test|chore|ci|build|perf|style|revert)(\([a-z0-9_/.-]+\))?!?: .+

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -25,8 +25,12 @@ case "$SUBJECT" in
         ;;
 esac
 
-ALLOWED_TYPES='feat|fix|docs|refactor|test|chore|ci|build|perf|style|revert'
-PATTERN="^(${ALLOWED_TYPES})(\([a-z0-9_/.-]+\))?!?: .+"
+PATTERN_FILE="$(git rev-parse --show-toplevel)/.githooks/_conventional_commits_pattern.txt"
+if [ ! -f "$PATTERN_FILE" ]; then
+    echo "commit-msg: pattern file missing: $PATTERN_FILE" >&2
+    exit 1
+fi
+PATTERN="$(head -n1 "$PATTERN_FILE")"
 
 fail() {
     cat >&2 <<'EOF'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,129 @@
+name: Lint and test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gofmt-vet:
+    name: gofmt + go vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/hermit
+          key: hermit-${{ runner.os }}-${{ hashFiles('bin/.*.pkg') }}
+
+      - uses: actions/cache@v4
+        with:
+          path: .tmp/go-mod-cache
+          key: gomod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+
+      - name: Activate Hermit
+        run: |
+          . ./bin/activate-hermit
+          env >> "$GITHUB_ENV"
+
+      - name: make lint
+        run: make lint
+
+  golangci-lint:
+    name: golangci-lint (repo-wide)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/hermit
+          key: hermit-${{ runner.os }}-${{ hashFiles('bin/.*.pkg') }}
+
+      - uses: actions/cache@v4
+        with:
+          path: .tmp/go-mod-cache
+          key: gomod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-${{ runner.os }}-${{ hashFiles('.golangci.yml', 'go.sum') }}
+
+      - name: Activate Hermit
+        run: |
+          . ./bin/activate-hermit
+          env >> "$GITHUB_ENV"
+
+      - name: golangci-lint run ./...
+        run: ./bin/golangci-lint run ./...
+
+  test:
+    name: go test ./...
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/hermit
+          key: hermit-${{ runner.os }}-${{ hashFiles('bin/.*.pkg') }}
+
+      - uses: actions/cache@v4
+        with:
+          path: .tmp/go-mod-cache
+          key: gomod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+
+      - name: Activate Hermit
+        run: |
+          . ./bin/activate-hermit
+          env >> "$GITHUB_ENV"
+
+      - name: make test
+        run: make test
+
+  commit-msg-check:
+    name: Conventional Commits PR title
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -eu
+          PATTERN_FILE=".githooks/_conventional_commits_pattern.txt"
+          if [ ! -f "$PATTERN_FILE" ]; then
+            echo "Pattern file missing: $PATTERN_FILE" >&2
+            exit 1
+          fi
+          PATTERN="$(head -n1 "$PATTERN_FILE")"
+
+          # Skip git-generated subjects (matches the commit-msg hook).
+          case "$PR_TITLE" in
+            "Merge "*|"Revert \""*|"fixup! "*|"squash! "*|"amend! "*) exit 0 ;;
+          esac
+
+          if ! [[ "$PR_TITLE" =~ $PATTERN ]]; then
+            echo "PR title does not follow Conventional Commits: $PR_TITLE" >&2
+            echo "Format: <type>(<optional-scope>)?: <subject>" >&2
+            echo "Allowed types: feat, fix, docs, refactor, test, chore, ci, build, perf, style, revert" >&2
+            exit 1
+          fi
+
+          if [ "${#PR_TITLE}" -gt 72 ]; then
+            echo "PR title is ${#PR_TITLE} chars (max 72): $PR_TITLE" >&2
+            exit 1
+          fi
+
+          case "$PR_TITLE" in
+            *.) echo "PR title ends with a period: $PR_TITLE" >&2; exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary
- New `.github/workflows/lint.yml` runs on every PR and on pushes to `main`. Four parallel jobs: `gofmt-vet` (`make lint`), `golangci-lint` (repo-wide), `test` (`make test`), and `commit-msg-check` (validates PR title against Conventional Commits).
- Closes the gap from the opt-in pre-commit hooks (#29): hooks only lint *staged* packages and can be bypassed; CI now lints/tests the whole repo on every PR.
- Extracts the Conventional Commits regex into `.githooks/_conventional_commits_pattern.txt`, read by both the `commit-msg` hook and the new workflow so they cannot drift.

## Test plan
- [x] All four jobs run on this PR
- [x] `gofmt-vet` passes
- [x] `golangci-lint` passes
- [x] `test` passes
- [x] `commit-msg-check` passes against this PR's title

## Out of scope (follow-ups)
- Adding the new check IDs to `.github/main-ruleset.json`'s required-status-checks — intentionally separate per the plan, after the workflow has been green on a few PRs.
- The `example-report.yml` e2e workflow is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)