### PR TITLE
docs(report): adapt prose to Datadog Security Labs voice

### DIFF
--- a/internal/analyzer/admission/content.go
+++ b/internal/analyzer/admission/content.go
@@ -48,7 +48,7 @@ var (
 func scopeForWebhook(configKind, configName, webhookName string) models.Scope {
 	return models.Scope{
 		Level:  models.ScopeCluster,
-		Detail: fmt.Sprintf("%s `%s` (webhook entry `%s`) — applies to admission across the entire cluster", configKind, configName, webhookName),
+		Detail: fmt.Sprintf("%s `%s` (webhook entry `%s`): applies to admission across the entire cluster", configKind, configName, webhookName),
 	}
 }
 
@@ -56,16 +56,16 @@ func contentAdmission001(configKind, configName, webhookName string) ruleContent
 	return ruleContent{
 		Title: fmt.Sprintf("%s `%s/%s` is fail-open (`failurePolicy: Ignore`) on security-critical resources", configKind, configName, webhookName),
 		Scope: scopeForWebhook(configKind, configName, webhookName),
-		Description: fmt.Sprintf("The webhook `%s` in `%s/%s` intercepts create/update on security-critical resources (pods, deployments, daemonsets, statefulsets, jobs, cronjobs, or podtemplates) but its `failurePolicy` is set to `Ignore`. The Kubernetes admission docs are explicit: `Ignore` means \"any error from the webhook is silently ignored, and the API request is allowed to continue\" — so if the webhook backend is unavailable, slow, or denies the request with an error, the offending pod/workload is admitted as if no policy existed.\n\n"+
-			"Concretely, this means: if the policy backend pod crashes, is rolling, has a network partition, fails its own admission, or returns an HTTP 500, then any pod can ship — including pods that violate Pod Security Standards, run as root, mount the host filesystem, or use hostNetwork. Worse, an attacker who can already trigger a denial-of-service against the webhook backend (high traffic, OOM via large requests, killing its pods) can deliberately disable enforcement and then admit privileged pods.\n\n"+
-			"The `failurePolicy` choice is one of two: `Fail` (deny when the webhook is unavailable — the conservative production default) or `Ignore` (allow when unavailable — only appropriate for non-security webhooks like cosmetic mutators). Security webhooks (PSA replacements, image signing, network-policy injection, secret encryption) should always use `Fail` paired with `objectSelector/namespaceSelector` carve-outs that ensure the policy backend itself can come up before any other workload is admitted.",
+		Description: fmt.Sprintf("The webhook `%s` in `%s/%s` intercepts create/update on security-critical resources (pods, deployments, daemonsets, statefulsets, jobs, cronjobs, or podtemplates) but its `failurePolicy` is set to `Ignore`. The Kubernetes admission docs are explicit: `Ignore` means \"any error from the webhook is silently ignored, and the API request is allowed to continue\". In practice, this means that if the webhook backend is unavailable, slow, or denies the request with an error, the offending pod/workload is admitted as if no policy existed.\n\n"+
+			"Concretely, if the policy backend pod crashes, is rolling, has a network partition, fails its own admission, or returns an HTTP 500, then any pod can ship. That includes pods that violate Pod Security Standards, run as root, mount the host filesystem, or use hostNetwork. Beyond that, an attacker who can already trigger a denial-of-service against the webhook backend (high traffic, OOM via large requests, killing its pods) can deliberately disable enforcement and then admit privileged pods.\n\n"+
+			"The `failurePolicy` choice is one of two: `Fail` (deny when the webhook is unavailable: the conservative production default) or `Ignore` (allow when unavailable: only appropriate for non-security webhooks like cosmetic mutators). Security webhooks (PSA replacements, image signing, network-policy injection, secret encryption) should always use `Fail` paired with `objectSelector/namespaceSelector` carve-outs that ensure the policy backend itself can come up before any other workload is admitted.",
 			webhookName, configKind, configName),
-		Impact: "Any outage or DoS of the webhook backend silently disables policy enforcement cluster-wide on the targeted resources — privileged pods, root containers, and PSS-violating workloads can be admitted while monitoring shows the webhook \"installed.\"",
+		Impact: "Any outage or DoS of the webhook backend silently disables policy enforcement cluster-wide on the targeted resources. Privileged pods, root containers, and PSS-violating workloads can be admitted while monitoring shows the webhook \"installed.\"",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker enumerates webhook configurations (`kubectl get %s`) and identifies that `%s` has `failurePolicy: Ignore`.", configKind, configName),
 			"They induce backend failure: kill the webhook's backing pods if they have RBAC for it, send oversized AdmissionReview payloads to OOM the backend, or simply wait for a deploy-time outage.",
 			"While the webhook is unhealthy, they apply a privileged pod manifest (hostPID, hostNetwork, hostPath `/`, runAsUser 0).",
-			"The API server calls the webhook, gets a connection-refused/timeout error, applies `Ignore`, and admits the pod — there is no audit trail noting that the webhook was bypassed beyond the API-server logs (which most teams do not alert on).",
+			"The API server calls the webhook, gets a connection-refused/timeout error, applies `Ignore`, and admits the pod. There is no audit trail noting that the webhook was bypassed beyond the API-server logs (which most teams do not alert on).",
 			"From the privileged pod the attacker pivots: chroot into `/host` for full node compromise, dump secrets, persist a daemonset.",
 		},
 		Remediation: fmt.Sprintf("Switch `%s.failurePolicy` to `Fail` and confirm the webhook backend has the availability/HA characteristics needed for the cluster's admission rate.", webhookName),
@@ -90,16 +90,16 @@ func contentAdmission002(configKind, configName, webhookName string) ruleContent
 	return ruleContent{
 		Title: fmt.Sprintf("%s `%s/%s` can be bypassed by omitting the workload-controlled labels in `objectSelector`", configKind, configName, webhookName),
 		Scope: scopeForWebhook(configKind, configName, webhookName),
-		Description: fmt.Sprintf("Webhook `%s` in `%s/%s` uses an `objectSelector` — its admission rules only apply to objects whose own labels match the selector. Because Kubernetes lets the workload author set arbitrary labels on the object they are creating, an `objectSelector` that gates security policy is opt-in: an attacker (or a careless developer) creates the same pod without the matching labels and the webhook never sees it.\n\n"+
-			"This is structurally different from `namespaceSelector` (which gates by namespace labels — namespaces are a higher-trust object that workload authors typically can't relabel). `objectSelector` checks the labels on the resource being admitted, so a pod manifest that simply omits the policy's gating label slips past untouched. The Kubernetes API reference notes this explicitly: \"If you skip the security label, the webhook is not called.\"\n\n"+
+		Description: fmt.Sprintf("Webhook `%s` in `%s/%s` uses an `objectSelector`, which limits its admission rules to objects whose own labels match the selector. Because Kubernetes lets the workload author set arbitrary labels on the object they are creating, an `objectSelector` that gates security policy is opt-in: an attacker (or a careless developer) creates the same pod without the matching labels and the webhook never sees it.\n\n"+
+			"This is structurally different from `namespaceSelector` (which gates by namespace labels; namespaces are a higher-trust object that workload authors typically can't relabel). `objectSelector` checks the labels on the resource being admitted, so a pod manifest that simply omits the policy's gating label slips past untouched. The Kubernetes API reference notes this explicitly: \"If you skip the security label, the webhook is not called.\"\n\n"+
 			"For policy-enforcing webhooks (PSS replacements, image-signing, sidecar injection of security tooling) this is the wrong tool. The right pattern is to inversely scope the webhook: select *all* objects (`objectSelector: {}` or absent) and use a `namespaceSelector` plus carefully targeted opt-out labels (e.g., `policy.example.com/exempt: true`) that are themselves gated by RBAC on the namespace, not on the pod author.",
 			webhookName, configKind, configName),
-		Impact: "Workload authors (legitimate or hostile) can opt out of admission enforcement simply by not setting the gating labels on their pods — defeating the point of the webhook for any user with create permission on the targeted resources.",
+		Impact: "Workload authors (legitimate or hostile) can opt out of admission enforcement simply by not setting the gating labels on their pods. This defeats the point of the webhook for any user with create permission on the targeted resources.",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker reads `%s/%s` and notes the `objectSelector` requires e.g. `app.kubernetes.io/managed-by: platform`.", configKind, configName),
 			"They author a pod manifest that omits the `app.kubernetes.io/managed-by` label entirely.",
 			"They `kubectl apply` it; the API server evaluates the objectSelector, finds it does not match, skips the webhook, and admits the pod.",
-			"The pod runs with whatever the namespace defaults allow — including PSS-violating settings the webhook was supposed to block.",
+			"The pod runs with whatever the namespace defaults allow, including PSS-violating settings the webhook was supposed to block.",
 			"Because nothing logs \"webhook skipped due to objectSelector,\" the bypass is invisible in the SIEM unless the team explicitly audits AdmissionReview misses.",
 		},
 		Remediation: fmt.Sprintf("Replace `objectSelector`-based gating on `%s` with `namespaceSelector` plus an RBAC-protected exemption label, or remove the selector and let the webhook see every object.", webhookName),
@@ -107,7 +107,7 @@ func contentAdmission002(configKind, configName, webhookName string) ruleContent
 			fmt.Sprintf("Audit what `%s` is trying to gate. If the goal is \"only apply to pods in tenant namespaces,\" use `namespaceSelector` (namespace labels are higher-trust).", webhookName),
 			"If you need an exemption mechanism, add a `policy.example.com/exempt: true` label *on the namespace* and protect it with RBAC so workload authors cannot grant their own exemption.",
 			fmt.Sprintf("Edit `%s/%s` and either drop `webhooks[name=%s].objectSelector` or invert it to a default-on form.", configKind, configName, webhookName),
-			"Re-test by attempting to create a pod that previously bypassed admission — it should now be evaluated.",
+			"Re-test by attempting to create a pod that previously bypassed admission; it should now be evaluated.",
 			"If the webhook ships with the cluster's admission stack, document the new exemption flow so platform users know how to request one.",
 		},
 		LearnMore: []models.Reference{
@@ -124,11 +124,11 @@ func contentAdmission003(configKind, configName, webhookName string) ruleContent
 	return ruleContent{
 		Title: fmt.Sprintf("%s `%s/%s` exempts sensitive system namespaces via `namespaceSelector`", configKind, configName, webhookName),
 		Scope: scopeForWebhook(configKind, configName, webhookName),
-		Description: fmt.Sprintf("Webhook `%s` in `%s/%s` has a `namespaceSelector` that uses `NotIn` or `DoesNotExist` to exempt `kube-system` (or another `*-system` namespace) from admission control. The exemption is sometimes a deliberate cold-start workaround — the webhook backend itself runs in `kube-system` and would deadlock if the webhook applied to it — but it routinely outlives the cold-start need and is rarely revisited.\n\n"+
-			"Sensitive namespaces are exactly where admission control matters most. `kube-system` hosts coredns, kube-proxy, the cloud-controller-manager, CNI agents, the metrics-server, and most clusters' add-on operators — workloads that already run with high privilege. An attacker who can create resources in `kube-system` (e.g., via a stolen `system:` ServiceAccount token, an over-permissive `roles/clusterroles` create rule, or a privileged operator) finds the admission webhooks deliberately turned off for them.\n\n"+
-			"This is also a defense-in-depth gap: even if a future privesc finding (`KUBE-PRIVESC-*`) is mitigated, the namespace-selector exemption keeps the door open. The right pattern is to scope the exemption to the *single* control-plane namespace the backend itself needs (and only at boot) — not to every `-system` namespace by suffix.",
+		Description: fmt.Sprintf("Webhook `%s` in `%s/%s` has a `namespaceSelector` that uses `NotIn` or `DoesNotExist` to exempt `kube-system` (or another `*-system` namespace) from admission control. The exemption is sometimes a deliberate cold-start workaround (the webhook backend itself runs in `kube-system` and would deadlock if the webhook applied to it), but it routinely outlives the cold-start need and is rarely revisited.\n\n"+
+			"Sensitive namespaces are exactly where admission control matters most. `kube-system` hosts coredns, kube-proxy, the cloud-controller-manager, CNI agents, the metrics-server, and most clusters' add-on operators: workloads that already run with high privilege. An attacker who can create resources in `kube-system` (e.g., via a stolen `system:` ServiceAccount token, an over-permissive `roles/clusterroles` create rule, or a privileged operator) finds the admission webhooks deliberately turned off for them.\n\n"+
+			"This is also a defense-in-depth gap: even if a future privesc finding (`KUBE-PRIVESC-*`) is mitigated, the namespace-selector exemption keeps the door open. The right pattern is to scope the exemption to the *single* control-plane namespace the backend itself needs (and only at boot), not to every `-system` namespace by suffix.",
 			webhookName, configKind, configName),
-		Impact: "An attacker who can create pods or other resources in the exempted system namespace bypasses every check this webhook implements — root containers, hostPath mounts, and arbitrary images all admit silently.",
+		Impact: "An attacker who can create pods or other resources in the exempted system namespace bypasses every check this webhook implements: root containers, hostPath mounts, and arbitrary images all admit silently.",
 		AttackScenario: []string{
 			"Attacker compromises a workload with `create pods` permission scoped to `kube-system` (typical of operators, addon managers, or stolen control-plane tokens).",
 			"They submit a pod manifest with `hostPath: /`, `runAsUser: 0`, and `securityContext.privileged: true`.",
@@ -138,7 +138,7 @@ func contentAdmission003(configKind, configName, webhookName string) ruleContent
 		},
 		Remediation: fmt.Sprintf("Narrow `%s.namespaceSelector` to the exact namespace the webhook backend needs to skip during cold start, or remove the exemption entirely once the backend is bootstrapped.", webhookName),
 		RemediationSteps: []string{
-			fmt.Sprintf("Check why `%s` excludes the namespace — is it a cold-start workaround or a permanent carve-out?", webhookName),
+			fmt.Sprintf("Check why `%s` excludes the namespace. Is it a cold-start workaround or a permanent carve-out?", webhookName),
 			"If cold-start: scope the exemption to the *exact* namespace the webhook backend runs in (e.g., `kubernetes.io/metadata.name NotIn [policy-system]`), not every `*-system`.",
 			"If permanent carve-out: replace it with the in-tree Pod Security Admission level for that namespace so privileged pods still face *some* check.",
 			"Validate by dry-running a privileged pod manifest in the previously-exempted namespace; the webhook should now process the request.",

--- a/internal/analyzer/network/content.go
+++ b/internal/analyzer/network/content.go
@@ -45,28 +45,28 @@ var (
 
 func contentNetpolCoverage001(namespace string) ruleContent {
 	return ruleContent{
-		Title: fmt.Sprintf("Namespace `%s` has zero NetworkPolicies — all pods accept any inbound and reach any outbound endpoint", namespace),
+		Title: fmt.Sprintf("Namespace `%s` has zero NetworkPolicies, so all pods accept any inbound and reach any outbound endpoint", namespace),
 		Scope: models.Scope{
 			Level:  models.ScopeNamespace,
-			Detail: fmt.Sprintf("Namespace `%s` — every workload inside inherits allow-all behavior", namespace),
+			Detail: fmt.Sprintf("Namespace `%s`: every workload inside inherits allow-all behavior", namespace),
 		},
 		Description: fmt.Sprintf("Namespace `%s` contains workloads but no NetworkPolicy objects. Without any policy selecting its pods, the Kubernetes networking model is allow-all in both directions: any pod in any namespace can open a TCP/UDP connection to any pod here, and any pod here can open arbitrary outbound connections (cluster pod CIDR, Services, node IPs, the cloud Instance Metadata Service at `169.254.169.254`, the public internet, and the API server).\n\n"+
-			"This is the documented Kubernetes default — a pod is non-isolated for ingress/egress until at least one NetworkPolicy with the relevant `policyTypes` selects it. CIS Kubernetes Benchmark 5.3.2 and the NSA/CISA Hardening Guide v1.2 both require a default-deny baseline in every namespace.\n\n"+
+			"This is the documented Kubernetes default. A pod is non-isolated for ingress/egress until at least one NetworkPolicy with the relevant `policyTypes` selects it. CIS Kubernetes Benchmark 5.3.2 and the NSA/CISA Hardening Guide v1.2 both require a default-deny baseline in every namespace.\n\n"+
 			"A single compromised pod (RCE, leaked credential, supply-chain backdoor) immediately gains the full L3/L4 reachability graph of the cluster: kube-DNS for service discovery, the cloud metadata service for IAM credentials, attacker-controlled C2 endpoints, and high-value pods (databases, vault, kube-system DaemonSets) all without crossing any policy boundary.",
 			namespace),
 		Impact: "Any pod compromise becomes cluster-wide L3/L4 reach: lateral movement, credential theft from IMDS, and arbitrary egress to attacker C2 are all unblocked.",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker exploits an unpatched dependency in any pod in `%s` and lands a shell.", namespace),
-			"They scan the pod CIDR (`for i in $(seq 1 254); do nc -zv 10.244.0.$i 6379 5432 3306 27017; done`) — every database port across every namespace is reachable.",
+			"They scan the pod CIDR (`for i in $(seq 1 254); do nc -zv 10.244.0.$i 6379 5432 3306 27017; done`). Every database port across every namespace is reachable.",
 			"They hit the cloud metadata endpoint `curl http://169.254.169.254/latest/meta-data/iam/security-credentials/` and exfiltrate the node's IAM credentials.",
 			"They establish outbound C2 to attacker-controlled IP/domain over 443 and tunnel harvested secrets, pod tokens, and DNS reconnaissance.",
-			"They pivot cluster-wide: query kube-DNS for `*.svc.cluster.local`, identify Vault/Postgres/Redis, authenticate with stolen tokens — full lateral movement.",
+			"They pivot cluster-wide: query kube-DNS for `*.svc.cluster.local`, identify Vault/Postgres/Redis, and authenticate with stolen tokens. Full lateral movement.",
 		},
 		Remediation: fmt.Sprintf("Apply a default-deny-all NetworkPolicy in `%s`, then add minimal explicit allow policies for DNS plus each workload's actual ingress/egress dependencies.", namespace),
 		RemediationSteps: []string{
 			fmt.Sprintf("Apply a default-deny baseline (`podSelector: {}`, `policyTypes: [Ingress, Egress]`) to `%s`.", namespace),
-			"Add a tightly-scoped DNS allow policy (UDP/TCP 53 to kube-system) — without DNS every workload's hostname resolution will fail.",
-			"For each workload, write an explicit allow policy: ingress from the named upstream and egress to its actual dependencies — never `0.0.0.0/0`.",
+			"Add a tightly-scoped DNS allow policy (UDP/TCP 53 to kube-system). Without DNS every workload's hostname resolution will fail.",
+			"For each workload, write an explicit allow policy: ingress from the named upstream and egress to its actual dependencies. Never `0.0.0.0/0`.",
 			fmt.Sprintf("Validate with a debug pod: `kubectl run -n %s --rm -it tmp --image=nicolaka/netshoot -- bash` confirming allowed paths work and disallowed paths time out.", namespace),
 			"Wire CIS 5.3.2 / Kyverno's `require-network-policy` policy into CI so future namespaces ship with a baseline.",
 		},
@@ -85,16 +85,16 @@ func contentNetpolWeakness002(namespace, policyName, cidr string) ruleContent {
 		Title: fmt.Sprintf("NetworkPolicy `%s/%s` allows egress to `%s` (entire internet)", namespace, policyName, cidr),
 		Scope: models.Scope{
 			Level:  models.ScopeObject,
-			Detail: fmt.Sprintf("NetworkPolicy `%s/%s` — the workloads it selects can reach any IPv4/IPv6 destination", namespace, policyName),
+			Detail: fmt.Sprintf("NetworkPolicy `%s/%s`: the workloads it selects can reach any IPv4/IPv6 destination", namespace, policyName),
 		},
-		Description: fmt.Sprintf("NetworkPolicy `%s/%s` contains an egress rule whose `ipBlock.cidr` is `%s`. This is the broadest possible CIDR — semantically equivalent to \"allow this workload to make outbound connections to any destination.\" Because NetworkPolicy egress rules are additive, this single rule defeats whatever segmentation other policies tried to build for the selected pods.\n\n"+
-			"Two properties make this rule especially dangerous: (1) `0.0.0.0/0` includes the link-local range that holds the cloud Instance Metadata Service (`169.254.169.254/32` on AWS/Azure, `metadata.google.internal` on GCP), so a compromised pod can scrape node IAM credentials and pivot to the underlying cloud account; (2) `0.0.0.0/0` also includes the Pod and Service CIDRs of the cluster itself, so the rule does not just open the internet — it also opens inter-namespace traffic for the selected pods unless an `except:` block carves out the cluster ranges.\n\n"+
+		Description: fmt.Sprintf("NetworkPolicy `%s/%s` contains an egress rule whose `ipBlock.cidr` is `%s`. This is the broadest possible CIDR, semantically equivalent to \"allow this workload to make outbound connections to any destination.\" Because NetworkPolicy egress rules are additive, this single rule defeats whatever segmentation other policies tried to build for the selected pods.\n\n"+
+			"Two properties make this rule especially dangerous: (1) `0.0.0.0/0` includes the link-local range that holds the cloud Instance Metadata Service (`169.254.169.254/32` on AWS/Azure, `metadata.google.internal` on GCP), so a compromised pod can scrape node IAM credentials and pivot to the underlying cloud account; (2) `0.0.0.0/0` also includes the Pod and Service CIDRs of the cluster itself, so the rule does not just open the internet. It also opens inter-namespace traffic for the selected pods unless an `except:` block carves out the cluster ranges.\n\n"+
 			"A correctly-scoped egress policy uses an `ipBlock` with the specific CIDRs the workload needs (a private VPC peer, a known SaaS provider's published range), or a `namespaceSelector + podSelector` pair to a named in-cluster dependency. `0.0.0.0/0` should never appear in a production egress allow rule.",
 			namespace, policyName, cidr),
-		Impact: "Selected workload can reach any IP, including cloud IMDS (credential theft) and arbitrary attacker C2 (data exfiltration) — turns any pod compromise into cloud-account compromise.",
+		Impact: "Selected workload can reach any IP, including cloud IMDS (credential theft) and arbitrary attacker C2 (data exfiltration). This turns any pod compromise into cloud-account compromise.",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker compromises a pod selected by `%s.spec.podSelector`.", policyName),
-			"They hit `http://169.254.169.254/latest/meta-data/iam/security-credentials/` and pull the node's IAM credentials — the egress rule allows this because IMDS is inside `0.0.0.0/0`.",
+			"They hit `http://169.254.169.254/latest/meta-data/iam/security-credentials/` and pull the node's IAM credentials. The egress rule allows this because IMDS is inside `0.0.0.0/0`.",
 			"They use stolen IAM credentials with `aws sts get-caller-identity` then enumerate the cloud account.",
 			"They open an outbound TLS connection to `c2.attacker.example` on 443 (covered by the same broad rule) and exfiltrate harvested secrets.",
 			"They abuse the same broad CIDR to reach other in-cluster Services unless `except:` carves out the cluster ranges.",
@@ -102,7 +102,7 @@ func contentNetpolWeakness002(namespace, policyName, cidr string) ruleContent {
 		Remediation: "Replace `0.0.0.0/0` with the specific CIDRs the workload needs, or use `namespaceSelector/podSelector` for in-cluster destinations, and explicitly carve out the IMDS range.",
 		RemediationSteps: []string{
 			fmt.Sprintf("Inventory what `%s`'s selected pods actually need to reach (use `kubectl exec ... -- ss -tnp` or VPC flow logs).", policyName),
-			"Replace the `0.0.0.0/0` rule with a specific allowlist — ipBlocks for required SaaS CIDRs, namespaceSelector/podSelector for in-cluster targets.",
+			"Replace the `0.0.0.0/0` rule with a specific allowlist: ipBlocks for required SaaS CIDRs, namespaceSelector/podSelector for in-cluster targets.",
 			"At a CNI tier (Calico GlobalNetworkPolicy or Cilium ClusterwideNetworkPolicy), add a non-overridable deny for `169.254.169.254/32`.",
 			"Validate with a netshoot pod: confirm legitimate destinations resolve and connect; confirm `curl --max-time 3 http://169.254.169.254/` and arbitrary internet hosts time out.",
 			"Add a Kyverno or OPA Gatekeeper policy that rejects any new NetworkPolicy whose ipBlock CIDR is `0.0.0.0/0` or `::/0`.",
@@ -122,16 +122,16 @@ func contentNetpolCoverage002(kind, namespace, name string, labels map[string]st
 		Title: fmt.Sprintf("Workload `%s/%s/%s` is in a policied namespace but no policy podSelector matches it", kind, namespace, name),
 		Scope: models.Scope{
 			Level:  models.ScopeWorkload,
-			Detail: fmt.Sprintf("Workload `%s/%s/%s` (labels %v) — covered by no NetworkPolicy in `%s`", kind, namespace, name, labels, namespace),
+			Detail: fmt.Sprintf("Workload `%s/%s/%s` (labels %v): covered by no NetworkPolicy in `%s`", kind, namespace, name, labels, namespace),
 		},
 		Description: fmt.Sprintf("Workload `%s/%s/%s` runs in `%s` which has at least one NetworkPolicy, but none of those policies' `podSelector` clauses match this workload's labels (`%v`). The Kubernetes NetworkPolicy specification is explicit: a pod is \"non-isolated\" for ingress/egress until a NetworkPolicy with the corresponding `policyTypes` entry selects it.\n\n"+
-			"This is the most common misconfiguration in clusters that have started rolling out NetworkPolicies: the operator added policies for the visible apps and forgot a sidecar Job, a CronJob spawned by an operator, a debug Deployment, or a workload whose labels were renamed. \"Selected by no policy\" is semantically identical to \"in a namespace with no policies at all\" for this specific pod — full allow-in, full allow-out — even though `kubectl get netpol` makes the namespace look protected.\n\n"+
-			"The failure mode is invisible at a glance: dashboards say \"NetworkPolicies present in namespace,\" CIS 5.3.2 may pass, but the uncovered workload is exactly the kind of pod attackers love — operator-managed, often privileged, often forgotten.",
+			"This is the most common misconfiguration in clusters that have started rolling out NetworkPolicies: the operator added policies for the visible apps and forgot a sidecar Job, a CronJob spawned by an operator, a debug Deployment, or a workload whose labels were renamed. \"Selected by no policy\" is semantically identical to \"in a namespace with no policies at all\" for this specific pod (full allow-in, full allow-out) even though `kubectl get netpol` makes the namespace look protected.\n\n"+
+			"The failure mode is invisible at a glance: dashboards say \"NetworkPolicies present in namespace,\" CIS 5.3.2 may pass, but the uncovered workload is exactly the kind of pod attackers love: operator-managed, often privileged, often forgotten.",
 			kind, namespace, name, namespace, labels),
-		Impact: "This single workload retains full allow-all ingress and egress while the rest of the namespace is segmented — making it the easiest pivot point for an attacker who lands anywhere else in the cluster.",
+		Impact: "This single workload retains full allow-all ingress and egress while the rest of the namespace is segmented, making it the easiest pivot point for an attacker who lands anywhere else in the cluster.",
 		AttackScenario: []string{
 			"Attacker compromises a low-value pod elsewhere in the cluster (CVE in a web app).",
-			fmt.Sprintf("They scan the namespace's pod CIDR for reachable services. Other pods in `%s` correctly drop unsolicited traffic — except `%s`, which is uncovered.", namespace, name),
+			fmt.Sprintf("They scan the namespace's pod CIDR for reachable services. Other pods in `%s` correctly drop unsolicited traffic, except `%s`, which is uncovered.", namespace, name),
 			fmt.Sprintf("They hit `%s`'s exposed application port and exploit a known issue, gaining a shell.", name),
 			fmt.Sprintf("From `%s`, attacker has unrestricted egress: hits IMDS for cloud IAM credentials, opens C2 to attacker IPs, uses the pod's mounted ServiceAccount token against the API server.", name),
 			"The attacker now has the network position the rest of the namespace's policies were designed to prevent.",
@@ -157,25 +157,25 @@ func contentNetpolCoverage003(namespace string) ruleContent {
 		Title: fmt.Sprintf("Namespace `%s` controls ingress but has no Egress policy (one-way enforcement)", namespace),
 		Scope: models.Scope{
 			Level:  models.ScopeNamespace,
-			Detail: fmt.Sprintf("Namespace `%s` — pods are firewalled inbound but can reach any outbound destination", namespace),
+			Detail: fmt.Sprintf("Namespace `%s`: pods are firewalled inbound but can reach any outbound destination", namespace),
 		},
-		Description: fmt.Sprintf("Namespace `%s` has NetworkPolicy objects that select pods for ingress filtering but no NetworkPolicy enforces egress. In Kubernetes' policy model, ingress and egress are independent dimensions: a pod is isolated for ingress only if a policy with `policyTypes: Ingress` selects it, and isolated for egress only if a policy with `policyTypes: Egress` selects it. A pod can be tightly firewalled inbound and still reach the entire internet outbound — exactly the asymmetry seen here.\n\n"+
+		Description: fmt.Sprintf("Namespace `%s` has NetworkPolicy objects that select pods for ingress filtering but no NetworkPolicy enforces egress. In Kubernetes' policy model, ingress and egress are independent dimensions: a pod is isolated for ingress only if a policy with `policyTypes: Ingress` selects it, and isolated for egress only if a policy with `policyTypes: Egress` selects it. A pod can be tightly firewalled inbound and still reach the entire internet outbound, which is exactly the asymmetry seen here.\n\n"+
 			"This is a classic misconfiguration after a half-finished zero-trust migration. Teams typically write ingress policies first because they think of \"who can talk to my service,\" and ship without revisiting outbound. The result looks compliant in dashboards but leaves data exfiltration, cloud IMDS access, and outbound C2 wide open.\n\n"+
 			"The practical risk is that egress is the dimension attackers actually want. Inbound restrictions help against external scanners, but a compromised pod's value to an attacker is in what it can talk *out* to: the cloud control plane via IMDS, attacker-controlled C2, internal databases in other namespaces, and the cluster's kube-apiserver.",
 			namespace),
-		Impact: "Compromised pods in this namespace retain full outbound reach — IMDS credential theft, C2 callbacks, and lateral pivots out of the namespace are unimpeded.",
+		Impact: "Compromised pods in this namespace retain full outbound reach. IMDS credential theft, C2 callbacks, and lateral pivots out of the namespace are unimpeded.",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker compromises any pod in `%s`.", namespace),
-			"They hit IMDS — the namespace has no egress policy, so the request succeeds and node IAM credentials are exfiltrated.",
+			"They hit IMDS. The namespace has no egress policy, so the request succeeds and node IAM credentials are exfiltrated.",
 			"They establish C2 to `attacker.example:443` and stream captured tokens, environment variables, and pod-mounted secrets.",
-			"They pivot to other namespaces by talking to ClusterIP Services directly — the missing egress policy doesn't restrict cluster-internal destinations either.",
+			"They pivot to other namespaces by talking to ClusterIP Services directly. The missing egress policy doesn't restrict cluster-internal destinations either.",
 			"They call kube-apiserver with the pod's ServiceAccount token (egress to apiserver also unrestricted), enumerating RBAC for any privesc opportunity.",
 		},
 		Remediation: fmt.Sprintf("Add a default-deny-egress NetworkPolicy in `%s`, then explicit per-workload egress allowlists for DNS and actual outbound dependencies.", namespace),
 		RemediationSteps: []string{
 			fmt.Sprintf("Apply a `default-deny-egress` policy in `%s` targeting `podSelector: {}` so every pod becomes egress-isolated.", namespace),
 			"Add an explicit DNS-allow policy (UDP/TCP 53 to kube-system).",
-			"For each workload that has legitimate egress, add a tight `to:` clause (specific Service, namespaceSelector+podSelector, or specific external CIDR — never `0.0.0.0/0`).",
+			"For each workload that has legitimate egress, add a tight `to:` clause (specific Service, namespaceSelector+podSelector, or specific external CIDR; never `0.0.0.0/0`).",
 			"Validate by `kubectl exec` into a representative pod and confirming `curl --max-time 3 https://example.com/` times out.",
 			"Wire CI policy (Kyverno `require-policytypes-egress`) to fail any future namespace with ingress-only coverage.",
 		},
@@ -193,23 +193,23 @@ func contentNetpolWeakness001(namespace, policyName string) ruleContent {
 		Title: fmt.Sprintf("NetworkPolicy `%s/%s` accepts ingress from any namespace via empty namespaceSelector", namespace, policyName),
 		Scope: models.Scope{
 			Level:  models.ScopeObject,
-			Detail: fmt.Sprintf("NetworkPolicy `%s/%s` — selected pods are reachable from every namespace, present and future", namespace, policyName),
+			Detail: fmt.Sprintf("NetworkPolicy `%s/%s`: selected pods are reachable from every namespace, present and future", namespace, policyName),
 		},
-		Description: fmt.Sprintf("NetworkPolicy `%s/%s` contains an ingress `from:` peer with a `namespaceSelector` that has no `matchLabels` and no `matchExpressions`. In NetworkPolicy semantics this is the special form that means \"every namespace in the cluster\" — exactly the opposite of the Kubernetes default for `from:` peers (which is \"only the policy's own namespace\").\n\n"+
-			"In multi-tenant or shared clusters the impact is direct: namespace boundaries are the cheapest soft tenancy boundary Kubernetes offers, and `namespaceSelector: {}` invalidates that boundary for the selected pods. A compromised pod in any tenant — even one with no business need to talk to these pods — has unrestricted access on the allowed ports.\n\n"+
-			"The correct pattern is to scope the `namespaceSelector` to the specific labels that identify allowed source namespaces (e.g., `tenancy.example.com/team: data-platform`) and combine it with an explicit `podSelector` so only the right pods in the right namespaces can connect. Combined selectors mean \"pods matching label X in namespaces matching label Y\" — the AND form, not the OR form.",
+		Description: fmt.Sprintf("NetworkPolicy `%s/%s` contains an ingress `from:` peer with a `namespaceSelector` that has no `matchLabels` and no `matchExpressions`. In NetworkPolicy semantics this is the special form that means \"every namespace in the cluster\", which is exactly the opposite of the Kubernetes default for `from:` peers (which is \"only the policy's own namespace\").\n\n"+
+			"In multi-tenant or shared clusters the impact is direct: namespace boundaries are the cheapest soft tenancy boundary Kubernetes offers, and `namespaceSelector: {}` invalidates that boundary for the selected pods. A compromised pod in any tenant (even one with no business need to talk to these pods) has unrestricted access on the allowed ports.\n\n"+
+			"The correct pattern is to scope the `namespaceSelector` to the specific labels that identify allowed source namespaces (e.g., `tenancy.example.com/team: data-platform`) and combine it with an explicit `podSelector` so only the right pods in the right namespaces can connect. Combined selectors mean \"pods matching label X in namespaces matching label Y\": the AND form, not the OR form.",
 			namespace, policyName),
-		Impact: "Selected workloads are reachable from any pod in any namespace on the allowed ports — defeating namespace-based tenant isolation and inviting cross-tenant lateral movement.",
+		Impact: "Selected workloads are reachable from any pod in any namespace on the allowed ports. This defeats namespace-based tenant isolation and invites cross-tenant lateral movement.",
 		AttackScenario: []string{
 			"Attacker compromises a low-value pod in some other namespace (CI runner, stale demo, shared sidecar).",
 			fmt.Sprintf("They enumerate ClusterIP Services and notice the Service backing `%s`'s pods in `%s`.", policyName, namespace),
-			"They attempt a TCP connect from the other namespace — under any other policy this would be denied at the CNI, but `namespaceSelector: {}` matches and the connection succeeds.",
+			"They attempt a TCP connect from the other namespace. Under any other policy this would be denied at the CNI, but `namespaceSelector: {}` matches and the connection succeeds.",
 			"They exploit an application-layer issue on the now-reachable port (auth bypass, weak credential, RCE) and pivot into the high-value workload.",
 			"They continue lateral motion from inside the target namespace using mounted tokens and secrets.",
 		},
 		Remediation: "Replace the empty `namespaceSelector` with explicit labels identifying the small set of namespaces that legitimately need access, paired with a `podSelector`.",
 		RemediationSteps: []string{
-			"Identify which namespaces actually need to reach the selected pods (often one or two — never \"all\").",
+			"Identify which namespaces actually need to reach the selected pods (often one or two; never \"all\").",
 			"Label those namespaces with a stable, policy-meaningful key (e.g., `tenancy.example.com/team: data-platform`).",
 			fmt.Sprintf("Edit `%s` to replace `namespaceSelector: {}` with `matchLabels` for the chosen label, and add a sibling `podSelector`.", policyName),
 			"Validate by attempting connections from a netshoot pod in a non-allowed namespace (must time out) and from an allowed namespace (must succeed).",

--- a/internal/analyzer/podsec/content.go
+++ b/internal/analyzer/podsec/content.go
@@ -35,10 +35,10 @@ func scopeForWorkload(kind, namespace, name string) models.Scope {
 	level := models.ScopeWorkload
 	detail := fmt.Sprintf("Workload `%s/%s/%s`", kind, namespace, name)
 	if kind == "DaemonSet" {
-		detail += " — runs on **every** node (per-node blast radius)"
+		detail += ", runs on **every** node (per-node blast radius)"
 	}
 	if strings.HasPrefix(namespace, "kube-") {
-		detail += " — control-plane namespace"
+		detail += ", control-plane namespace"
 	}
 	return models.Scope{Level: level, Detail: detail}
 }
@@ -81,7 +81,7 @@ func contentEscape001(kind, namespace, name, container string) ruleContent {
 			"This is the single most dangerous PodSpec setting: capability drops, read-only root filesystem, and `runAsNonRoot` are all neutralised because the container can simply remount, reload kernel modules, or call `setuid(0)`. The Pod Security Standards explicitly forbid privileged containers at both Baseline and Restricted levels.\n\n"+
 			"Real-world breakout: an attacker with code execution loads a kernel module with `insmod` (CAP_SYS_MODULE), or uses `mknod` to recreate `/dev/sda1`, mounts the host root, and writes to `/root/.ssh/authorized_keys`. Public exploit tooling (`deepce`, `kdigger -ac`, `kubeletmein`) automates these in seconds.",
 			container, kind, namespace, name),
-		Impact: "Full root on the host node — read every Secret on the node, exfiltrate the kubelet client certificate, schedule pods anywhere, and pivot to other nodes.",
+		Impact: "Full root on the host node: read every Secret on the node, exfiltrate the kubelet client certificate, schedule pods anywhere, and pivot to other nodes.",
 		AttackScenario: []string{
 			"Attacker gains code execution inside the privileged pod (RCE, malicious image, SSRF→shell).",
 			"They confirm the configuration with `kdigger dig admission` or `deepce.sh`.",
@@ -91,7 +91,7 @@ func contentEscape001(kind, namespace, name, container string) ruleContent {
 		},
 		Remediation: "Remove `privileged: true` and explicitly grant only the Linux capabilities the workload actually needs.",
 		RemediationSteps: []string{
-			"Audit why the container needs privileged — most apps do not. Trace which capability is actually required (often only `NET_BIND_SERVICE`).",
+			"Audit why the container needs privileged. Most apps do not. Trace which capability is actually required (often only `NET_BIND_SERVICE`).",
 			"Replace `privileged: true` with `capabilities.drop: [ALL]` and an explicit `capabilities.add: [<NEEDED_CAP>]`. Add `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, and `seccompProfile.type: RuntimeDefault`.",
 			"Enforce at admission time: label the namespace `pod-security.kubernetes.io/enforce: baseline` (or `restricted`) so future regressions are blocked.",
 			fmt.Sprintf("Validate with `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.containers[*].securityContext.privileged}'` returning empty/false.", strings.ToLower(kind), name, namespace),
@@ -106,11 +106,11 @@ func contentEscape001(kind, namespace, name, container string) ruleContent {
 func contentEscape002(kind, namespace, name string) ruleContent {
 	scope := scopeForWorkload(kind, namespace, name)
 	return ruleContent{
-		Title: fmt.Sprintf("Pod shares host PID namespace (`hostPID: true`) — `%s/%s/%s`", kind, namespace, name),
+		Title: fmt.Sprintf("Pod shares host PID namespace (`hostPID: true`) in `%s/%s/%s`", kind, namespace, name),
 		Scope: scope,
-		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostPID: true`, joining the host's PID namespace. Every process on the node — kubelet, container runtime, other tenant workloads, sshd, cloud-init agents — is visible via `/proc` and addressable by PID from inside this pod.\n\n"+
+		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostPID: true`, joining the host's PID namespace. Every process on the node (kubelet, container runtime, other tenant workloads, sshd, cloud-init agents) is visible via `/proc` and addressable by PID from inside this pod.\n\n"+
 			"The risk is twofold. First, information disclosure: `/proc/<pid>/environ`, `/proc/<pid>/cmdline`, and `/proc/<pid>/root/...` leak environment variables (which often contain database passwords, cloud credentials, and Kubernetes service-account tokens), CLI args, and arbitrary file contents from other containers' rootfs. Second, when combined with CAP_SYS_PTRACE or `privileged: true`, an attacker can `nsenter --target 1 --mount --uts --ipc --net --pid -- /bin/bash` and land directly in the host's mount namespace as root.\n\n"+
-			"Bishop Fox's `bad-pods` library and `kdigger`'s `processes` bucket grep `/proc/*/environ` for `AWS_`, `KUBE_`, `DATABASE_URL`, and service-account JWTs. Even without extra capabilities, host-PID alone is enough to harvest cleartext credentials from neighboring pods on the same node — a classic noisy-neighbor escalation primitive (TeamTNT, Hildegard).",
+			"Bishop Fox's `bad-pods` library and `kdigger`'s `processes` bucket grep `/proc/*/environ` for `AWS_`, `KUBE_`, `DATABASE_URL`, and service-account JWTs. Even without extra capabilities, host-PID alone is enough to harvest cleartext credentials from neighboring pods on the same node. This is a classic noisy-neighbor escalation primitive (TeamTNT, Hildegard).",
 			kind, namespace, name),
 		Impact: "Read process arguments, environment variables, and `/proc/<pid>/root` of every other pod on the node; harvest service-account tokens and cloud credentials from neighbors.",
 		AttackScenario: []string{
@@ -120,7 +120,7 @@ func contentEscape002(kind, namespace, name string) ruleContent {
 			"Read other pods' service-account tokens via `cat /proc/<pid>/root/var/run/secrets/kubernetes.io/serviceaccount/token`.",
 			"If CAP_SYS_PTRACE or privileged is also present, `nsenter -t 1 -a` to land in the host root namespace and persist via SSH key or systemd unit.",
 		},
-		Remediation: "Set `spec.hostPID: false` (or omit it — defaults to false).",
+		Remediation: "Set `spec.hostPID: false` (or omit it; the default is false).",
 		RemediationSteps: []string{
 			"Identify why hostPID was set; legitimate uses are limited to node-monitoring DaemonSets like node-exporter.",
 			"Remove `hostPID: true` from the pod template (or set explicitly to `false`).",
@@ -137,23 +137,23 @@ func contentEscape002(kind, namespace, name string) ruleContent {
 func contentEscape003(kind, namespace, name string) ruleContent {
 	scope := scopeForWorkload(kind, namespace, name)
 	return ruleContent{
-		Title: fmt.Sprintf("Pod shares host network (`hostNetwork: true`) — `%s/%s/%s`", kind, namespace, name),
+		Title: fmt.Sprintf("Pod shares host network (`hostNetwork: true`) in `%s/%s/%s`", kind, namespace, name),
 		Scope: scope,
-		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostNetwork: true`. The container is no longer in a sandboxed network namespace — it sees the node's interfaces, listens on the node's IPs and ports, and reaches every loopback service the kubelet talks to.\n\n"+
-			"The most dangerous consequence is that NetworkPolicies cannot apply. Cilium, Calico, and the upstream NetworkPolicy spec key off the pod's veth and labels — a hostNetwork pod has neither, so all egress filtering is silently bypassed. On managed Kubernetes (EKS/GKE/AKS) the workload can reach the cloud Instance Metadata Service at `169.254.169.254` even when the cluster has set IMDSv2 hop-count protection. The result is a one-step path from container RCE to AWS/Azure/GCP IAM credential theft.\n\n"+
+		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostNetwork: true`. The container is no longer in a sandboxed network namespace. It sees the node's interfaces, listens on the node's IPs and ports, and reaches every loopback service the kubelet talks to.\n\n"+
+			"The most dangerous consequence is that NetworkPolicies cannot apply. Cilium, Calico, and the upstream NetworkPolicy spec key off the pod's veth and labels, and a hostNetwork pod has neither, so all egress filtering is silently bypassed. On managed Kubernetes (EKS/GKE/AKS) the workload can reach the cloud Instance Metadata Service at `169.254.169.254` even when the cluster has set IMDSv2 hop-count protection. The result is a one-step path from container RCE to AWS/Azure/GCP IAM credential theft.\n\n"+
 			"The pod can also bind privileged ports the host already uses, redirect kube-proxy, sniff service traffic, or scan internal-only addresses such as `127.0.0.1:10250` (kubelet) which is otherwise unreachable from a normal pod.",
 			kind, namespace, name),
-		Impact: "Bypasses NetworkPolicy and IMDSv2 hop protection; container reaches cloud metadata, kubelet localhost, and any node-loopback service — pivots cluster compromise into cloud-account compromise.",
+		Impact: "Bypasses NetworkPolicy and IMDSv2 hop protection; container reaches cloud metadata, kubelet localhost, and any node-loopback service. This pivots cluster compromise into cloud-account compromise.",
 		AttackScenario: []string{
 			"Gain code execution in the pod (web RCE, malicious image).",
 			"Confirm hostNetwork: `ip addr` shows the node's primary interface, not a pod CIDR.",
 			"Hit the IMDS: `curl -s http://169.254.169.254/latest/api/token -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'` then fetch `iam/security-credentials/<role>`.",
 			"Use stolen IAM creds with `aws sts get-caller-identity` and pivot to S3/EKS API.",
-			"Optional: probe `127.0.0.1:10250` (kubelet) — if anonymous auth, run `curl -k https://127.0.0.1:10250/pods` to enumerate every pod on the node and exec into any of them.",
+			"Optional: probe `127.0.0.1:10250` (kubelet). If anonymous auth is enabled, run `curl -k https://127.0.0.1:10250/pods` to enumerate every pod on the node and exec into any of them.",
 		},
 		Remediation: "Set `hostNetwork: false` (default) and route any node-level networking through a CNI-managed Service or NetworkPolicy-aware DaemonSet.",
 		RemediationSteps: []string{
-			"Audit if hostNetwork is required — typically only kube-proxy, CNI agents, or node-local DNS legitimately need it.",
+			"Audit if hostNetwork is required. Typically only kube-proxy, CNI agents, or node-local DNS legitimately need it.",
 			"Remove `hostNetwork: true`. If a host port is genuinely required, prefer a Service of type NodePort or an Ingress controller behind a NetworkPolicy.",
 			"Enforce IMDSv2 with hop-limit = 1 on every node; apply an egress NetworkPolicy denying `169.254.169.254/32` for application namespaces.",
 			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.hostNetwork}'` is empty/false; `kubectl exec ... -- curl -m 2 http://169.254.169.254/` should fail.", strings.ToLower(kind), name, namespace),
@@ -170,10 +170,10 @@ func contentEscape003(kind, namespace, name string) ruleContent {
 func contentEscape004(kind, namespace, name string) ruleContent {
 	scope := scopeForWorkload(kind, namespace, name)
 	return ruleContent{
-		Title: fmt.Sprintf("Pod shares host IPC (`hostIPC: true`) — `%s/%s/%s`", kind, namespace, name),
+		Title: fmt.Sprintf("Pod shares host IPC (`hostIPC: true`) in `%s/%s/%s`", kind, namespace, name),
 		Scope: scope,
 		Description: fmt.Sprintf("Workload `%s/%s/%s` sets `spec.hostIPC: true`, joining the host's IPC (Inter-Process Communication) namespace. The container can read and write the host's POSIX shared-memory segments (`/dev/shm`), SysV shared memory, message queues, and semaphore arrays.\n\n"+
-			"The attack surface is data, not code execution. Many host-resident processes — caching layers, GPU compute (CUDA's `cuMemAlloc`), Redis with `unixsocket`, Postgres' shared buffers, even kernel-side IMA logs — store in-memory state in IPC segments under the assumption no untrusted process can address them. With `hostIPC: true` an attacker dumps every visible segment, harvests cached secrets, replays message queues, or corrupts semaphores to cause denial-of-service.\n\n"+
+			"The attack surface is data, not code execution. Many host-resident processes (caching layers, GPU compute via CUDA's `cuMemAlloc`, Redis with `unixsocket`, Postgres' shared buffers, even kernel-side IMA logs) store in-memory state in IPC segments under the assumption no untrusted process can address them. With `hostIPC: true` an attacker dumps every visible segment, harvests cached secrets, replays message queues, or corrupts semaphores to cause denial-of-service.\n\n"+
 			"Bishop Fox's `bad-pods/hostipc` example uses `ipcs -m` to list shared-memory segments and `ipcs -p` to identify owning PIDs, then `cat /dev/shm/*` (or attaches via `shmat`) to extract their contents. hostIPC is forbidden by the Pod Security Standards Baseline level.",
 			kind, namespace, name),
 		Impact: "Read or modify shared memory and SysV IPC of every process on the node; leak in-memory secrets, GPU buffers, database caches; denial-of-service via semaphore corruption.",
@@ -186,7 +186,7 @@ func contentEscape004(kind, namespace, name string) ruleContent {
 		},
 		Remediation: "Set `hostIPC: false` (default).",
 		RemediationSteps: []string{
-			"Confirm no legitimate IPC sharing requirement; very few application workloads need this — typically only NVIDIA GPU sharing or some HPC workloads.",
+			"Confirm no legitimate IPC sharing requirement; very few application workloads need this. Typically only NVIDIA GPU sharing or some HPC workloads.",
 			"Remove `hostIPC: true` from the pod template.",
 			"Where shared memory is a feature need (containers cooperating), use a single Pod with multiple containers and an `emptyDir { medium: Memory }` volume instead of host IPC.",
 			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.hostIPC}'` is empty/false.", strings.ToLower(kind), name, namespace),
@@ -204,11 +204,11 @@ func contentEscape005(kind, namespace, name, volumeName string) ruleContent {
 	return ruleContent{
 		Title: fmt.Sprintf("Docker socket mounted into `%s/%s/%s` (volume `%s` → `/var/run/docker.sock`)", kind, namespace, name, volumeName),
 		Scope: scope,
-		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts the Docker UNIX socket `/var/run/docker.sock` from the node into the container (volume `%s`). The Docker daemon listens on this socket as root and exposes the entire Docker Engine API — including `POST /containers/create`, which lets any client launch a new container with arbitrary mounts, devices, capabilities, and host-namespace settings.\n\n"+
-			"Mounting docker.sock is equivalent to giving the workload an unrestricted root shell on the node. There is no permission boundary inside the Docker API; \"read-only\" mount of the socket file does not help because the socket is a request channel, not a stored object — once you can `connect()` to it, you can issue any command. The OWASP Docker Security Cheat Sheet calls this the top-priority anti-pattern, and HackTricks documents the breakout as a one-liner.\n\n"+
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts the Docker UNIX socket `/var/run/docker.sock` from the node into the container (volume `%s`). The Docker daemon listens on this socket as root and exposes the entire Docker Engine API, including `POST /containers/create`, which lets any client launch a new container with arbitrary mounts, devices, capabilities, and host-namespace settings.\n\n"+
+			"Mounting docker.sock is equivalent to giving the workload an unrestricted root shell on the node. There is no permission boundary inside the Docker API; a \"read-only\" mount of the socket file does not help because the socket is a request channel, not a stored object. Once you can `connect()` to it, you can issue any command. The OWASP Docker Security Cheat Sheet calls this the top-priority anti-pattern, and HackTricks documents the breakout as a one-liner.\n\n"+
 			"From inside the container, install the Docker CLI (or use `curl --unix-socket`) and run `docker run -v /:/host --privileged --pid=host -it alpine chroot /host`. The new container mounts the host root, runs as host root, and can drop a backdoor into `/etc/cron.d/`, steal `/var/lib/kubelet/pki/`, or `nsenter -t 1 -a` to land on the host directly.",
 			kind, namespace, name, volumeName),
-		Impact: "Equivalent to root on the node — launch any container with any mount, mount the host filesystem, steal kubelet certs, and pivot to the entire cluster.",
+		Impact: "Equivalent to root on the node: launch any container with any mount, mount the host filesystem, steal kubelet certs, and pivot to the entire cluster.",
 		AttackScenario: []string{
 			"Gain code execution in the pod with docker.sock mounted.",
 			"Verify: `ls -la /var/run/docker.sock; curl --unix-socket /var/run/docker.sock http://localhost/version`.",
@@ -218,7 +218,7 @@ func contentEscape005(kind, namespace, name, volumeName string) ruleContent {
 		},
 		Remediation: "Remove the docker.sock hostPath mount; do not run sibling-container patterns on Kubernetes.",
 		RemediationSteps: []string{
-			"Identify why the workload talks to Docker — usually a CI runner, log shipper, or build system. Replace with a Kubernetes-native alternative: Buildah/Kaniko/Buildkit-rootless for builds, the Kubernetes API for pod orchestration, fluent-bit's tail input for logs.",
+			"Identify why the workload talks to Docker. The usual suspects are a CI runner, log shipper, or build system. Replace with a Kubernetes-native alternative: Buildah/Kaniko/Buildkit-rootless for builds, the Kubernetes API for pod orchestration, fluent-bit's tail input for logs.",
 			"Remove the `hostPath: /var/run/docker.sock` volume and corresponding `volumeMount`.",
 			"Apply Pod Security Admission `baseline` to the namespace (forbids hostPath volumes) and/or use a Kyverno/OPA policy that explicitly denies this path.",
 			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o jsonpath='{.spec.template.spec.volumes}' | jq` should not contain `/var/run/docker.sock`.", strings.ToLower(kind), name, namespace),
@@ -238,21 +238,21 @@ func contentContainerdSocket001(kind, namespace, name, volumeName string) ruleCo
 	return ruleContent{
 		Title: fmt.Sprintf("Containerd socket mounted into `%s/%s/%s` (volume `%s`)", kind, namespace, name, volumeName),
 		Scope: scope,
-		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts containerd's UNIX socket (`/run/containerd/containerd.sock` or `/var/run/containerd/containerd.sock`) into the container via volume `%s`. Containerd runs as root and is the runtime the kubelet uses to start every pod on the node — if you can talk to its API, you can create, modify, or exec into any container on the host, including kube-system control-plane pods.\n\n"+
-			"This is the modern equivalent of the docker.sock anti-pattern. Since Kubernetes 1.24 removed dockershim, most clusters use containerd or CRI-O directly; the same breakout primitives apply but the tooling differs (`ctr`, `crictl`). Kubernetes places its containers under containerd namespace `k8s.io` — `ctr -n k8s.io containers list` enumerates every pod on the node.\n\n"+
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts containerd's UNIX socket (`/run/containerd/containerd.sock` or `/var/run/containerd/containerd.sock`) into the container via volume `%s`. Containerd runs as root and is the runtime the kubelet uses to start every pod on the node. In practice, this means that if you can talk to its API, you can create, modify, or exec into any container on the host, including kube-system control-plane pods.\n\n"+
+			"This is the modern equivalent of the docker.sock anti-pattern. Since Kubernetes 1.24 removed dockershim, most clusters use containerd or CRI-O directly; the same breakout primitives apply but the tooling differs (`ctr`, `crictl`). Kubernetes places its containers under containerd namespace `k8s.io`, so `ctr -n k8s.io containers list` enumerates every pod on the node.\n\n"+
 			"The Grey Corner's containerd-socket-exploitation series documents the one-liner: install or copy the `ctr` binary, then run `ctr --address /run/containerd/containerd.sock -n k8s.io run --rm --mount type=bind,src=/,dst=/host,options=rbind:rw --privileged docker.io/library/alpine:latest pwn /bin/sh`. The result is a privileged container with `/` mounted at `/host`. From there an attacker reads the kubelet client cert, dumps every pod's secrets, or `task exec`s a reverse shell into the apiserver static pod on a control-plane node.",
 			kind, namespace, name, volumeName),
 		Impact: "Root on the node and arbitrary code execution inside any container on the node, including kube-system static pods. Equivalent to compromising the kubelet itself.",
 		AttackScenario: []string{
 			"Code execution in the pod with containerd.sock mounted.",
 			"`ls -la /run/containerd/containerd.sock; ctr --address /run/containerd/containerd.sock version`.",
-			"List target containers: `ctr -n k8s.io containers list` — note kube-apiserver, etcd, or any victim app.",
+			"List target containers: `ctr -n k8s.io containers list`. Note kube-apiserver, etcd, or any victim app.",
 			"Spawn a privileged escape container: `ctr -n k8s.io run --rm --privileged --mount type=bind,src=/,dst=/host,options=rbind:rw docker.io/library/alpine:latest x /bin/sh -c 'chroot /host'`.",
 			"From host, harvest `/var/lib/kubelet/pki/kubelet-client-current.pem` and pivot to the API server.",
 		},
 		Remediation: "Remove the containerd-socket hostPath mount; use the Kubernetes API or CRI-aware tools instead.",
 		RemediationSteps: []string{
-			"Determine why the workload needs CRI access. Legitimate use is rare — typically only specific node-agent observability tools. Replace with a Kubernetes-API-driven alternative.",
+			"Determine why the workload needs CRI access. Legitimate use is rare and typically limited to specific node-agent observability tools. Replace with a Kubernetes-API-driven alternative.",
 			"Remove the hostPath volume and volumeMount targeting `/run/containerd/containerd.sock` (and aliases).",
 			"For monitoring use cases, use the kubelet's `/metrics/cadvisor` endpoint behind an RBAC-scoped ServiceAccount, not raw socket access.",
 			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o yaml | grep -i containerd` returns no socket mount.", strings.ToLower(kind), name, namespace),
@@ -272,9 +272,9 @@ func contentEscape006(kind, namespace, name, volumeName string) ruleContent {
 	return ruleContent{
 		Title: fmt.Sprintf("Root filesystem (`/`) mounted from host into `%s/%s/%s`", kind, namespace, name),
 		Scope: scope,
-		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts the host's root filesystem (`hostPath: /`) inside the container via volume `%s`. Combined with the container's UID (typically root), this exposes the entire node filesystem — kubelet credentials, every other pod's mounted secrets, the container runtime state, and on control-plane nodes the static-pod manifests under `/etc/kubernetes/manifests`.\n\n"+
-			"Mounting `/` is one of the few configurations that, by itself, guarantees host compromise without requiring a CVE, kernel exploit, or even the `privileged` flag. The kubelet stores per-pod secrets at `/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~secret/<name>/...` in cleartext (tmpfs); a read-only host-root mount is enough to copy them all out. A read-write mount turns this into trivial persistence: write to `/etc/cron.d/`, modify `/etc/sudoers`, drop a shared-object into `/etc/ld.so.preload`, or — on a control-plane node — drop a malicious manifest into `/etc/kubernetes/manifests/` which the kubelet then runs as a static pod with full privileges.\n\n"+
-			"A single command sequence — `chroot /host`, `cat /host/var/lib/kubelet/pki/kubelet-client-current.pem`, then `kubectl --kubeconfig=<crafted> get secrets -A` — yields full secret enumeration on every pod on the node. Public exploit aids (`kubeletmein`, `peirates`) automate the chain.",
+		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts the host's root filesystem (`hostPath: /`) inside the container via volume `%s`. Combined with the container's UID (typically root), this exposes the entire node filesystem: kubelet credentials, every other pod's mounted secrets, the container runtime state, and on control-plane nodes the static-pod manifests under `/etc/kubernetes/manifests`.\n\n"+
+			"Mounting `/` is one of the few configurations that, by itself, guarantees host compromise without requiring a CVE, kernel exploit, or even the `privileged` flag. The kubelet stores per-pod secrets at `/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~secret/<name>/...` in cleartext (tmpfs); a read-only host-root mount is enough to copy them all out. A read-write mount turns this into trivial persistence: write to `/etc/cron.d/`, modify `/etc/sudoers`, drop a shared-object into `/etc/ld.so.preload`, or, on a control-plane node, drop a malicious manifest into `/etc/kubernetes/manifests/` which the kubelet then runs as a static pod with full privileges.\n\n"+
+			"A single command sequence (`chroot /host`, `cat /host/var/lib/kubelet/pki/kubelet-client-current.pem`, then `kubectl --kubeconfig=<crafted> get secrets -A`) yields full secret enumeration on every pod on the node. Public exploit aids (`kubeletmein`, `peirates`) automate the chain.",
 			kind, namespace, name, volumeName),
 		Impact: "Read every secret on the node; write to host cron, SSH, kubelet PKI, or static-pod manifests; persistence and pivot to cluster-admin.",
 		AttackScenario: []string{
@@ -304,7 +304,7 @@ func contentEscape006(kind, namespace, name, volumeName string) ruleContent {
 func contentEscape008(kind, namespace, name, volumeName string) ruleContent {
 	scope := scopeForWorkload(kind, namespace, name)
 	return ruleContent{
-		Title: fmt.Sprintf("`/var/log` mounted from host into `%s/%s/%s` — log-symlink escape primitive", kind, namespace, name),
+		Title: fmt.Sprintf("`/var/log` mounted from host into `%s/%s/%s` enables log-symlink escape primitive", kind, namespace, name),
 		Scope: scope,
 		Description: fmt.Sprintf("Workload `%s/%s/%s` mounts `/var/log` from the host via volume `%s`. This directory is the canonical container-log staging area: the kubelet writes per-pod logs into `/var/log/pods/<ns>_<pod>_<uid>/<container>/0.log` as symlinks pointing to the runtime's actual log files.\n\n"+
 			"The exploit is that `kubectl logs` causes the kubelet (running as root) to read those symlinks. If a pod can write into the host's `/var/log` (because it has the directory mounted), it can replace its own `0.log` symlink with one pointing to ANY file on the node, e.g. `/etc/shadow` or `/var/lib/kubelet/pki/kubelet-client-current.pem`. The next `kubectl logs <pod>` returns the contents of that file as if it were the container's stdout. This is the well-known `/var/log` symlink escape (Aqua Security, KubeHound `CE_VAR_LOG_SYMLINK`, CVE-2017-1002101, CVE-2021-25741).\n\n"+
@@ -322,7 +322,7 @@ func contentEscape008(kind, namespace, name, volumeName string) ruleContent {
 		RemediationSteps: []string{
 			"For log-shipper DaemonSets that genuinely need host logs, switch to read-only mount AND restrict to `/var/log/containers` and `/var/log/pods` only (not the parent `/var/log`).",
 			"Configure the log shipper to refuse following symlinks (e.g. Fluent Bit `Path_Key`) and run as a non-root UID.",
-			"For application pods, route logs to stdout/stderr only — Kubernetes captures these without any hostPath. Drop the hostPath mount.",
+			"For application pods, route logs to stdout/stderr only. Kubernetes captures these without any hostPath. Drop the hostPath mount.",
 			fmt.Sprintf("Validate: `kubectl get %s/%s -n %s -o yaml | grep -A2 hostPath` does not contain `/var/log` (or only narrow read-only sub-path).", strings.ToLower(kind), name, namespace),
 		},
 		LearnMore: []models.Reference{
@@ -346,14 +346,14 @@ func contentHostPath001(kind, namespace, name, volumeName, path string) ruleCont
 		Impact: "Variable but always elevated risk: at minimum exposes node-specific files; commonly leaks credentials or enables privilege escalation depending on the path.",
 		AttackScenario: []string{
 			"Identify the mounted path via `mount` or `cat /proc/mounts` from inside the pod.",
-			"Enumerate sensitive contents — for `/etc`: `cat /etc/shadow`, `/etc/kubernetes/admin.conf`; for `/proc`: `echo '|/tmp/x' > /proc/sys/kernel/core_pattern` then trigger a crash.",
+			"Enumerate sensitive contents. For `/etc`: `cat /etc/shadow`, `/etc/kubernetes/admin.conf`. For `/proc`: `echo '|/tmp/x' > /proc/sys/kernel/core_pattern` then trigger a crash.",
 			"If writable, drop a payload, modify a config, or symlink-swap.",
 			"Confirm impact with `kdigger dig mount` or `deepce.sh -e`.",
 			"Persist via the path's owning daemon (cron under `/etc`, systemd unit under `/lib/systemd`, etc.).",
 		},
 		Remediation: "Replace hostPath with a managed alternative (CSI volume, ConfigMap, Secret, projected volume, or local PV).",
 		RemediationSteps: []string{
-			"Determine why hostPath is used — config injection, log scraping, GPU device access. Each has a Kubernetes-native replacement.",
+			"Determine why hostPath is used: config injection, log scraping, GPU device access. Each has a Kubernetes-native replacement.",
 			"If hostPath is unavoidable, narrow `path:` to the smallest possible directory, set `type:` to the strictest matching value, and add `readOnly: true` on the volumeMount.",
 			"Pair with `runAsNonRoot: true`, drop `ALL` capabilities, and `allowPrivilegeEscalation: false`.",
 			fmt.Sprintf("Enforce via PSA `baseline` (denies hostPath) or a Kyverno/Gatekeeper allowlist. Validate: `kubectl get %s/%s -o yaml | grep -A3 hostPath`.", strings.ToLower(kind), name),
@@ -374,14 +374,14 @@ func contentPodSecAPE001(kind, namespace, name, container string) ruleContent {
 		Title: fmt.Sprintf("Container `%s` allows privilege escalation in `%s/%s/%s`", container, kind, namespace, name),
 		Scope: scope,
 		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` either omits `securityContext.allowPrivilegeEscalation` or sets it to `true`. This directly controls the `no_new_privs` Linux process flag: when `allowPrivilegeEscalation: false`, the kernel sets `NoNewPrivs: 1` on PID 1 in the container, and any subsequent `execve()` call cannot acquire additional privileges via setuid/setgid binaries, file capabilities, or LSM transitions.\n\n"+
-			"Leaving the field unset is dangerous because the runtime default is `true` for backward compatibility. If the container image happens to contain a setuid binary — even an inadvertent one from the base image (`mount`, `ping`, `su`, vendor agent helpers) — an attacker who lands as a non-root user inside the container can re-acquire root just by exec'ing it.\n\n"+
+			"Leaving the field unset is dangerous because the runtime default is `true` for backward compatibility. If the container image happens to contain a setuid binary (even an inadvertent one from the base image, like `mount`, `ping`, `su`, or vendor agent helpers), an attacker who lands as a non-root user inside the container can re-acquire root just by exec'ing it.\n\n"+
 			"The Pod Security Standards Restricted profile mandates `allowPrivilegeEscalation: false` precisely because it is the gate that makes capability drops and runAsNonRoot meaningful.",
 			container, kind, namespace, name),
 		Impact: "If an attacker lands as a non-root user, they can re-acquire root via setuid binaries; defeats capability drops and runAsNonRoot defenses.",
 		AttackScenario: []string{
 			"Gain code execution as a non-root user (web RCE in a Node/Python/Java app).",
 			"Enumerate setuid binaries: `find / -perm -4000 -type f 2>/dev/null` (often returns `/usr/bin/passwd`, `/bin/su`, `/bin/mount`, `/usr/bin/newuidmap`).",
-			"Exploit one — `su -` if password-less, or a known setuid CVE.",
+			"Exploit one: `su -` if password-less, or a known setuid CVE.",
 			"Once root in-container, restore previously-dropped capabilities via setcap-style techniques or chain with another finding.",
 		},
 		Remediation: "Set `allowPrivilegeEscalation: false` on every container.",
@@ -404,7 +404,7 @@ func contentPodSecRoot001(kind, namespace, name, container string) ruleContent {
 	return ruleContent{
 		Title: fmt.Sprintf("Container `%s` runs as root (UID 0) in `%s/%s/%s`", container, kind, namespace, name),
 		Scope: scope,
-		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` runs as UID 0 — either via an explicit `runAsUser: 0`, an explicit `runAsNonRoot: false`, or by relying on the image's default user (which for most public images is root). Container UID 0 is mapped to host UID 0 by default (Linux user namespaces are still off-by-default in Kubernetes), so any kernel exploit, capability misuse, or volume-write vulnerability lands with full root privileges.\n\n"+
+		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` runs as UID 0, either via an explicit `runAsUser: 0`, an explicit `runAsNonRoot: false`, or by relying on the image's default user (which for most public images is root). Container UID 0 is mapped to host UID 0 by default (Linux user namespaces are still off-by-default in Kubernetes), so any kernel exploit, capability misuse, or volume-write vulnerability lands with full root privileges.\n\n"+
 			"Running as root erodes every layer of in-container defense. A read-only root filesystem can be remounted (`mount -o remount,rw`) if CAP_SYS_ADMIN is held; a kernel CVE that requires root credentials in user-space (the runC \"Leaky Vessels\" CVE-2024-21626 class, the cgroup-release-agent CVE-2022-0492 class) becomes trivially exploitable; and bind-mounted directories owned by host root become writable.\n\n"+
 			"The Pod Security Standards Restricted profile requires `runAsNonRoot: true` AND a `runAsUser` ≥ 1.",
 			container, kind, namespace, name),
@@ -412,7 +412,7 @@ func contentPodSecRoot001(kind, namespace, name, container string) ruleContent {
 		AttackScenario: []string{
 			"Gain code execution as root inside the container.",
 			"Read all bind-mounted host files writable to root, including ConfigMaps and Secrets.",
-			"Attempt a capability-bearing kernel exploit — e.g., trigger CVE-2024-21626 (Leaky Vessels) by spawning a child with `WORKDIR=/proc/self/fd/8` semantics.",
+			"Attempt a capability-bearing kernel exploit. For example, trigger CVE-2024-21626 (Leaky Vessels) by spawning a child with `WORKDIR=/proc/self/fd/8` semantics.",
 			"With CAP_SYS_ADMIN remount the root filesystem read-write and modify init scripts.",
 			"Persist via dropped binaries in `/usr/local/bin` whose mounts may survive container restart.",
 		},
@@ -436,15 +436,15 @@ func contentSADefault001(kind, namespace, name, serviceAccount string) ruleConte
 		Title: fmt.Sprintf("Workload `%s/%s/%s` runs as the namespace `default` ServiceAccount", kind, namespace, name),
 		Scope: scope,
 		Description: fmt.Sprintf("Workload `%s/%s/%s` does not specify `serviceAccountName` and therefore runs as the namespace's `default` ServiceAccount, which by default has its token auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`.\n\n"+
-			"The `default` SA is harmless in a fresh namespace, but it is a magnet for permission accumulation: operators, Helm charts, and ClusterRoleBindings frequently bind permissions to it (often by mistake — `subjects: [{kind: ServiceAccount, name: default, namespace: foo}]`), and the only way to know if the SA is dangerous is to enumerate every binding referencing it.\n\n"+
-			"The Kubernetes RBAC Good Practices guide explicitly recommends per-workload ServiceAccounts so that the blast radius of an exposed token is bounded by a single workload's needs. An attacker with RCE in this pod reads the token, then runs `kubectl auth can-i --list` to find every accreted permission — often elevated by drift over the namespace's lifetime.",
+			"The `default` SA is harmless in a fresh namespace, but it is a magnet for permission accumulation: operators, Helm charts, and ClusterRoleBindings frequently bind permissions to it (often by mistake, via `subjects: [{kind: ServiceAccount, name: default, namespace: foo}]`), and the only way to know if the SA is dangerous is to enumerate every binding referencing it.\n\n"+
+			"The Kubernetes RBAC Good Practices guide explicitly recommends per-workload ServiceAccounts so that the blast radius of an exposed token is bounded by a single workload's needs. An attacker with RCE in this pod reads the token, then runs `kubectl auth can-i --list` to find every accreted permission, often elevated by drift over the namespace's lifetime.",
 			kind, namespace, name),
 		Impact: "Token theft yields whatever permissions the namespace `default` SA has been granted (often elevated by drift); enables lateral movement to other workloads in the namespace.",
 		AttackScenario: []string{
 			"RCE in the pod.",
 			"Read the SA token: `cat /var/run/secrets/kubernetes.io/serviceaccount/token`.",
 			"Enumerate permissions: `kubectl --token=$TOKEN auth can-i --list`.",
-			"Exploit any usable verb — common findings: `secrets/get` (loot all secrets), `pods/exec` (shell into other pods), `pods/create` with privileged template (escalate to node).",
+			"Exploit any usable verb. Common findings: `secrets/get` (loot all secrets), `pods/exec` (shell into other pods), `pods/create` with privileged template (escalate to node).",
 			"Persist by creating a hidden Deployment with the same compromised SA.",
 		},
 		Remediation: "Create a dedicated ServiceAccount per workload with least-privilege RBAC; disable automount on the namespace `default` SA.",
@@ -469,7 +469,7 @@ func contentImageLatest001(kind, namespace, name, container, image string) ruleC
 		Title: fmt.Sprintf("Container `%s` uses mutable image tag `%s` in `%s/%s/%s`", container, image, kind, namespace, name),
 		Scope: scope,
 		Description: fmt.Sprintf("Container `%s` in `%s/%s/%s` references the image `%s` using a mutable tag (either `:latest` or no tag, which Kubernetes resolves to `:latest`). Mutable tags break two safety properties: (1) the same manifest produces non-deterministic deployments, since the tag may resolve to different content on different days; (2) there is no cryptographic binding between the manifest and the image content actually run, so registry-side or in-flight tampering cannot be detected.\n\n"+
-			"This is a defense-evasion / supply-chain hygiene finding rather than an active exploit. Image digests (`@sha256:<hex>`) are immutable — the digest is computed over the manifest content, so any change yields a different digest. SLSA, Sigstore Cosign, and admission controllers like Kyverno or Connaisseur are the modern controls; pinning to a digest is the prerequisite for verifying signatures.\n\n"+
+			"This is a defense-evasion / supply-chain hygiene finding rather than an active exploit. Image digests (`@sha256:<hex>`) are immutable: the digest is computed over the manifest content, so any change yields a different digest. SLSA, Sigstore Cosign, and admission controllers like Kyverno or Connaisseur are the modern controls; pinning to a digest is the prerequisite for verifying signatures.\n\n"+
 			"A public package compromise (Codecov-style or PyPI-typosquat scenarios, or the 2024 ultralytics PyPI compromise) can republish `image:latest` with malicious code; clusters with `imagePullPolicy: Always` and `:latest` silently pick it up. Pinning to a digest turns a silent supply-chain attack into a noisy CI failure.",
 			container, kind, namespace, name, image),
 		Impact: "Non-deterministic deployments and silent ingestion of upstream supply-chain compromises; disables digest-based verification and signature checking.",

--- a/internal/analyzer/privesc/content.go
+++ b/internal/analyzer/privesc/content.go
@@ -53,12 +53,12 @@ func scopeForPath(source models.SubjectRef, target models.EscalationTarget) mode
 	case models.TargetClusterAdmin, models.TargetSystemMasters, models.TargetNodeEscape:
 		return models.Scope{
 			Level:  models.ScopeCluster,
-			Detail: fmt.Sprintf("Source `%s` → `%s` — terminal sink is cluster-scoped (full API control or host root)", source.Key(), targetLabel(target)),
+			Detail: fmt.Sprintf("Source `%s` → `%s`: terminal sink is cluster-scoped (full API control or host root)", source.Key(), targetLabel(target)),
 		}
 	case models.TargetKubeSystemSecrets:
 		return models.Scope{
 			Level:  models.ScopeNamespace,
-			Detail: fmt.Sprintf("Source `%s` → kube-system Secrets — control-plane namespace; reads here typically yield credentials usable cluster-wide", source.Key()),
+			Detail: fmt.Sprintf("Source `%s` → kube-system Secrets (control-plane namespace). Reads here typically yield credentials usable cluster-wide", source.Key()),
 		}
 	default:
 		return models.Scope{
@@ -90,31 +90,31 @@ func hopNarrative(hop models.EscalationHop) string {
 
 	switch hop.Action {
 	case "bound_to_cluster_admin":
-		return fmt.Sprintf("%s is bound directly to the `cluster-admin` ClusterRole — no chain step is needed beyond compromising the subject itself.", from)
+		return fmt.Sprintf("%s is bound directly to the `cluster-admin` ClusterRole. No chain step is needed beyond compromising the subject itself.", from)
 
 	case "wildcard_permission":
 		return fmt.Sprintf("The identity %s already holds wildcard verbs on wildcard resources (%s), which is functionally identical to `cluster-admin`. The attacker can take any action on any resource in the cluster without further escalation.", from, perm)
 
 	case "modify_role_binding":
-		return fmt.Sprintf("Acting as %s, the attacker abuses RoleBinding write access (%s) to add themselves (or any subject they control) to a high-privilege ClusterRoleBinding — typically `cluster-admin`. They don't need the target role's permissions today, only the ability to change bindings.", from, perm)
+		return fmt.Sprintf("Acting as %s, the attacker abuses RoleBinding write access (%s) to add themselves (or any subject they control) to a high-privilege ClusterRoleBinding, typically `cluster-admin`. They don't need the target role's permissions today, only the ability to change bindings.", from, perm)
 
 	case "bind_or_escalate":
 		if hasTo {
 			return fmt.Sprintf("Acting as %s, the attacker uses the RBAC `bind/escalate` bypass (%s) to grant themselves a role they do not currently hold and bind to %s. `bind/escalate` is the carve-out that lets the holder escape RBAC's normal \"you can only grant what you have\" guardrail.", from, perm, to)
 		}
-		return fmt.Sprintf("Acting as %s, the attacker uses the RBAC `bind/escalate` bypass (%s) to grant themselves any role they choose — typically `cluster-admin`. `bind/escalate` is the carve-out that lets the holder escape RBAC's normal \"you can only grant what you have\" guardrail.", from, perm)
+		return fmt.Sprintf("Acting as %s, the attacker uses the RBAC `bind/escalate` bypass (%s) to grant themselves any role they choose, typically `cluster-admin`. `bind/escalate` is the carve-out that lets the holder escape RBAC's normal \"you can only grant what you have\" guardrail.", from, perm)
 
 	case "impersonate":
 		if hasTo {
-			return fmt.Sprintf("Acting as %s, the attacker uses RBAC impersonation (the `impersonate` verb on %s) to send API requests as %s — the kube-apiserver honours the `Impersonate-User/Impersonate-Group` headers and authorizes the request against the impersonated identity's permissions instead of the attacker's.", from, perm, to)
+			return fmt.Sprintf("Acting as %s, the attacker uses RBAC impersonation (the `impersonate` verb on %s) to send API requests as %s. In practice, the kube-apiserver honours the `Impersonate-User/Impersonate-Group` headers and authorizes the request against the impersonated identity's permissions instead of the attacker's.", from, perm, to)
 		}
-		return fmt.Sprintf("Acting as %s, the attacker uses RBAC impersonation (the `impersonate` verb on %s) to send API requests as any identity in the cluster — including `system:masters`, which the apiserver hard-codes as cluster-admin. Granting `impersonate` on `groups: [\"*\"]` is functionally a cluster-admin grant.", from, perm)
+		return fmt.Sprintf("Acting as %s, the attacker uses RBAC impersonation (the `impersonate` verb on %s) to send API requests as any identity in the cluster, including `system:masters`, which the apiserver hard-codes as cluster-admin. Granting `impersonate` on `groups: [\"*\"]` is functionally a cluster-admin grant.", from, perm)
 
 	case "impersonate_system_masters":
-		return fmt.Sprintf("Acting as %s, the attacker impersonates the `system:masters` group (%s). The kube-apiserver hard-codes that group as authorized for every operation regardless of RBAC — a single such grant collapses the entire authorization layer.", from, perm)
+		return fmt.Sprintf("Acting as %s, the attacker impersonates the `system:masters` group (%s). The kube-apiserver hard-codes that group as authorized for every operation regardless of RBAC. A single such grant collapses the entire authorization layer.", from, perm)
 
 	case "read_secrets":
-		return fmt.Sprintf("Acting as %s, the attacker reads ServiceAccount tokens out of the cluster's Secrets store (%s) and uses one of those tokens — typically a control-plane controller's — to escalate. Read-access on Secrets is the most consequential single verb in Kubernetes RBAC because every other identity's credential lives in a Secret object somewhere.", from, perm)
+		return fmt.Sprintf("Acting as %s, the attacker reads ServiceAccount tokens out of the cluster's Secrets store (%s) and uses one of those tokens (typically a control-plane controller's) to escalate. Read-access on Secrets is the most consequential single verb in Kubernetes RBAC because every other identity's credential lives in a Secret object somewhere.", from, perm)
 
 	case "nodes_proxy":
 		return fmt.Sprintf("Acting as %s, the attacker uses `nodes/proxy` (%s) to forward requests directly to the kubelet on each node. Combined with the kubelet's `/exec` endpoint this becomes a primitive for running commands inside any pod the kubelet can see.", from, perm)
@@ -123,7 +123,7 @@ func hopNarrative(hop models.EscalationHop) string {
 		if hasTo {
 			return fmt.Sprintf("Acting as %s, the attacker creates a pod that mounts the %s ServiceAccount and then reads `/var/run/secrets/kubernetes.io/serviceaccount/token` from inside the container. The pod becomes a token-theft primitive: any ServiceAccount the attacker can mount, they can lift.", from, to)
 		}
-		return fmt.Sprintf("Acting as %s, the attacker creates a pod that mounts a privileged ServiceAccount and reads `/var/run/secrets/kubernetes.io/serviceaccount/token` from inside the container — the pod is a token-theft primitive.", from)
+		return fmt.Sprintf("Acting as %s, the attacker creates a pod that mounts a privileged ServiceAccount and reads `/var/run/secrets/kubernetes.io/serviceaccount/token` from inside the container. The pod is a token-theft primitive.", from)
 
 	case "pod_exec":
 		if hasTo {
@@ -133,9 +133,9 @@ func hopNarrative(hop models.EscalationHop) string {
 
 	case "token_request":
 		if hasTo {
-			return fmt.Sprintf("Acting as %s, the attacker calls the `serviceaccounts/token` subresource (%s) to mint a fresh, valid token for %s — no pod creation required, and a thinner audit trail than the pod-mount route.", from, perm, to)
+			return fmt.Sprintf("Acting as %s, the attacker calls the `serviceaccounts/token` subresource (%s) to mint a fresh, valid token for %s. No pod creation required, and a thinner audit trail than the pod-mount route.", from, perm, to)
 		}
-		return fmt.Sprintf("Acting as %s, the attacker calls the `serviceaccounts/token` subresource (%s) to mint a fresh token for a privileged ServiceAccount — no pod creation required, and a thinner audit trail than the pod-mount route.", from, perm)
+		return fmt.Sprintf("Acting as %s, the attacker calls the `serviceaccounts/token` subresource (%s) to mint a fresh token for a privileged ServiceAccount. No pod creation required, and a thinner audit trail than the pod-mount route.", from, perm)
 
 	case "mint_arbitrary_token":
 		return fmt.Sprintf("Acting as %s, the attacker calls `serviceaccounts/token` at cluster scope (%s) to mint a token for any ServiceAccount in any namespace. With no `resourceNames` constraint, the verb amounts to a credential-issuing oracle.", from, perm)
@@ -158,7 +158,7 @@ func hopNarrative(hop models.EscalationHop) string {
 		fmt.Fprintf(&b, " via %s", perm)
 	}
 	if gains != "" {
-		fmt.Fprintf(&b, " — %s", gains)
+		fmt.Fprintf(&b, ", which gains %s", gains)
 	}
 	b.WriteString(".")
 	return b.String()
@@ -204,20 +204,20 @@ func contentClusterAdminPath(source models.SubjectRef, hops []models.EscalationH
 	for _, hop := range hops {
 		steps = append(steps, hopNarrative(hop))
 	}
-	steps = append(steps, "Final step: attacker now wields a credential authorized for `verbs:[*]` on `resources:[*]` — they read every Secret cluster-wide, exec into any pod, and persist via DaemonSets, mutating webhooks, or backdoor RBAC bindings.")
+	steps = append(steps, "Final step: attacker now wields a credential authorized for `verbs:[*]` on `resources:[*]`. They read every Secret cluster-wide, exec into any pod, and persist via DaemonSets, mutating webhooks, or backdoor RBAC bindings.")
 	return ruleContent{
 		Title: fmt.Sprintf("`%s` can reach **cluster-admin equivalent** in %d hop(s)", source.Key(), hopCount),
 		Scope: scopeForPath(source, models.TargetClusterAdmin),
-		Description: fmt.Sprintf("Subject `%s` has a multi-hop privilege-escalation path that ends at a cluster-admin-equivalent identity (`verbs:[*]` on `resources:[*]`). The graph search found a chain of %d hop(s) where each hop is an RBAC primitive: secret-read into token theft, role binding, role escalation, impersonation, or pod-create-with-mounted-SA. Once a chain exists, the question is not \"could this be exploited\" but \"how quickly\" — every hop is a built-in API operation, no exploit dev needed.\n\n"+
+		Description: fmt.Sprintf("Subject `%s` has a multi-hop privilege-escalation path that ends at a cluster-admin-equivalent identity (`verbs:[*]` on `resources:[*]`). The graph search found a chain of %d hop(s) where each hop is an RBAC primitive: secret-read into token theft, role binding, role escalation, impersonation, or pod-create-with-mounted-SA. Once a chain exists, the question is not \"could this be exploited\" but \"how quickly\". Every hop is a built-in API operation, no exploit dev needed.\n\n"+
 			"The chain (each step uses an explicit RBAC verb the engine validated against the snapshot):\n%s\n\n"+
-			"This finding is correlated against pod-mounted ServiceAccounts and the engine's `correlate` pass — a chain whose source is mounted by a workload is qualitatively worse than one whose source is a manually-issued user, because every workload compromise becomes an immediate path to cluster-admin.",
+			"This finding is correlated against pod-mounted ServiceAccounts and the engine's `correlate` pass. A chain whose source is mounted by a workload is qualitatively worse than one whose source is a manually-issued user, because every workload compromise becomes an immediate path to cluster-admin.",
 			source.Key(), hopCount, formatHopList(hops)),
 		Impact:         fmt.Sprintf("Compromise of `%s` (or anything mounted by it) yields full cluster control: read every Secret, mutate any workload, exfiltrate any data, plant persistent backdoors. There is no defense-in-depth past this point.", source.Key()),
 		AttackScenario: steps,
 		Remediation:    fmt.Sprintf("Break the chain at the weakest hop: %s.", hopsRemediation(hops)),
 		RemediationSteps: []string{
 			"Confirm the chain is real with `kubectl auth can-i` for each verb the engine cited (run as the source SA / each intermediate hop).",
-			fmt.Sprintf("Identify the lowest-cost hop to break (typically %s) — removing one mid-chain hop kills the entire path.", hopsRemediation(hops)),
+			fmt.Sprintf("Identify the lowest-cost hop to break (typically %s); removing one mid-chain hop kills the entire path.", hopsRemediation(hops)),
 			"Apply the change in a non-prod cluster first; re-run the scanner to confirm the path no longer resolves.",
 			"For each remaining `wildcard verbs / wildcard resources` binding in the chain, run `audit2rbac` to derive the minimum verbs the workload actually uses, then replace.",
 			"Wire enforcement: a Kyverno or OPA Gatekeeper policy that fails any new RoleBinding/ClusterRoleBinding with `verbs:[*]` on `resources:[*]` to non-system subjects, plus a CI check that re-runs `kubesplaining` against the rendered manifests of every PR.",
@@ -239,21 +239,21 @@ func contentNodeEscapePath(source models.SubjectRef, hops []models.EscalationHop
 	for _, hop := range hops {
 		steps = append(steps, hopNarrative(hop))
 	}
-	steps = append(steps, "Final step: a privileged pod with `hostPath: /` (or `hostPID + privileged: true`) is created. The attacker `chroot /host bash` and now runs as root on the worker node — reading every other pod's filesystem, every projected ServiceAccount token on that node, and the kubelet client cert.")
+	steps = append(steps, "Final step: a privileged pod with `hostPath: /` (or `hostPID + privileged: true`) is created. The attacker `chroot /host bash` and now runs as root on the worker node, reading every other pod's filesystem, every projected ServiceAccount token on that node, and the kubelet client cert.")
 	return ruleContent{
 		Title: fmt.Sprintf("`%s` can reach **node escape** (host root) in %d hop(s)", source.Key(), hopCount),
 		Scope: scopeForPath(source, models.TargetNodeEscape),
-		Description: fmt.Sprintf("Subject `%s` has a privesc path that terminates in the ability to schedule a pod with host-level access (`hostPath: /`, `privileged: true`, `hostPID`, or hostNetwork) — which is structurally equivalent to root on the worker node. Once an attacker has node root, all defense-in-depth at the Kubernetes layer is bypassed: pod isolation depends on the kernel and runtime, not on RBAC, and node root reads every other pod's filesystem (including projected ServiceAccount tokens) and every kubelet credential.\n\n"+
+		Description: fmt.Sprintf("Subject `%s` has a privesc path that terminates in the ability to schedule a pod with host-level access (`hostPath: /`, `privileged: true`, `hostPID`, or hostNetwork), which is structurally equivalent to root on the worker node. Once an attacker has node root, all defense-in-depth at the Kubernetes layer is bypassed: pod isolation depends on the kernel and runtime, not on RBAC, and node root reads every other pod's filesystem (including projected ServiceAccount tokens) and every kubelet credential.\n\n"+
 			"The chain (%d hop(s); each step uses an explicit RBAC verb or pod primitive the engine validated):\n%s\n\n"+
 			"Node escape is qualitatively different from cluster-admin: cluster-admin gives API control; node escape gives *operational* control over a host. With node root the attacker can plant a persistent rootkit, install a kernel module, capture every container's network traffic via tcpdump on the host's `cni0/flannel.1/cali*` interface, and exfiltrate every projected ServiceAccount token by reading `/var/lib/kubelet/pods/*/volumes/.../token`. From there, those tokens cascade into more cluster-admin paths.",
 			source.Key(), hopCount, formatHopList(hops)),
-		Impact:         fmt.Sprintf("Compromise of `%s` yields host root on a worker node — every co-located pod's filesystem and every projected SA token are immediately readable, and the kubelet client cert can be used to access node-level APIs.", source.Key()),
+		Impact:         fmt.Sprintf("Compromise of `%s` yields host root on a worker node. Every co-located pod's filesystem and every projected SA token are immediately readable, and the kubelet client cert can be used to access node-level APIs.", source.Key()),
 		AttackScenario: steps,
 		Remediation:    fmt.Sprintf("Break the chain by either (a) removing the pod-creation primitive that enables node escape, or (b) constraining what privileged settings the chain's pods can request. Lowest-cost cut: %s.", hopsRemediation(hops)),
 		RemediationSteps: []string{
 			"Identify which hop ends in `pod_create_*` or grants Pod Security violations (`privileged`, `hostPath`, `hostPID`, `hostNetwork`).",
-			"Apply Pod Security Admission `restricted` profile to namespaces reachable from this chain — `kubectl label namespace <ns> pod-security.kubernetes.io/enforce=restricted`. This blocks privileged pods at admission.",
-			"Audit any namespace that is `privileged`-labeled — DaemonSets and operators that genuinely need host access should run in a dedicated namespace not reachable via tenant chains.",
+			"Apply Pod Security Admission `restricted` profile to namespaces reachable from this chain: `kubectl label namespace <ns> pod-security.kubernetes.io/enforce=restricted`. This blocks privileged pods at admission.",
+			"Audit any namespace that is `privileged`-labeled. DaemonSets and operators that genuinely need host access should run in a dedicated namespace not reachable via tenant chains.",
 			fmt.Sprintf("Remove the cited capability: %s.", hopsRemediation(hops)),
 			"Wire admission policy (Kyverno `restrict-host-path-mount`, `disallow-privileged-containers`) so future pods cannot regress.",
 		},
@@ -278,11 +278,11 @@ func contentKubeSystemSecretsPath(source models.SubjectRef, hops []models.Escala
 	return ruleContent{
 		Title: fmt.Sprintf("`%s` can read **kube-system Secrets** in %d hop(s)", source.Key(), hopCount),
 		Scope: scopeForPath(source, models.TargetKubeSystemSecrets),
-		Description: fmt.Sprintf("Subject `%s` has a privesc path that terminates in `get/list/watch secrets` in `kube-system`. This is not full cluster-admin, but it is the most consequential namespace to read — `kube-system` Secrets typically contain the credentials that *unlock* cluster-admin: cloud IAM keys (cloud-controller-manager, EBS/PD/Disk CSI), registry pull secrets (system images), addon API keys, and tokens for SAs that are themselves bound to `cluster-admin` (operator installers, helm-controllers).\n\n"+
+		Description: fmt.Sprintf("Subject `%s` has a privesc path that terminates in `get/list/watch secrets` in `kube-system`. This is not full cluster-admin, but it is the most consequential namespace to read. `kube-system` Secrets typically contain the credentials that *unlock* cluster-admin: cloud IAM keys (cloud-controller-manager, EBS/PD/Disk CSI), registry pull secrets (system images), addon API keys, and tokens for SAs that are themselves bound to `cluster-admin` (operator installers, helm-controllers).\n\n"+
 			"The chain (%d hop(s); each step uses an explicit RBAC verb the engine validated):\n%s\n\n"+
-			"In production clusters this path is the single most common one in `kubesplaining`'s output — `secrets:get` is over-granted by Helm chart defaults, by stale `view`-style roles, and by ConfigMap-reader roles that wildcard `resources` to include Secrets. The path is short (often 1-2 hops) and exploitation is trivial: the attacker decodes base64 and is in.",
+			"In production clusters this path is the single most common one in `kubesplaining`'s output. `secrets:get` is over-granted by Helm chart defaults, by stale `view`-style roles, and by ConfigMap-reader roles that wildcard `resources` to include Secrets. The path is short (often 1-2 hops) and exploitation is trivial: the attacker decodes base64 and is in.",
 			source.Key(), hopCount, formatHopList(hops)),
-		Impact:         "Reading kube-system Secrets typically yields cloud-account compromise, registry write (supply-chain implant), and tokens for cluster-admin-adjacent SAs — a one-way ratchet to full cluster control through subsequent privesc paths.",
+		Impact:         "Reading kube-system Secrets typically yields cloud-account compromise, registry write (supply-chain implant), and tokens for cluster-admin-adjacent SAs. In practice, this is a one-way ratchet to full cluster control through subsequent privesc paths.",
 		AttackScenario: steps,
 		Remediation:    fmt.Sprintf("Eliminate the path by tightening `secrets:get` in `kube-system` to a narrow allowlist of system controllers, then break the chain at: %s.", hopsRemediation(hops)),
 		RemediationSteps: []string{
@@ -310,13 +310,13 @@ func contentSystemMastersPath(source models.SubjectRef, hops []models.Escalation
 	for _, hop := range hops {
 		steps = append(steps, hopNarrative(hop))
 	}
-	steps = append(steps, "Final step: attacker can impersonate group `system:masters`. The kube-apiserver short-circuits authorization for `system:masters` via the static token / certificate path — bypassing every RBAC check. They are now indistinguishable from a kubeadm control-plane operator.")
+	steps = append(steps, "Final step: attacker can impersonate group `system:masters`. The kube-apiserver short-circuits authorization for `system:masters` via the static token / certificate path, bypassing every RBAC check. They are now indistinguishable from a kubeadm control-plane operator.")
 	return ruleContent{
-		Title: fmt.Sprintf("`%s` can impersonate **`system:masters`** in %d hop(s) — bypasses all RBAC", source.Key(), hopCount),
+		Title: fmt.Sprintf("`%s` can impersonate **`system:masters`** in %d hop(s), bypassing all RBAC", source.Key(), hopCount),
 		Scope: scopeForPath(source, models.TargetSystemMasters),
-		Description: fmt.Sprintf("Subject `%s` can chain into the ability to impersonate the `system:masters` group. `system:masters` is special: the kube-apiserver hard-codes it as authorized for *every* operation regardless of RBAC. There is no Role or ClusterRole that grants `system:masters` reach — it is a pre-RBAC carve-out for kubeadm control-plane operators (cert-based auth with `O=system:masters` skips authorization entirely).\n\n"+
+		Description: fmt.Sprintf("Subject `%s` can chain into the ability to impersonate the `system:masters` group. `system:masters` is special: the kube-apiserver hard-codes it as authorized for *every* operation regardless of RBAC. There is no Role or ClusterRole that grants `system:masters` reach. It is a pre-RBAC carve-out for kubeadm control-plane operators (cert-based auth with `O=system:masters` skips authorization entirely).\n\n"+
 			"The chain (%d hop(s); each step is an RBAC verb the engine validated):\n%s\n\n"+
-			"Impersonation of `system:masters` is the rarest but most severe finding type. Most clusters do not give workload SAs `impersonate users/groups` because `system:masters` is the pathological consequence — a single `impersonate` grant on a workload SA is the entire chain. CIS Kubernetes 5.1.4 and the RBAC good-practices guide explicitly call out impersonation grants for review.",
+			"Impersonation of `system:masters` is the rarest but most severe finding type. Most clusters do not give workload SAs `impersonate users/groups` because `system:masters` is the pathological consequence: a single `impersonate` grant on a workload SA is the entire chain. CIS Kubernetes 5.1.4 and the RBAC good-practices guide explicitly call out impersonation grants for review.",
 			source.Key(), hopCount, formatHopList(hops)),
 		Impact:         "Impersonating `system:masters` bypasses every RBAC check the cluster ever had. Every API call succeeds. Audit logs are written but the actor field shows the impersonated principal; attribution requires reading the `impersonate` audit annotation.",
 		AttackScenario: steps,
@@ -325,7 +325,7 @@ func contentSystemMastersPath(source models.SubjectRef, hops []models.Escalation
 			"List subjects with impersonate: `kubectl get rolebindings,clusterrolebindings -A -o json | jq '.items[] | select(.subjects[]? | .kind == \"User\" or .kind == \"Group\" or .kind == \"ServiceAccount\") | .metadata.name + \" → \" + (.roleRef.name)'` then check each role's rules for `impersonate`.",
 			"Almost no production workload genuinely needs `impersonate users/groups`. Kubectl plugins/dashboards that *do* need it should use `kubectl --as=...` from a human admin's session, not a workload SA.",
 			fmt.Sprintf("Break the chain: %s.", hopsRemediation(hops)),
-			"For kubectl-as-a-service workloads, scope the impersonation with `resourceNames: [<allowed-user>]` to a fixed allowlist of principals — *never* `users: [*]` or `groups: [*]`.",
+			"For kubectl-as-a-service workloads, scope the impersonation with `resourceNames: [<allowed-user>]` to a fixed allowlist of principals; *never* `users: [*]` or `groups: [*]`.",
 			"Wire admission policy: a Kyverno rule that fails any RoleBinding granting `impersonate` to a non-system subject without an explicit `resourceNames` carve-out.",
 		},
 		LearnMore: []models.Reference{
@@ -351,7 +351,7 @@ func contentGenericPath(source models.SubjectRef, target models.EscalationTarget
 		Scope: scopeForPath(source, target),
 		Description: fmt.Sprintf("Subject `%s` has a multi-hop chain to `%s`. Each hop in the chain is an RBAC primitive the engine validated against the snapshot.\n\nThe chain:\n%s",
 			source.Key(), target, formatHopList(hops)),
-		Impact:         fmt.Sprintf("Compromise of `%s` chains to `%s` — investigate the specific privileges this sink represents in your cluster.", source.Key(), target),
+		Impact:         fmt.Sprintf("Compromise of `%s` chains to `%s`. Investigate the specific privileges this sink represents in your cluster.", source.Key(), target),
 		AttackScenario: steps,
 		Remediation:    fmt.Sprintf("Break the chain at the weakest hop: %s.", hopsRemediation(hops)),
 		RemediationSteps: []string{
@@ -371,11 +371,11 @@ func contentGenericPath(source models.SubjectRef, target models.EscalationTarget
 // formatHopList renders the chain as a numbered Markdown list embeddable in Description.
 func formatHopList(hops []models.EscalationHop) string {
 	if len(hops) == 0 {
-		return "  (no hops — direct membership)"
+		return "  (no hops; direct membership)"
 	}
 	lines := make([]string, 0, len(hops))
 	for _, hop := range hops {
-		lines = append(lines, fmt.Sprintf("  %d. `%s` → `%s` via `%s` (%s) — %s", hop.Step, hop.FromSubject.Key(), hop.ToSubject.Key(), hop.Action, hop.Permission, hop.Gains))
+		lines = append(lines, fmt.Sprintf("  %d. `%s` → `%s` via `%s` (%s): %s", hop.Step, hop.FromSubject.Key(), hop.ToSubject.Key(), hop.Action, hop.Permission, hop.Gains))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/analyzer/rbac/content.go
+++ b/internal/analyzer/rbac/content.go
@@ -35,7 +35,7 @@ func scopeForRule(ruleNamespace string) models.Scope {
 	if ruleNamespace == "" {
 		return models.Scope{
 			Level:  models.ScopeCluster,
-			Detail: "Cluster-wide — applies to every current and future namespace",
+			Detail: "Cluster-wide: applies to every current and future namespace",
 		}
 	}
 	return models.Scope{
@@ -188,11 +188,11 @@ func contentPrivesc017(ruleNamespace string, subject models.SubjectRef, sourceBi
 		Scope: scope,
 		Description: fmt.Sprintf("RBAC rule from %s → %s grants `*` verbs on `*` resources in `*` apiGroups to %s. %s.\n\n"+
 			"Wildcards are dangerous beyond their current expansion: any resource type added later (CRDs, new core subresources, future verbs) is automatically granted to this subject without anyone reviewing the change. The Kubernetes project explicitly flags this in `RBAC Good Practices` as an anti-pattern.\n\n"+
-			"In a typical attack, an adversary who reaches a workload bound to this rule has full control: they read every Secret, create privileged pods on any node, bind themselves to additional ClusterRoles, and persist by minting long-lived tokens via the TokenRequest API. There is no further escalation needed — the box is already at the top.",
+			"In a typical attack, an adversary who reaches a workload bound to this rule has full control: they read every Secret, create privileged pods on any node, bind themselves to additional ClusterRoles, and persist by minting long-lived tokens via the TokenRequest API. There is no further escalation needed. The box is already at the top.",
 			sourceBinding, sourceRole, subjectKey(subject), scope.Detail),
-		Impact: fmt.Sprintf("Full control over %s — read/write every Secret, RBAC, Pod, Node; equivalent to `cluster-admin` when cluster-scoped.", phrase),
+		Impact: fmt.Sprintf("Full control over %s: read/write every Secret, RBAC, Pod, Node; equivalent to `cluster-admin` when cluster-scoped.", phrase),
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker compromises a workload that resolves to %s — vulnerable container image, supply-chain backdoor, or stolen kubeconfig.", subjectKey(subject)),
+			fmt.Sprintf("Attacker compromises a workload that resolves to %s (vulnerable container image, supply-chain backdoor, or stolen kubeconfig).", subjectKey(subject)),
 			fmt.Sprintf("They run `%s` and confirm wildcard permissions.", kubectlAuthCanI("'*'", "'*'", ruleNamespace, subject)),
 			"They list every Secret in scope (`kubectl get secrets -A -o yaml`) to harvest cloud-provider credentials, registry pull secrets, and other ServiceAccount tokens.",
 			"They create a privileged DaemonSet that mounts the host filesystem and reads `/etc/kubernetes/pki/*` to steal the cluster CA.",
@@ -200,7 +200,7 @@ func contentPrivesc017(ruleNamespace string, subject models.SubjectRef, sourceBi
 		},
 		Remediation: "Replace the wildcard rule with an explicit allowlist of (apiGroups, resources, verbs) limited to what the workload actually calls.",
 		RemediationSteps: []string{
-			fmt.Sprintf("Inventory what %s actually needs — run `%s` and correlate with audit logs filtered on `user.username`.", subjectKey(subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
+			fmt.Sprintf("Inventory what %s actually needs. Run `%s` and correlate with audit logs filtered on `user.username`.", subjectKey(subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
 			"Author a least-privilege Role/ClusterRole listing only those (apiGroups, resources, verbs); drop every wildcard. Prefer namespace-scoped Role+RoleBinding over ClusterRole+ClusterRoleBinding wherever possible.",
 			fmt.Sprintf("Apply the new binding, delete the wildcard binding %s, and verify with `%s` returning `no`.", sourceBinding, kubectlAuthCanI("'*'", "'*'", ruleNamespace, subject)),
 			"Add a ValidatingAdmissionPolicy (or Kyverno/OPA Gatekeeper rule) that rejects any future Role/ClusterRole containing `*` in verbs, resources, or apiGroups.",
@@ -221,13 +221,13 @@ func contentPrivesc005(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s read access to Secrets — `%s`", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s read access to Secrets on `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s can `get`, `list`, or `watch` core `secrets` via %s → %s. %s.\n\n"+
-			"The Kubernetes documentation is explicit that `list` and `watch` reveal Secret contents in the response body — they are not metadata-only verbs — so all three verbs leak the same data.\n\n"+
+			"The Kubernetes documentation is explicit that `list` and `watch` reveal Secret contents in the response body (they are not metadata-only verbs), so all three verbs leak the same data.\n\n"+
 			"Kubernetes Secrets typically hold ServiceAccount tokens, kubeconfigs, image-pull credentials, TLS private keys, database passwords, and integration secrets for cloud APIs. Once Secret contents are exposed, the holder can authenticate as the corresponding ServiceAccount/user, which usually amplifies the original blast radius far beyond 'read access'. Cluster-wide reads include `kube-system` ServiceAccount tokens, which are routinely cluster-admin-equivalent.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
-		Impact: fmt.Sprintf("%s read of every Secret — ServiceAccount tokens, TLS keys, registry credentials, integration secrets — enabling identity replay and cross-namespace lateral movement.", phrase),
+		Impact: fmt.Sprintf("%s read of every Secret (ServiceAccount tokens, TLS keys, registry credentials, integration secrets), enabling identity replay and cross-namespace lateral movement.", phrase),
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker reaches %s (compromised pod, leaked kubeconfig, or stolen token).", subjectKey(subject)),
 			"They run `kubectl get secrets -o yaml` in scope and base64-decode every `data` field.",
@@ -238,7 +238,7 @@ func contentPrivesc005(ruleNamespace string, subject models.SubjectRef, sourceBi
 		Remediation: "Remove `get/list/watch` on `secrets` from this subject; if a specific Secret is genuinely needed, scope by `resourceNames` to that one name.",
 		RemediationSteps: []string{
 			"Confirm the workload genuinely needs API-time Secret access. Most apps consume Secrets via volume/env injection at pod start and don't need RBAC read.",
-			"If runtime access is required, scope the rule by `resourceNames` to the exact Secret(s) the workload reads — never leave it as 'all secrets'. Drop `list` and `watch`; keep only `get`.",
+			"If runtime access is required, scope the rule by `resourceNames` to the exact Secret(s) the workload reads. Never leave it as 'all secrets'. Drop `list` and `watch`; keep only `get`.",
 			"Move the binding from cluster-wide to namespace-scoped (RoleBinding instead of ClusterRoleBinding) so the blast radius is bounded.",
 			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("list", "secrets", ruleNamespace, subject)),
 			"For sensitive Secrets (TLS keys, cloud credentials), consider an external secret store (Vault, AWS/GCP Secrets Manager via CSI driver) and enable encryption-at-rest with a KMS-backed `EncryptionConfiguration`.",
@@ -259,15 +259,15 @@ func contentPrivesc001(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s pod creation — token-theft and node-takeover path (`%s`)", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s pod creation enables token theft and node takeover (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s can `create` pods via %s → %s. %s.\n\n"+
-			"Under Kubernetes' RBAC model, pod creation is one of the most powerful permissions because the API server does not police the privileges of the pod being created — only the create verb itself. A pod is a request to run code as a ServiceAccount; by choosing `spec.serviceAccountName` the attacker borrows the identity (and RBAC permissions) of any ServiceAccount in the target namespace, with the token mounted automatically at `/var/run/secrets/kubernetes.io/serviceaccount/token`.\n\n"+
-			"Beyond identity hopping, a created pod can request `hostPath`, `hostNetwork`, `hostPID`, `privileged: true`, or `SYS_ADMIN` — none of which are blocked by RBAC; only Pod Security Admission or a policy engine (Kyverno, Gatekeeper, ValidatingAdmissionPolicy) can stop them. A typical attack mounts / from the host and reads `/etc/kubernetes/pki/admin.conf` directly.",
+			"Under Kubernetes' RBAC model, pod creation is one of the most powerful permissions because the API server does not police the privileges of the pod being created, only the create verb itself. A pod is a request to run code as a ServiceAccount; by choosing `spec.serviceAccountName` the attacker borrows the identity (and RBAC permissions) of any ServiceAccount in the target namespace, with the token mounted automatically at `/var/run/secrets/kubernetes.io/serviceaccount/token`.\n\n"+
+			"Beyond identity hopping, a created pod can request `hostPath`, `hostNetwork`, `hostPID`, `privileged: true`, or `SYS_ADMIN`. None of those are blocked by RBAC; only Pod Security Admission or a policy engine (Kyverno, Gatekeeper, ValidatingAdmissionPolicy) can stop them. A typical attack mounts / from the host and reads `/etc/kubernetes/pki/admin.conf` directly.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
 		Impact: fmt.Sprintf("Run arbitrary code as any ServiceAccount in %s (including privileged ones); optionally request privileged/host-mount pods to escape to the underlying node.", phrase),
 		AttackScenario: []string{
-			"Attacker enumerates target namespaces — `kubectl get sa -A` to find privileged ServiceAccounts (e.g. `kube-system/clusterrole-aggregation-controller`).",
+			"Attacker enumerates target namespaces with `kubectl get sa -A` to find privileged ServiceAccounts (e.g. `kube-system/clusterrole-aggregation-controller`).",
 			"They craft a pod manifest with `spec.serviceAccountName: <privileged-sa>` and any container image they control.",
 			"They `kubectl apply -f` the pod; the kubelet mounts the privileged ServiceAccount's JWT into the container at the well-known path.",
 			"They `exec` into the pod (or have the container phone home), read the token, and replay it against the API server.",
@@ -296,15 +296,15 @@ func contentPrivesc003(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s workload-controller mutation can spawn privileged pods — `%s`", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s workload-controller mutation can spawn privileged pods on `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s can `create/update/patch` workload controllers (`deployments`, `daemonsets`, `statefulsets`, `jobs`, `cronjobs`) via %s → %s. %s.\n\n"+
-			"Anyone who can write a workload template inherits the same implicit permissions as `pods/create`: choice of ServiceAccount, choice of Pod Security context, and choice of host-level features. The specific danger of controller mutation (vs. pod create) is durability and stealth: a `kubectl edit deployment` adding a `privileged: true` sidecar produces pods continuously — restart-loop the pod and you get a fresh shell every time.\n\n"+
-			"DaemonSet write is the most dangerous variant because a DaemonSet runs one pod on every node — including new nodes added later. CronJobs offer time-based persistence that survives pod evictions, node reboots, and short-lived RBAC remediations. A realistic incident: an attacker with `patch daemonsets` in `kube-system` mutates `kube-proxy` to add a malicious sidecar inheriting the existing pod's host-mounts and ServiceAccount.",
+			"Anyone who can write a workload template inherits the same implicit permissions as `pods/create`: choice of ServiceAccount, choice of Pod Security context, and choice of host-level features. The specific danger of controller mutation (vs. pod create) is durability and stealth: a `kubectl edit deployment` adding a `privileged: true` sidecar produces pods continuously, so restart-looping the pod returns a fresh shell every time.\n\n"+
+			"DaemonSet write is the most dangerous variant because a DaemonSet runs one pod on every node, including new nodes added later. CronJobs offer time-based persistence that survives pod evictions, node reboots, and short-lived RBAC remediations. A realistic incident: an attacker with `patch daemonsets` in `kube-system` mutates `kube-proxy` to add a malicious sidecar inheriting the existing pod's host-mounts and ServiceAccount.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
-		Impact: fmt.Sprintf("Spawn (or mutate existing) pods running as any ServiceAccount in %s; DaemonSet write specifically yields one attacker pod per node, including future nodes.", phrase),
+		Impact: fmt.Sprintf("Spawn (or mutate existing) pods running as any ServiceAccount in %s. DaemonSet write specifically yields one attacker pod per node, including future nodes.", phrase),
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker enumerates writable controllers — `%s`.", kubectlAuthCanI("patch", "daemonsets", ruleNamespace, subject)),
+			fmt.Sprintf("Attacker enumerates writable controllers with `%s`.", kubectlAuthCanI("patch", "daemonsets", ruleNamespace, subject)),
 			"They identify a high-value DaemonSet (e.g. `kube-system/kube-proxy`, `kube-system/cilium`, or any node-agent that already runs privileged).",
 			"They `kubectl patch` to add a sidecar container under their control, inheriting the existing pod's host-mounts, capabilities, and ServiceAccount.",
 			"The DaemonSet controller rolls the change to every node; the attacker now has a privileged shell on every node and a node-level token on each.",
@@ -333,15 +333,15 @@ func contentPrivesc008(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s `impersonate` permission — `%s`", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s `impersonate` permission on `%s`", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s has the `impersonate` verb on `users/groups/serviceaccounts` via %s → %s. %s.\n\n"+
 			"Kubernetes' impersonation lets a request set `Impersonate-User/Impersonate-Group` headers (or `kubectl --as`) so the API server processes the request as a different identity. The Kubernetes project flags this in `RBAC Good Practices` as one of three verbs (alongside `bind` and `escalate`) that override normal RBAC limits.\n\n"+
-			"Most damaging is the ability to impersonate the `system:masters` group, which is hardcoded inside kube-apiserver to bypass RBAC entirely — there is no Role or RoleBinding that grants `system:masters` membership; the apiserver simply trusts the assertion. `kubectl --as=admin --as-group=system:masters get secrets -A` runs as cluster-admin, full stop. Impersonation is also stealthier than a binding change because audit logs show `user.username` as the original subject.",
+			"Most damaging is the ability to impersonate the `system:masters` group, which is hardcoded inside kube-apiserver to bypass RBAC entirely. There is no Role or RoleBinding that grants `system:masters` membership; the apiserver simply trusts the assertion. `kubectl --as=admin --as-group=system:masters get secrets -A` runs as cluster-admin, full stop. Impersonation is also stealthier than a binding change because audit logs show `user.username` as the original subject.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
 		Impact: fmt.Sprintf("Act as any user/group/ServiceAccount in %s; impersonating `system:masters` bypasses all RBAC checks irrevocably.", phrase),
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("impersonate", "users", ruleNamespace, subject)),
+			fmt.Sprintf("Attacker confirms the verb with `%s`.", kubectlAuthCanI("impersonate", "users", ruleNamespace, subject)),
 			"They run `kubectl --as=admin --as-group=system:masters get clusterrolebindings` to confirm `system:masters` impersonation succeeds.",
 			"They impersonate the highest-privileged ServiceAccount they can find (e.g. `system:serviceaccount:kube-system:clusterrole-aggregation-controller`) and exfiltrate Secrets cluster-wide.",
 			"They establish persistence by creating a benign-looking ClusterRoleBinding via the impersonated identity (audit logs blame the impersonated SA, not the attacker).",
@@ -350,7 +350,7 @@ func contentPrivesc008(ruleNamespace string, subject models.SubjectRef, sourceBi
 		Remediation: "Remove `impersonate` entirely; if a SaaS console truly needs it, gate on `resourceNames` and never grant it on `groups`.",
 		RemediationSteps: []string{
 			"Remove `impersonate` on `users`, `groups`, and `serviceaccounts`. The vast majority of workloads have no need for impersonation.",
-			"If impersonation is genuinely required, scope to `users` only (not `groups` — never allow `system:masters`), use `resourceNames` to allow only specific identities, and never grant cluster-wide.",
+			"If impersonation is genuinely required, scope to `users` only (not `groups`, and never allow `system:masters`), use `resourceNames` to allow only specific identities, and never grant cluster-wide.",
 			"Enable Impersonate-* audit policy at `Metadata` level minimum so every impersonated request is logged with the original caller. SIEM-alert on impersonation of any `system:` user or group.",
 			fmt.Sprintf("Verify with `%s` returning `no`.", kubectlAuthCanI("impersonate", "'*'", ruleNamespace, subject)),
 		},
@@ -370,16 +370,16 @@ func contentPrivesc009(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s `bind/escalate` on roles — RBAC bypass (`%s`)", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s `bind/escalate` on roles bypasses RBAC (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s has the `bind` or `escalate` verb on `roles/clusterroles` via %s → %s. %s.\n\n"+
 			"Kubernetes' RBAC normally enforces a privilege-escalation guard: you cannot create a Role/RoleBinding granting permissions you do not already hold. The `escalate` and `bind` verbs are explicit, documented exceptions to that guard.\n\n"+
-			"`escalate` lets the subject author or modify a Role/ClusterRole with verbs and resources they don't currently possess — they rewrite an existing Role they're already bound to and instantly inherit whatever they wrote into it.\n\n"+
+			"`escalate` lets the subject author or modify a Role/ClusterRole with verbs and resources they don't currently possess. In practice, they rewrite an existing Role they're already bound to and instantly inherit whatever they wrote into it.\n\n"+
 			"`bind` lets the subject create a RoleBinding/ClusterRoleBinding referencing a (Cluster)Role they don't already hold. With `bind` on `clusterroles`, an attacker creates a ClusterRoleBinding from themselves to `cluster-admin` and is done in one step.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
 		Impact: fmt.Sprintf("Defeat the API-level escalation guard in %s; subject can grant itself any (Cluster)Role's permissions, including `cluster-admin`.", phrase),
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("bind", "clusterroles", ruleNamespace, subject)),
+			fmt.Sprintf("Attacker confirms the verb with `%s`.", kubectlAuthCanI("bind", "clusterroles", ruleNamespace, subject)),
 			"They write a one-line ClusterRoleBinding from their identity (or a SA they control) to the `cluster-admin` ClusterRole and `kubectl apply` it.",
 			"They re-use the same token (ClusterRoleBindings take effect immediately on next request) and have full cluster control.",
 			"Alternatively, with `escalate` on `clusterroles`, they `kubectl edit clusterrole/<role-they-already-have>` and add `*` verbs/resources/apiGroups, retaining the same binding.",
@@ -387,7 +387,7 @@ func contentPrivesc009(ruleNamespace string, subject models.SubjectRef, sourceBi
 		},
 		Remediation: "Remove `bind` and `escalate` from non-admin identities; gate any legitimate need behind admission policy that rejects bindings to `cluster-admin` or system roles.",
 		RemediationSteps: []string{
-			"Audit every Role/ClusterRole that includes `bind` or `escalate` — `kubectl get clusterroles,roles -A -o json | jq '.items[] | select(.rules[]?.verbs[]? | IN(\"bind\",\"escalate\"))'`.",
+			"Audit every Role/ClusterRole that includes `bind` or `escalate` with `kubectl get clusterroles,roles -A -o json | jq '.items[] | select(.rules[]?.verbs[]? | IN(\"bind\",\"escalate\"))'`.",
 			"Remove the verbs from this Role/ClusterRole. If operators legitimately need them (Argo CD, Crossplane, OperatorHub), scope `bind` with `resourceNames` to a list of low-privilege ClusterRoles.",
 			"Add a ValidatingAdmissionPolicy (or Kyverno) that rejects creation of any ClusterRoleBinding referencing `cluster-admin/admin/system:masters` outside a tiny admin allowlist.",
 			fmt.Sprintf("Verify with `%s` and `%s` both returning `no`.", kubectlAuthCanI("bind", "clusterroles", ruleNamespace, subject), kubectlAuthCanI("escalate", "roles", ruleNamespace, subject)),
@@ -408,15 +408,15 @@ func contentPrivesc010(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s write access to (Cluster)RoleBindings — self-grant path (`%s`)", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s write access to (Cluster)RoleBindings opens a self-grant path (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s can `create/update/patch` `rolebindings/clusterrolebindings` via %s → %s. %s.\n\n"+
 			"RoleBinding write is the most direct self-grant path in Kubernetes. Even with the API-level escalation guard active (binding only to roles whose permissions you already have), this permission is dangerous: if the subject already holds any powerful permission (often inherited from a default ClusterRole like `view/edit`), they can re-bind it to backup identities for persistence.\n\n"+
-			"A RoleBinding can also reference a *ClusterRole*, granting that ClusterRole's permissions inside the binding's namespace — so `create rolebindings` in `kube-system` is effectively cluster-admin-on-kube-system. Combined with `bind` on `clusterroles` (KUBE-PRIVESC-009), this bypasses the escalation guard entirely and yields cluster-admin in one step. Microsoft's Threat Matrix for Kubernetes documents this as the `Cluster-admin binding` technique.",
+			"A RoleBinding can also reference a *ClusterRole*, granting that ClusterRole's permissions inside the binding's namespace, so `create rolebindings` in `kube-system` is effectively cluster-admin-on-kube-system. Combined with `bind` on `clusterroles` (KUBE-PRIVESC-009), this bypasses the escalation guard entirely and yields cluster-admin in one step. Microsoft's Threat Matrix for Kubernetes documents this as the `Cluster-admin binding` technique.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
 		Impact: "Self-grant any role the subject already holds (or any ClusterRole, when paired with `bind` or when binding into namespaces); cluster-wide writes are one step from cluster-admin.",
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker enumerates what they can already bind — `%s` and `%s`.", kubectlAuthCanI("create", "clusterrolebindings", ruleNamespace, subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
+			fmt.Sprintf("Attacker enumerates what they can already bind with `%s` and `%s`.", kubectlAuthCanI("create", "clusterrolebindings", ruleNamespace, subject), kubectlAuthCanI("--list", "", ruleNamespace, subject)),
 			"If they hold a useful role, they create a ClusterRoleBinding granting that role to a backup identity for persistence.",
 			"With `bind` on `cluster-admin` (often via wildcards), they create a ClusterRoleBinding from themselves to `cluster-admin`.",
 			"Even without `bind`, in `kube-system` they create a RoleBinding referencing `system:controller:clusterrole-aggregation-controller` (which has `escalate` baked in) and pivot from there.",
@@ -424,7 +424,7 @@ func contentPrivesc010(ruleNamespace string, subject models.SubjectRef, sourceBi
 		},
 		Remediation: "Restrict `create/update/patch` on `rolebindings/clusterrolebindings` to a small admin boundary; require all RBAC changes to flow through GitOps with PR review.",
 		RemediationSteps: []string{
-			"Audit who has write access to RBAC bindings — most workloads should have zero RBAC write rights.",
+			"Audit who has write access to RBAC bindings. Most workloads should have zero RBAC write rights.",
 			"Remove the verbs entirely from this Role/ClusterRole, or scope them with `resourceNames` to a fixed list of binding names that the workload owns.",
 			"Move RBAC management to GitOps (Argo CD/Flux) so binding changes require a PR. The GitOps controller should be the only identity with cluster-wide RBAC write access.",
 			"Add a ValidatingAdmissionPolicy that rejects ClusterRoleBindings to high-risk ClusterRoles (`cluster-admin`, `admin`, anything matching `*system:*`) outside an approved admin allowlist.",
@@ -449,23 +449,23 @@ func contentPrivesc012(ruleNamespace string, subject models.SubjectRef, sourceBi
 		Detail: "Cluster-wide kubelet API on every node (nodes is cluster-scoped)",
 	}
 	return ruleContent{
-		Title: fmt.Sprintf("`get nodes/proxy` — kubelet exec via API server (`%s`)", subjectKey(subject)),
+		Title: fmt.Sprintf("`get nodes/proxy` enables kubelet exec via API server (`%s`)", subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s can `get` `nodes/proxy` via %s → %s. Despite the read-only-sounding `get` verb, this permission lets the holder execute arbitrary commands inside any pod on any node by tunneling through the API server to the kubelet's internal HTTP API — `/exec`, `/run`, `/attach`, `/portforward`.\n\n"+
-			"The technical root cause: pod exec uses an HTTP-to-WebSocket upgrade. The API server authorizes the upgrade based on the initial GET against the proxy subresource — not against `pods/exec`. So a subject with `get nodes/proxy` can issue `kubectl get --raw '/api/v1/nodes/<node>/proxy/exec/...'` and end up with an interactive shell in any container, even with no `pods/exec` permission anywhere.\n\n"+
-			"Worse, the resulting commands execute over a direct API-server-to-kubelet WebSocket and are NOT recorded in apiserver audit logs at the `objectRef/verb` granularity — the audit log shows only the proxy GET. Detection requires node-level eBPF/process monitoring (Falco, Tetragon, KubeArmor), not API-server logs alone. Kubernetes issue #119640 and Stream Security have published proof-of-concept exploits.",
+		Description: fmt.Sprintf("Subject %s can `get` `nodes/proxy` via %s → %s. Despite the read-only-sounding `get` verb, this permission lets the holder execute arbitrary commands inside any pod on any node by tunneling through the API server to the kubelet's internal HTTP API: `/exec`, `/run`, `/attach`, `/portforward`.\n\n"+
+			"The technical root cause: pod exec uses an HTTP-to-WebSocket upgrade. The API server authorizes the upgrade based on the initial GET against the proxy subresource, not against `pods/exec`. So a subject with `get nodes/proxy` can issue `kubectl get --raw '/api/v1/nodes/<node>/proxy/exec/...'` and end up with an interactive shell in any container, even with no `pods/exec` permission anywhere.\n\n"+
+			"Worse, the resulting commands execute over a direct API-server-to-kubelet WebSocket and are NOT recorded in apiserver audit logs at the `objectRef/verb` granularity. The audit log shows only the proxy GET. Detection requires node-level eBPF/process monitoring (Falco, Tetragon, KubeArmor), not API-server logs alone. Kubernetes issue #119640 and Stream Security have published proof-of-concept exploits.",
 			subjectKey(subject), sourceBinding, sourceRole),
 		Impact: "Cluster-wide remote code execution: exec into any container on any node via the kubelet API, with execution invisible to standard apiserver audit logs.",
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("get", "nodes/proxy", "", subject)),
-			"They list nodes (`kubectl get nodes`) and pick a high-value one — typically a control-plane node, or any node hosting `kube-apiserver/etcd`/operator pods.",
+			fmt.Sprintf("Attacker confirms the verb with `%s`.", kubectlAuthCanI("get", "nodes/proxy", "", subject)),
+			"They list nodes (`kubectl get nodes`) and pick a high-value one, typically a control-plane node or any node hosting `kube-apiserver/etcd`/operator pods.",
 			"They issue an exec request via the proxy endpoint, e.g. `kubectl get --raw '/api/v1/nodes/<node>/proxy/run/kube-system/<pod>/<container>?cmd=id'`, or open a WebSocket to `/exec`.",
 			"They land in the target container with that container's privileges (host-mounts, capabilities, ServiceAccount token).",
 			"From a control-plane container they read `/etc/kubernetes/pki/admin.conf` for cluster-admin credentials. The entire chain leaves no `pods/exec` audit entries.",
 		},
 		Remediation: "Remove `nodes/proxy` from this subject; reserve it for the API server itself and a tiny set of trusted operators that document this need.",
 		RemediationSteps: []string{
-			"Remove the rule entirely. Application workloads never need `nodes/proxy` — Kubernetes documents this as a 'severe escalation hazard' in RBAC Good Practices.",
+			"Remove the rule entirely. Application workloads never need `nodes/proxy`; Kubernetes documents this as a 'severe escalation hazard' in RBAC Good Practices.",
 			"If a monitoring/observability stack genuinely requires it, migrate to the `nodes/metrics` and `nodes/stats` subresources, which expose telemetry without the exec endpoints.",
 			"Deploy node-level runtime monitoring (Falco, Tetragon, KubeArmor) to detect kubelet `/exec`, `/run`, `/attach` usage at the kernel level.",
 			fmt.Sprintf("Verify with `%s` returning `no`. Test the high-impact case with `kubectl get --raw '/api/v1/nodes/<node>/proxy/run/...'` returning 403.", kubectlAuthCanI("get", "nodes/proxy", "", subject)),
@@ -486,19 +486,19 @@ func contentPrivesc014(ruleNamespace string, subject models.SubjectRef, sourceBi
 	scope := scopeForRule(ruleNamespace)
 	phrase := scopePhrase(scope)
 	return ruleContent{
-		Title: fmt.Sprintf("%s `create serviceaccounts/token` — token minting (`%s`)", phrase, subjectKey(subject)),
+		Title: fmt.Sprintf("%s `create serviceaccounts/token` enables token minting (`%s`)", phrase, subjectKey(subject)),
 		Scope: scope,
 		Description: fmt.Sprintf("Subject %s can `create` on the `serviceaccounts/token` subresource via %s → %s. %s.\n\n"+
 			"The TokenRequest API (Kubernetes 1.22+) is the canonical way to mint a JWT ServiceAccount token, and its `create` verb is gated by RBAC on the `serviceaccounts/token` subresource. Anyone holding this verb on a ServiceAccount can mint a token authenticated as that ServiceAccount.\n\n"+
-			"Datadog Security Labs published a write-up on its abuse for persistence: an attacker mints a long-lived token for the highest-privileged ServiceAccount they can reach (commonly `kube-system/clusterrole-aggregation-controller`, which holds `escalate` on ClusterRoles), and uses that token as a backdoor that survives the original RBAC binding being removed. Crucially, this verb is NOT covered by 'list secrets' detections — TokenRequest tokens are NOT stored as Secret objects; they're issued live by the apiserver and never leave a footprint on disk.",
+			"Datadog Security Labs published a write-up on its abuse for persistence: an attacker mints a long-lived token for the highest-privileged ServiceAccount they can reach (commonly `kube-system/clusterrole-aggregation-controller`, which holds `escalate` on ClusterRoles), and uses that token as a backdoor that survives the original RBAC binding being removed. Crucially, this verb is NOT covered by 'list secrets' detections. TokenRequest tokens are NOT stored as Secret objects; they're issued live by the apiserver and never leave a footprint on disk.",
 			subjectKey(subject), sourceBinding, sourceRole, scope.Detail),
 		Impact: fmt.Sprintf("Mint a JWT for any ServiceAccount in %s. Cluster-wide variant trivially yields cluster-admin (mint a kube-system controller token). Tokens persist after the original binding is revoked.", phrase),
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker confirms the verb — `%s`.", kubectlAuthCanI("create", "serviceaccounts/token", ruleNamespace, subject)),
+			fmt.Sprintf("Attacker confirms the verb with `%s`.", kubectlAuthCanI("create", "serviceaccounts/token", ruleNamespace, subject)),
 			"They enumerate high-privilege ServiceAccounts: `kubectl get clusterrolebindings -o json | jq '.items[].subjects[]?.name'` and pick one with `cluster-admin`, `system:masters`, or aggregated permissions.",
 			"They mint a long-lived token via the TokenRequest API: `kubectl create token <sa-name> -n <ns> --duration=8760h` (1 year), or call `/api/v1/namespaces/<ns>/serviceaccounts/<sa>/token` directly.",
 			"They `kubectl --token=<jwt> get nodes` and confirm the new identity.",
-			"They cache the token off-cluster as a backdoor: rotating the original binding does NOT invalidate an issued token until its `exp` claim — by default up to `--service-account-max-token-expiration`, often 1 year on legacy clusters.",
+			"They cache the token off-cluster as a backdoor: rotating the original binding does NOT invalidate an issued token until its `exp` claim, which defaults to `--service-account-max-token-expiration` (often 1 year on legacy clusters).",
 		},
 		Remediation: "Remove `create` on `serviceaccounts/token` from non-control-plane identities; constrain any legitimate use with `resourceNames` to a tiny allowlist.",
 		RemediationSteps: []string{
@@ -528,13 +528,13 @@ func contentRBACOverbroad001(subject models.SubjectRef, bindingName string) rule
 	return ruleContent{
 		Title: fmt.Sprintf("Non-system subject `%s` directly bound to `cluster-admin`", subjectKey(subject)),
 		Scope: scope,
-		Description: fmt.Sprintf("Subject %s is directly bound to the built-in `cluster-admin` ClusterRole via the ClusterRoleBinding `%s`. The `cluster-admin` ClusterRole grants `*` on `*` resources in `*` apiGroups — full read/write to every Kubernetes object including Secrets, RBAC, Nodes, Pods, and CRDs cluster-wide.\n\n"+
+		Description: fmt.Sprintf("Subject %s is directly bound to the built-in `cluster-admin` ClusterRole via the ClusterRoleBinding `%s`. The `cluster-admin` ClusterRole grants `*` on `*` resources in `*` apiGroups, which means full read/write to every Kubernetes object: Secrets, RBAC, Nodes, Pods, and CRDs cluster-wide.\n\n"+
 			"Microsoft's Threat Matrix for Kubernetes lists `Cluster-admin binding` as a top-tier privilege-escalation technique, and CIS Kubernetes Benchmark control 5.1.1 ('Ensure that the cluster-admin role is only used where required') is one of the foundational RBAC hardening checks. Common anti-patterns that produce this finding: `kubectl create clusterrolebinding admin-binding --clusterrole=cluster-admin --user=alice@example.com` for a developer; Helm charts that ship a default ClusterRoleBinding to `cluster-admin`; SaaS/operator installers that take the lazy path.\n\n"+
 			"An attacker who compromises %s (stolen kubeconfig, vulnerable container, supply-chain backdoor, or OIDC token replay) immediately holds full cluster control with zero lateral movement required.",
 			subjectKey(subject), bindingName, subjectKey(subject)),
 		Impact: "Full cluster control: read/write every resource cluster-wide, mint any token, modify any binding, schedule on any node. Equivalent to root on the entire cluster.",
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker compromises %s — stolen kubeconfig, OIDC session hijack, leaked CI credential, or compromised pod mounting the SA token.", subjectKey(subject)),
+			fmt.Sprintf("Attacker compromises %s (stolen kubeconfig, OIDC session hijack, leaked CI credential, or compromised pod mounting the SA token).", subjectKey(subject)),
 			"They run `kubectl auth can-i '*' '*' --all-namespaces` and confirm `yes`.",
 			"They harvest all Secrets cluster-wide for cloud-credential pivot.",
 			"They establish persistence by minting a 1-year TokenRequest for `kube-system/clusterrole-aggregation-controller`, or by creating a benign-looking ClusterRoleBinding to a backup identity.",

--- a/internal/analyzer/secrets/content.go
+++ b/internal/analyzer/secrets/content.go
@@ -51,17 +51,17 @@ func contentSecrets001(namespace, name string) ruleContent {
 		Title: fmt.Sprintf("Secret `%s/%s` is a long-lived `kubernetes.io/service-account-token` (legacy, no expiry)", namespace, name),
 		Scope: models.Scope{
 			Level:  models.ScopeObject,
-			Detail: fmt.Sprintf("Secret `%s/%s` — credential is valid until manually deleted; readable by any subject with `get/list secrets` in `%s`", namespace, name, namespace),
+			Detail: fmt.Sprintf("Secret `%s/%s`: credential is valid until manually deleted; readable by any subject with `get/list secrets` in `%s`", namespace, name, namespace),
 		},
 		Description: fmt.Sprintf("Secret `%s/%s` has type `kubernetes.io/service-account-token`. This is the legacy ServiceAccount token model: the token-controller persists a JWT into a Secret, the token has *no expiry* (the audience is the API server, the validity is open-ended), and it is readable by any subject with `get/list secrets` permission in the namespace.\n\n"+
-			"Since Kubernetes v1.22, Bound ServiceAccount Tokens (KEP-1205) replaced this model: the kubelet projects a *new* token into the pod's filesystem with a short TTL (default 1h) and the token is bound to the pod object, so deleting the pod invalidates the token. v1.24 stopped auto-creating these legacy Secret tokens, and v1.27+ ships the `LegacyServiceAccountTokenCleaner` controller that removes unused ones automatically. A legacy token Secret today is either an artifact of a pre-1.24 cluster, a manually-created `serviceAccountToken` Secret, or a controller that explicitly created one — none of which carry the bind-to-pod, time-bounded properties of projected tokens.\n\n"+
+			"Since Kubernetes v1.22, Bound ServiceAccount Tokens (KEP-1205) replaced this model: the kubelet projects a *new* token into the pod's filesystem with a short TTL (default 1h) and the token is bound to the pod object, so deleting the pod invalidates the token. v1.24 stopped auto-creating these legacy Secret tokens, and v1.27+ ships the `LegacyServiceAccountTokenCleaner` controller that removes unused ones automatically. A legacy token Secret today is either an artifact of a pre-1.24 cluster, a manually-created `serviceAccountToken` Secret, or a controller that explicitly created one. None of these carry the bind-to-pod, time-bounded properties of projected tokens.\n\n"+
 			"The risk profile: a leaked legacy token grants whatever permissions its ServiceAccount has, *forever*, with no automatic revocation. It survives Pod restarts, node reboots, audit events, and rotation of the SA itself. Detection of misuse requires explicit audit-log monitoring against the SA name; rotation requires deleting the Secret and reissuing.",
 			namespace, name),
 		Impact: "Anyone who exfiltrates this Secret holds a non-expiring credential with the ServiceAccount's full RBAC; rotation requires manual `kubectl delete secret` and re-issue, and there is no time-based mitigation.",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker compromises any subject with `get secrets` in `%s` (e.g., a forgotten `view`-style role, an over-permissive ConfigMap-reader role that wildcards resources, or a pod token with secret-read).", namespace),
 			fmt.Sprintf("They `kubectl get secret %s -n %s -o jsonpath='{.data.token}' | base64 -d` and obtain the raw JWT.", name, namespace),
-			"They use the token against the kube-apiserver from outside the cluster (`kubectl --token=...`) — no pod, no node, no IMDS hop required.",
+			"They use the token against the kube-apiserver from outside the cluster (`kubectl --token=...`). No pod, no node, no IMDS hop required.",
 			"Because the token has no `exp` claim and no audience binding to a Pod, it remains valid weeks or months later. Rotation in IR is manual: delete the Secret + recreate, and any cached copies attacker has are *still valid until that delete*.",
 			"Attacker uses the SA's RBAC to read other Secrets, list pods cluster-wide (if SA has it), exec into pods, or escalate via any of the privesc paths the SA enables.",
 		},
@@ -89,26 +89,26 @@ func contentSecrets002(name string) ruleContent {
 		Title: fmt.Sprintf("Opaque Secret `kube-system/%s` likely holds control-plane or addon credentials", name),
 		Scope: models.Scope{
 			Level:  models.ScopeObject,
-			Detail: fmt.Sprintf("Secret `kube-system/%s` — control-plane namespace; readers in `kube-system` are typically system controllers and high-privilege operators", name),
+			Detail: fmt.Sprintf("Secret `kube-system/%s`: control-plane namespace; readers in `kube-system` are typically system controllers and high-privilege operators", name),
 		},
-		Description: fmt.Sprintf("Secret `kube-system/%s` has type `Opaque`. The `kube-system` namespace is reserved for control-plane workloads and cluster add-ons (cloud-controller-manager, CNI, CSI, ingress controllers, certificate operators, observability agents) — Opaque Secrets there are almost always one of: cloud IAM credentials for the cloud-controller-manager, registry pull secrets for system images, TLS client certs for an etcd snapshot agent, kubeconfigs for an external-DNS controller, or addon-vendor API keys.\n\n"+
+		Description: fmt.Sprintf("Secret `kube-system/%s` has type `Opaque`. The `kube-system` namespace is reserved for control-plane workloads and cluster add-ons (cloud-controller-manager, CNI, CSI, ingress controllers, certificate operators, observability agents). Opaque Secrets there are almost always one of: cloud IAM credentials for the cloud-controller-manager, registry pull secrets for system images, TLS client certs for an etcd snapshot agent, kubeconfigs for an external-DNS controller, or addon-vendor API keys.\n\n"+
 			"Because of where they live, these Secrets carry outsized blast radius compared to a workload Secret. A leak here typically grants either (a) credentials to the cloud account hosting the cluster, (b) the ability to publish or pull from the cluster's container registry, or (c) durable access to control-plane components that can be used to subvert further controls.\n\n"+
-			"Two specific concerns: (1) `kube-system` Secrets are often forgotten when teams set up Vault or external-secret-store integrations — they live on as the bootstrap credential, never rotated; (2) RBAC for `kube-system` is typically broad (operator service accounts often `cluster-admin`-adjacent) so the set of subjects that can read them is much larger than the team realizes.",
+			"Two specific concerns: (1) `kube-system` Secrets are often forgotten when teams set up Vault or external-secret-store integrations, so they live on as the bootstrap credential, never rotated; (2) RBAC for `kube-system` is typically broad (operator service accounts often `cluster-admin`-adjacent) so the set of subjects that can read them is much larger than the team realizes.",
 			name),
 		Impact: "This Secret likely encodes credentials with cluster-wide or cloud-account reach. A read by any subject with `get secrets` in `kube-system` (operator SAs, kube-system pods, cluster-admin tokens) escalates to whatever the credential authorizes.",
 		AttackScenario: []string{
 			"Attacker gains a `kube-system` ServiceAccount token with `get secrets` (e.g., compromised addon, addon-installer Job, helm-release Secret reader).",
 			fmt.Sprintf("They `kubectl get secret %s -n kube-system -o yaml` and decode each `data` key.", name),
 			"They identify the credential type: AWS access key (`aws_access_key_id/aws_secret_access_key`), GCP service-account JSON, Azure tenant/client ID, Docker config (registry credentials), or an inline kubeconfig.",
-			"They authenticate out-of-cluster with the credential — cloud account compromise, registry image-publishing for supply-chain implant, or a parallel kubeconfig that survives in-cluster RBAC revocation.",
+			"They authenticate out-of-cluster with the credential: cloud account compromise, registry image-publishing for supply-chain implant, or a parallel kubeconfig that survives in-cluster RBAC revocation.",
 			"They persist by issuing a new IAM key / pushing an unsigned image / writing a kubeconfig to a hidden location, then cover by deleting their access logs.",
 		},
 		Remediation: fmt.Sprintf("Audit `kube-system/%s`'s contents and consumers; rotate the credential; move long-lived credentials to a sealed-secret or external secret store; restrict who can `get secrets` in `kube-system`.", name),
 		RemediationSteps: []string{
-			fmt.Sprintf("Inspect the Secret's content shape (key names, not values) to identify the credential type — `kubectl get secret %s -n kube-system -o jsonpath='{.data}' | jq 'keys'`.", name),
+			fmt.Sprintf("Inspect the Secret's content shape (key names, not values) to identify the credential type via `kubectl get secret %s -n kube-system -o jsonpath='{.data}' | jq 'keys'`.", name),
 			fmt.Sprintf("Find consumers: `kubectl get pods -n kube-system -o json | jq '.items[] | select(.spec.volumes[]?.secret.secretName == \"%s\" or .spec.containers[].envFrom[]?.secretRef.name == \"%s\") | .metadata.name'`.", name, name),
-			"Rotate the underlying credential at its source (cloud IAM, registry, etc.) and update the Secret with the new value — preferably by switching to External Secrets Operator (Vault/SecretsManager backend) so the Secret becomes a generated artifact instead of source-of-truth.",
-			"Tighten RBAC on `kube-system` Secrets — most operator SAs only need their own Secret, not `secrets` cluster-wide. Audit with `kubectl auth can-i get secrets -n kube-system --as=system:serviceaccount:kube-system:<sa>` for each one.",
+			"Rotate the underlying credential at its source (cloud IAM, registry, etc.) and update the Secret with the new value, preferably by switching to External Secrets Operator (Vault/SecretsManager backend) so the Secret becomes a generated artifact instead of source-of-truth.",
+			"Tighten RBAC on `kube-system` Secrets so each operator SA only sees its own Secret, not `secrets` cluster-wide. Audit with `kubectl auth can-i get secrets -n kube-system --as=system:serviceaccount:kube-system:<sa>` for each one.",
 			"Wire enforcement: a Kyverno or OPA Gatekeeper policy that flags any Pod referencing a long-lived `kube-system` Secret name not on an allowlist.",
 		},
 		LearnMore: []models.Reference{
@@ -127,23 +127,23 @@ func contentConfigMap001(namespace, name string, matchedKeys []string) ruleConte
 		Title: fmt.Sprintf("ConfigMap `%s/%s` exposes credential-shaped keys (`%s`) in plaintext", namespace, name, keysList),
 		Scope: models.Scope{
 			Level:  models.ScopeObject,
-			Detail: fmt.Sprintf("ConfigMap `%s/%s` — readable by every subject with `get configmaps` in `%s`, ships unencrypted in etcd, surfaces in `kubectl describe` and audit logs", namespace, name, namespace),
+			Detail: fmt.Sprintf("ConfigMap `%s/%s`: readable by every subject with `get configmaps` in `%s`, ships unencrypted in etcd, surfaces in `kubectl describe` and audit logs", namespace, name, namespace),
 		},
-		Description: fmt.Sprintf("ConfigMap `%s/%s` contains keys with names matching credential-like patterns: `%s`. The Kubernetes API treats ConfigMaps as non-sensitive — etcd stores them unencrypted by default (encryption-at-rest is opt-in and almost always limited to Secrets), `kubectl describe configmap` prints values inline, audit logs include the data on get/list, and RBAC defaults give workload service accounts much wider read on ConfigMaps than on Secrets.\n\n"+
+		Description: fmt.Sprintf("ConfigMap `%s/%s` contains keys with names matching credential-like patterns: `%s`. The Kubernetes API treats ConfigMaps as non-sensitive: etcd stores them unencrypted by default (encryption-at-rest is opt-in and almost always limited to Secrets), `kubectl describe configmap` prints values inline, audit logs include the data on get/list, and RBAC defaults give workload service accounts much wider read on ConfigMaps than on Secrets.\n\n"+
 			"Storing a credential in a ConfigMap therefore violates the basic Kubernetes data-classification model in three ways simultaneously: (1) it appears in plaintext to anyone with `get configmaps` (a much larger set of subjects than `get secrets`); (2) it ends up in cluster backups, etcd dumps, and platform observability tooling that explicitly excludes Secrets; (3) it does not benefit from any of the surface area Kubernetes builds around Secrets (envelope encryption, file-mode 0600 projection, KMS provider, External Secrets Operator).\n\n"+
-			"The matched keys are heuristic — `key` matches both `apiKey` and `public_key`, so review is required before assuming compromise. But the pattern is strong: in production clusters this finding correlates with real leaks the majority of the time. Treat as exposed-until-proven-otherwise.",
+			"The matched keys are heuristic, since `key` matches both `apiKey` and `public_key`, so review is required before assuming compromise. In practice the pattern is strong: in production clusters this finding correlates with real leaks the majority of the time. Treat as exposed-until-proven-otherwise.",
 			namespace, name, keysList),
-		Impact: fmt.Sprintf("If any of the flagged keys (`%s`) actually hold a credential, that credential is exposed to a wide audience — every workload SA in `%s`, every backup operator, every audit log consumer, and possibly cluster-mirroring tooling.", keysList, namespace),
+		Impact: fmt.Sprintf("If any of the flagged keys (`%s`) actually hold a credential, that credential is exposed to a wide audience: every workload SA in `%s`, every backup operator, every audit log consumer, and possibly cluster-mirroring tooling.", keysList, namespace),
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker compromises a workload in `%s` whose ServiceAccount has `get configmaps` (the typical default `view` role grants it).", namespace),
-			fmt.Sprintf("They `kubectl get cm %s -n %s -o yaml` and read the matched keys directly — no decoding needed since ConfigMap data is plaintext.", name, namespace),
+			fmt.Sprintf("They `kubectl get cm %s -n %s -o yaml` and read the matched keys directly. No decoding needed since ConfigMap data is plaintext.", name, namespace),
 			"They identify the credential class (DB connection string, API key, OAuth client_secret, signing key) from the key name and value shape.",
-			"They use the credential immediately — DB connection strings often grant the same write permission the application has; API keys often have no IP restriction; client_secrets unlock the upstream identity provider.",
+			"They use the credential immediately: DB connection strings often grant the same write permission the application has; API keys often have no IP restriction; client_secrets unlock the upstream identity provider.",
 			"Because audit-log review on ConfigMaps is rare, the read goes unnoticed until the upstream credential is rotated for unrelated reasons.",
 		},
 		Remediation: fmt.Sprintf("Move the credential out of `%s/%s` into a Kubernetes Secret (or, better, an external secret store) and remove the keys from the ConfigMap.", namespace, name),
 		RemediationSteps: []string{
-			fmt.Sprintf("Inspect each matched key (`%s`) to confirm whether it is a real credential — some keys like `cache_key_prefix` are false positives.", keysList),
+			fmt.Sprintf("Inspect each matched key (`%s`) to confirm whether it is a real credential. Some keys like `cache_key_prefix` are false positives.", keysList),
 			fmt.Sprintf("For real credentials, create a Secret in `%s` and update consumers (envFrom or volume mounts) to read from the Secret.", namespace),
 			"Rotate the credential at its source: if it was already in plaintext in a ConfigMap, treat it as compromised (assume any subject with view-on-configmaps had access).",
 			fmt.Sprintf("Remove the credential keys from `%s/%s`. Verify the consumer still works (`kubectl rollout status`).", namespace, name),
@@ -162,27 +162,27 @@ func contentConfigMap001(namespace, name string, matchedKeys []string) ruleConte
 
 func contentConfigMap002() ruleContent {
 	return ruleContent{
-		Title: "CoreDNS Corefile contains rewrite or external-forward directives — DNS plane is mutable from `kube-system/coredns`",
+		Title: "CoreDNS Corefile contains rewrite or external-forward directives that make the cluster DNS plane mutable from `kube-system/coredns`",
 		Scope: models.Scope{
 			Level:  models.ScopeCluster,
-			Detail: "ConfigMap `kube-system/coredns` — every pod in the cluster uses this Corefile for resolution; a change here is a cluster-wide effect",
+			Detail: "ConfigMap `kube-system/coredns`: every pod in the cluster uses this Corefile for resolution; a change here is a cluster-wide effect",
 		},
 		Description: "The CoreDNS Corefile in `kube-system/coredns` contains directives that change DNS behavior in ways that warrant explicit review: `rewrite` directives mutate query names or response data, and `forward` directives that send queries to external resolvers (`8.8.8.8`, `1.1.1.1`, `tls://...`) bypass the cluster's authoritative records and the cluster's egress firewall.\n\n" +
-			"Two threat models matter here. (1) **Defensive misconfiguration**: a `rewrite` rule that maps an internal name to an external one can cause apps to talk to attacker-controlled hosts when the rule's intent was something else (typo, copy-paste from a tutorial). External `forward` to public resolvers means DNS queries (which often contain pod names, namespace names, internal service topology) leave the cluster perimeter unencrypted to a third-party operator with no DPA. (2) **Active subversion**: an attacker with write access to the `kube-system/coredns` ConfigMap (a far rarer condition, but exactly the prize for `KUBE-PRIVESC-005` chains) can add a `rewrite` rule that redirects `*.svc.cluster.local` to attacker pods, then capture every connection that does not pin TLS — full cluster-wide MITM. CoreDNS reloads the Corefile automatically; no operator action needed.\n\n" +
+			"Two threat models matter here. (1) **Defensive misconfiguration**: a `rewrite` rule that maps an internal name to an external one can cause apps to talk to attacker-controlled hosts when the rule's intent was something else (typo, copy-paste from a tutorial). External `forward` to public resolvers means DNS queries (which often contain pod names, namespace names, internal service topology) leave the cluster perimeter unencrypted to a third-party operator with no DPA. (2) **Active subversion**: an attacker with write access to the `kube-system/coredns` ConfigMap (a far rarer condition, but exactly the prize for `KUBE-PRIVESC-005` chains) can add a `rewrite` rule that redirects `*.svc.cluster.local` to attacker pods, then capture every connection that does not pin TLS. The result is full cluster-wide MITM, and CoreDNS reloads the Corefile automatically with no operator action needed.\n\n" +
 			"This is the most common active-subversion path discussed in DNS-rebinding-in-Kubernetes research: the CoreDNS ConfigMap is structurally a one-shot to compromise resolution for every pod, and clusters often grant `kube-system` ConfigMap write to addon installers, helm-controllers, and network operators that the security team hasn't audited.",
-		Impact: "If the Corefile is malicious, every DNS query in the cluster can be silently redirected — including queries for in-cluster services, cloud APIs, and external SaaS — enabling MITM and data exfiltration. If the Corefile is merely sloppy, internal DNS names may leak to public resolvers.",
+		Impact: "If the Corefile is malicious, every DNS query in the cluster can be silently redirected (including queries for in-cluster services, cloud APIs, and external SaaS), enabling MITM and data exfiltration. If the Corefile is merely sloppy, internal DNS names may leak to public resolvers.",
 		AttackScenario: []string{
 			"Attacker gains write access to `kube-system/coredns` (often via an over-broad `configmaps` permission on a control-plane SA, or a `KUBE-PRIVESC-005` secret-reads-then-token-theft chain that ends at a kube-system SA).",
 			"They edit the Corefile to add `rewrite name regex (.*)\\.cluster\\.local\\. attacker-pod.poc.svc.cluster.local. answer auto`.",
 			"CoreDNS reloads automatically (`reload` plugin), and within ~30 seconds every cluster service-discovery query is misdirected.",
 			"Apps that don't pin TLS-SNI-to-IP fall over to attacker-pod, which terminates TLS with a self-signed cert (acceptable for many in-cluster integrations using `InsecureSkipVerify: true`).",
-			"The attacker harvests credentials from the redirected traffic, then quietly removes the rewrite rule when done — `kube-system/coredns` change history is not audited by most teams.",
+			"The attacker harvests credentials from the redirected traffic, then quietly removes the rewrite rule when done. `kube-system/coredns` change history is not audited by most teams.",
 		},
 		Remediation: "Audit each `rewrite` and `forward` directive against expected DNS topology, lock down write access to the `kube-system/coredns` ConfigMap, and add change detection.",
 		RemediationSteps: []string{
 			"`kubectl get cm coredns -n kube-system -o yaml` and review every `rewrite/forward` line. Confirm with the platform/networking team that each is intentional.",
 			"For `forward` to public resolvers: prefer the cloud provider's private resolver (which respects VPC routing and is logged) over `8.8.8.8/1.1.1.1`. If public is required, restrict via egress NetworkPolicy.",
-			"`kubectl auth can-i update configmaps -n kube-system --as=system:serviceaccount:<ns>:<sa>` for every SA — most do not need this. Tighten RBAC and remove cluster-wide `*` resource grants.",
+			"`kubectl auth can-i update configmaps -n kube-system --as=system:serviceaccount:<ns>:<sa>` for every SA. Most do not need this; tighten RBAC and remove cluster-wide `*` resource grants.",
 			"Wire change detection: an admission policy (Kyverno) that alerts on any ConfigMap update in `kube-system` named `coredns`, or a GitOps source-of-truth so manual edits diverge visibly.",
 			"Add a periodic CronJob that diffs the live Corefile against the GitOps version and pages on drift.",
 		},

--- a/internal/analyzer/serviceaccount/content.go
+++ b/internal/analyzer/serviceaccount/content.go
@@ -49,34 +49,34 @@ func scopeForSubject(subject models.SubjectRef) models.Scope {
 	if subject.Namespace == "" {
 		return models.Scope{
 			Level:  models.ScopeCluster,
-			Detail: fmt.Sprintf("ServiceAccount `%s` — bound at the cluster scope; permissions apply across every namespace", subject.Name),
+			Detail: fmt.Sprintf("ServiceAccount `%s`: bound at the cluster scope; permissions apply across every namespace", subject.Name),
 		}
 	}
 	return models.Scope{
 		Level:  models.ScopeNamespace,
-		Detail: fmt.Sprintf("ServiceAccount `%s/%s` — namespace-scoped subject; mounted by pods in `%s`", subject.Namespace, subject.Name, subject.Namespace),
+		Detail: fmt.Sprintf("ServiceAccount `%s/%s`: namespace-scoped subject; mounted by pods in `%s`", subject.Namespace, subject.Name, subject.Namespace),
 	}
 }
 
 func contentSADefault002(subject models.SubjectRef, workloads, ruleSummary string) ruleContent {
 	return ruleContent{
-		Title: fmt.Sprintf("Default ServiceAccount `%s/default` carries explicit RBAC — every pod that omits `serviceAccountName` inherits these rights", subject.Namespace),
+		Title: fmt.Sprintf("Default ServiceAccount `%s/default` carries explicit RBAC, so every pod that omits `serviceAccountName` inherits these rights", subject.Namespace),
 		Scope: models.Scope{
 			Level:  models.ScopeNamespace,
-			Detail: fmt.Sprintf("Namespace `%s` — every Pod that does not set `serviceAccountName` mounts the `default` SA's token", subject.Namespace),
+			Detail: fmt.Sprintf("Namespace `%s`: every Pod that does not set `serviceAccountName` mounts the `default` SA's token", subject.Namespace),
 		},
-		Description: fmt.Sprintf("ServiceAccount `%s/default` has explicit RBAC bindings. Every Pod created in `%s` that does not set `spec.serviceAccountName` is silently bound to this SA, the kubelet projects its token into the pod, and the workload can call kube-apiserver with whatever permissions the bindings grant — without anyone explicitly asking for them.\n\n"+
+		Description: fmt.Sprintf("ServiceAccount `%s/default` has explicit RBAC bindings. Every Pod created in `%s` that does not set `spec.serviceAccountName` is silently bound to this SA, the kubelet projects its token into the pod, and the workload can call kube-apiserver with whatever permissions the bindings grant. Nobody explicitly asked for any of this.\n\n"+
 			"Aggregated rules:\n%s\n\n"+
 			"This is one of the most common privilege-escalation gateways in Kubernetes for two reasons: (1) the `default` SA is the *implicit* identity for every misconfigured manifest, so a single binding to it propagates to every team in the namespace; (2) developers iterating on a deployment regularly forget to set `serviceAccountName` and never notice the elevated identity because the API behaves as expected. The Kubernetes RBAC good-practices guide is explicit: \"Avoid granting RBAC to the default service account in any namespace,\" precisely because it converts \"forgetting a field\" into \"granting privilege.\"\n\n"+
-			"The right model is to leave the default SA permissionless and require every workload to declare its identity explicitly — turning the implicit-default into a fail-closed signal that something is misconfigured.",
+			"The right model is to leave the default SA permissionless and require every workload to declare its identity explicitly. That turns the implicit default into a fail-closed signal that something is misconfigured.",
 			subject.Namespace, subject.Namespace, ruleSummary),
 		Impact: fmt.Sprintf("Any Pod in `%s` that omits `serviceAccountName` quietly mounts a token for these RBAC rules. Compromise of any such pod (RCE in any app) yields immediate API access at the granted privileges. Workloads attached: %s.", subject.Namespace, workloads),
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker exploits a workload in `%s` that did not set `spec.serviceAccountName` (a common omission).", subject.Namespace),
 			"They read `/var/run/secrets/kubernetes.io/serviceaccount/token` from the pod filesystem.",
-			"They `curl` the kube-apiserver with the token's bearer header — the granted RBAC applies, even though the developer never knew the SA had any permissions.",
+			"They `curl` the kube-apiserver with the token's bearer header. The granted RBAC applies, even though the developer never knew the SA had any permissions.",
 			"They use the granted rights (typical patterns: list secrets in the namespace, list pods cluster-wide, exec into other pods) to extend reach.",
-			fmt.Sprintf("Because the binding is to `default` rather than a named SA, future pods in `%s` *also* inherit this identity — every redeploy of every workload in the namespace becomes a potential privesc point.", subject.Namespace),
+			fmt.Sprintf("Because the binding is to `default` rather than a named SA, future pods in `%s` *also* inherit this identity. Every redeploy of every workload in the namespace becomes a potential privesc point.", subject.Namespace),
 		},
 		Remediation: fmt.Sprintf("Remove all RoleBindings/ClusterRoleBindings to `%s/default`, create dedicated ServiceAccounts per workload, and set `automountServiceAccountToken: false` on the default SA.", subject.Namespace),
 		RemediationSteps: []string{
@@ -101,12 +101,12 @@ func contentSAPrivileged001(subject models.SubjectRef, workloads, ruleSummary st
 	return ruleContent{
 		Title: fmt.Sprintf("ServiceAccount `%s` holds wildcard verbs on wildcard resources (cluster-admin equivalent)", subject.Key()),
 		Scope: scopeForSubject(subject),
-		Description: fmt.Sprintf("ServiceAccount `%s` is bound to a Role/ClusterRole that grants `verbs: [*]` on `resources: [*]` (and typically `apiGroups: [*]`). This is structurally indistinguishable from `cluster-admin` — every API operation on every resource is authorized.\n\n"+
+		Description: fmt.Sprintf("ServiceAccount `%s` is bound to a Role/ClusterRole that grants `verbs: [*]` on `resources: [*]` (and typically `apiGroups: [*]`). This is structurally indistinguishable from `cluster-admin`. Every API operation on every resource is authorized.\n\n"+
 			"Aggregated rules:\n%s\n\n"+
 			"Wildcard-on-wildcard bindings are almost never the right design. They are typically the result of: (a) copy-pasting `cluster-admin` for an operator the team didn't have time to scope down; (b) a wildcard added \"temporarily\" during integration that never got rotated; (c) a third-party operator's installer that ships with `*/*` and assumes the operator runs in a dedicated cluster. None of those reasons survive a security review, but the binding survives because there is no concrete reason to break it. CIS Kubernetes 5.1.1 / 5.1.2 explicitly call out wildcard-on-wildcard as a finding.\n\n"+
-			"Workloads using this SA: %s. Any compromise of any of those workloads — a single CVE, a poisoned container image, a leaked configuration file containing the SA token — becomes full cluster compromise immediately. There is no defense-in-depth left.",
+			"Workloads using this SA: %s. Any compromise of any of those workloads (a single CVE, a poisoned container image, a leaked configuration file containing the SA token) becomes full cluster compromise immediately. There is no defense-in-depth left.",
 			subject.Key(), ruleSummary, workloads),
-		Impact: "A single compromise of any pod mounting this SA grants full cluster control: read every Secret, exec into any pod, mutate RBAC, drain nodes, taint scheduling, install backdoor DaemonSets — every API operation succeeds.",
+		Impact: "A single compromise of any pod mounting this SA grants full cluster control: read every Secret, exec into any pod, mutate RBAC, drain nodes, taint scheduling, install backdoor DaemonSets. Every API operation succeeds.",
 		AttackScenario: []string{
 			fmt.Sprintf("Attacker compromises any of the workloads using `%s` (or finds the token in any storage that touched it: backup, CI logs, a developer's kubeconfig).", subject.Key()),
 			"They `kubectl auth can-i '*' '*' --all-namespaces --token=<stolen-token>` and confirm full reach.",
@@ -117,7 +117,7 @@ func contentSAPrivileged001(subject models.SubjectRef, workloads, ruleSummary st
 		Remediation: fmt.Sprintf("Replace the wildcard binding on `%s` with the smallest concrete role that satisfies the workload's actual needs. Treat the existing token as compromised.", subject.Key()),
 		RemediationSteps: []string{
 			fmt.Sprintf("Identify the binding: `kubectl get rolebindings,clusterrolebindings -A -o json | jq '.items[] | select(.subjects[]? | .kind == \"ServiceAccount\" and .name == \"%s\" and .namespace == \"%s\")'`.", subject.Name, subject.Namespace),
-			"Generate a least-privilege role from the workload's actual API calls — capture them with `audit2rbac` (https://github.com/liggitt/audit2rbac) over a representative window, or read the operator's source for the API verbs it issues.",
+			"Generate a least-privilege role from the workload's actual API calls. Capture them with `audit2rbac` (https://github.com/liggitt/audit2rbac) over a representative window, or read the operator's source for the API verbs it issues.",
 			fmt.Sprintf("Create a Role/ClusterRole with the minimum verbs and bind it to `%s`. Verify with `kubectl auth can-i` for the actual operations the workload needs (and only those).", subject.Key()),
 			"Delete the wildcard binding and rotate the SA's token (delete and recreate the SA, or rely on projected SA token TTL). Audit-log review for the SA over the last 30 days to gauge possible misuse.",
 			"Wire enforcement: a Kyverno cluster policy that fails any RoleBinding/ClusterRoleBinding granting `verbs: ['*']` on `resources: ['*']` to a non-system subject.",
@@ -138,7 +138,7 @@ func contentSAPrivileged002(subject models.SubjectRef, workloads string, dangero
 	return ruleContent{
 		Title: fmt.Sprintf("ServiceAccount `%s` is mounted by live workloads and has dangerous permissions: %s", subject.Key(), dangerList),
 		Scope: scopeForSubject(subject),
-		Description: fmt.Sprintf("ServiceAccount `%s` carries one or more dangerous RBAC capabilities (%s) *and* is actively mounted by workloads (%s). The combination matters: a dangerous permission on an unused SA is latent risk; the same permission on an SA that ships in a running pod is a pre-positioned exploitation primitive — the attacker does not need to find the SA token, the pod is the SA token.\n\n"+
+		Description: fmt.Sprintf("ServiceAccount `%s` carries one or more dangerous RBAC capabilities (%s) *and* is actively mounted by workloads (%s). The combination matters: a dangerous permission on an unused SA is latent risk; the same permission on an SA that ships in a running pod is a pre-positioned exploitation primitive. The attacker does not need to find the SA token, because the pod is the SA token.\n\n"+
 			"The flagged capabilities map directly to known privesc paths:\n"+
 			"- `secrets` → read service-account tokens of higher-privileged SAs (`KUBE-PRIVESC-005`).\n"+
 			"- `create pods` → mount any SA in a new pod, run as root, or set `hostPath: /` to escape (`KUBE-PRIVESC-001`, `KUBE-ESCAPE-*`).\n"+
@@ -148,17 +148,17 @@ func contentSAPrivileged002(subject models.SubjectRef, workloads string, dangero
 			"- `nodes/proxy` → kubelet API access to read all pod logs/exec on a node (`KUBE-PRIVESC-012`).\n\n"+
 			"Workloads using this SA: %s. Each is a starting point: any RCE, any leaked container image layer, any logs accidentally containing the token are equivalent to the SA's RBAC.",
 			subject.Key(), dangerList, workloads, workloads),
-		Impact: fmt.Sprintf("Compromise of any workload using `%s` immediately grants the listed dangerous capabilities — typically a one- or two-hop chain to cluster-admin equivalent (see correlated `KUBE-PRIVESC-*` findings on the same subject).", subject.Key()),
+		Impact: fmt.Sprintf("Compromise of any workload using `%s` immediately grants the listed dangerous capabilities. In practice, this is a one- or two-hop chain to cluster-admin equivalent (see correlated `KUBE-PRIVESC-*` findings on the same subject).", subject.Key()),
 		AttackScenario: []string{
-			fmt.Sprintf("Attacker compromises any of the workloads (`%s`) — RCE in the application, malicious image layer, leaked manifest with embedded token.", workloads),
+			fmt.Sprintf("Attacker compromises any of the workloads (`%s`) via RCE in the application, a malicious image layer, or a leaked manifest with embedded token.", workloads),
 			"They read `/var/run/secrets/kubernetes.io/serviceaccount/token` from the pod.",
-			fmt.Sprintf("They use the token to invoke the dangerous capabilities (%s) directly — the token already authenticates as `%s`, no further escalation needed.", dangerList, subject.Key()),
+			fmt.Sprintf("They use the token to invoke the dangerous capabilities (%s) directly. The token already authenticates as `%s`, so no further escalation is needed.", dangerList, subject.Key()),
 			"For each capability they convert into the matching privesc path: `secrets`→token theft → impersonate higher SA; `bind`→grant self cluster-admin; `pods/create`→privileged pod with hostPath /.",
-			"Within minutes they hold an identity equivalent to the most privileged subject reachable from this SA's chain — typically `cluster-admin` if any privesc path connects.",
+			"Within minutes they hold an identity equivalent to the most privileged subject reachable from this SA's chain, typically `cluster-admin` if any privesc path connects.",
 		},
 		Remediation: fmt.Sprintf("Split `%s` into one SA per workload, remove the dangerous capabilities that aren't actually used, and ensure each workload's SA holds only the minimum verbs.", subject.Key()),
 		RemediationSteps: []string{
-			fmt.Sprintf("Audit which of the workloads (%s) actually exercises each dangerous capability — start with `audit2rbac` over a 7-day window, then ask the workload's owner to confirm.", workloads),
+			fmt.Sprintf("Audit which of the workloads (%s) actually exercises each dangerous capability. Start with `audit2rbac` over a 7-day window, then ask the workload's owner to confirm.", workloads),
 			"For each unique workload, create a dedicated SA and a least-privilege Role/ClusterRole with only the verbs that audit-2rbac observed. Bind only that Role to the new SA.",
 			fmt.Sprintf("Migrate workloads to the new dedicated SA (set `spec.serviceAccountName`). Delete the bindings against the original `%s` and rotate its token.", subject.Key()),
 			"For capabilities that *no* workload actually exercises, delete the binding entirely.",
@@ -181,29 +181,29 @@ func contentSADaemonset001(subject models.SubjectRef, workloads, ruleSummary str
 		rulesPart = ruleSummary
 	}
 	return ruleContent{
-		Title: fmt.Sprintf("ServiceAccount `%s` is mounted by a DaemonSet — the SA token lives on every node the DaemonSet schedules to", subject.Key()),
+		Title: fmt.Sprintf("ServiceAccount `%s` is mounted by a DaemonSet, so its token lives on every node the DaemonSet schedules to", subject.Key()),
 		Scope: models.Scope{
 			Level:  models.ScopeCluster,
-			Detail: fmt.Sprintf("ServiceAccount `%s` — DaemonSet places its token on every node in the cluster (or every node matching the DaemonSet's nodeSelector)", subject.Key()),
+			Detail: fmt.Sprintf("ServiceAccount `%s`: DaemonSet places its token on every node in the cluster (or every node matching the DaemonSet's nodeSelector)", subject.Key()),
 		},
 		Description: fmt.Sprintf("ServiceAccount `%s` is mounted by a DaemonSet (%s). DaemonSets schedule one pod per matching node, so the kubelet projects this SA's token onto every one of those nodes. From an attacker's perspective, that turns any single node compromise (kernel CVE, runtime escape, host-mount-via-misconfigured-pod, malicious workload that escapes its sandbox) into immediate possession of the SA's identity, scaled by node count.\n\n"+
 			"Aggregated rules: %s\n\n"+
 			"DaemonSet-mounted SAs are special-case for two reasons:\n"+
-			"1. **Distribution**: a typical cluster has tens to thousands of nodes. The token is on each one, in `/var/lib/kubelet/pods/<uid>/volumes/...`. Any node compromise — including ones the security team would normally call \"contained to one node\" — exfiltrates the same token, and rotating one node's token does not invalidate the others (until the next pod re-projection cycle, ~1h with default token TTL).\n"+
+			"1. **Distribution**: a typical cluster has tens to thousands of nodes. The token is on each one, in `/var/lib/kubelet/pods/<uid>/volumes/...`. Any node compromise (including ones the security team would normally call \"contained to one node\") exfiltrates the same token, and rotating one node's token does not invalidate the others (until the next pod re-projection cycle, ~1h with default token TTL).\n"+
 			"2. **Privilege**: DaemonSets are typically infrastructure agents (logging, monitoring, CNI, CSI, cluster-autoscaler) that legitimately need cluster-wide reads. So the SA tends to carry above-average permissions: `nodes:get`, `pods:list`, `events:create`, sometimes `secrets:get` for image-pull credentials. Combined with cluster-wide distribution this is a high-leverage credential.",
 			subject.Key(), workloads, rulesPart),
 		Impact: "A single node compromise yields a token that authorizes whatever this SA's RBAC says, anywhere in the cluster. With DaemonSet-typical permissions (cluster-wide reads, sometimes node-level controls) this is a fast pivot from one host to cluster-wide visibility/influence.",
 		AttackScenario: []string{
-			"Attacker compromises one node — could be a kernel CVE in a tenant workload, an outdated containerd, or a misconfigured pod with `hostPath: /` they were able to schedule there.",
+			"Attacker compromises one node via a kernel CVE in a tenant workload, an outdated containerd, or a misconfigured pod with `hostPath: /` they were able to schedule there.",
 			fmt.Sprintf("From the host they read `/var/lib/kubelet/pods/*/volumes/kubernetes.io~projected-volumes/token` (the projected token of `%s`).", subject.Key()),
-			"They use the token from outside the cluster (`kubectl --token=...`) — the token still works because projection-renewal does not invalidate already-extracted copies until the original expiration.",
-			"They use the SA's RBAC for whatever it grants — typically `nodes:get`, `pods:list`, `secrets:get` for image pulls — to locate higher-value targets.",
+			"They use the token from outside the cluster (`kubectl --token=...`). The token still works because projection-renewal does not invalidate already-extracted copies until the original expiration.",
+			"They use the SA's RBAC for whatever it grants (typically `nodes:get`, `pods:list`, `secrets:get` for image pulls) to locate higher-value targets.",
 			"Scale: every node has a copy. Cleanup is per-node, and the team typically only rotates the compromised node's token, leaving the same SA active on all the others.",
 		},
 		Remediation: fmt.Sprintf("Tighten `%s`'s RBAC to the literal minimum the DaemonSet needs, set short token TTL (`expirationSeconds: 600`) on the projected token, and treat the DaemonSet's image and host mounts as part of the SA's effective trust boundary.", subject.Key()),
 		RemediationSteps: []string{
 			fmt.Sprintf("Audit `%s`'s actual API calls with `audit2rbac` and pare the bindings down to the minimum verbs. Remove any `secrets:get` unless explicitly required for image pulls.", subject.Key()),
-			"In the DaemonSet pod template, project the token with `expirationSeconds: 600` (10 min) instead of the default 1h — this caps the leak window for any single token theft.",
+			"In the DaemonSet pod template, project the token with `expirationSeconds: 600` (10 min) instead of the default 1h. This caps the leak window for any single token theft.",
 			"Audit the DaemonSet's container image and host mounts: a DaemonSet with `hostPath: /` is itself an escape primitive. Disallow privileged containers, `hostPath`, `hostPID`, `hostNetwork` in the DaemonSet's PodSpec.",
 			"Add per-node detection: alert on `kubectl create token <sa>` invocations from outside expected control-plane subjects, and on usage of the SA's name from IPs that are not pod CIDR.",
 			fmt.Sprintf("If the DaemonSet does not actually need an API token, set `automountServiceAccountToken: false` on its PodSpec and on `%s` itself.", subject.Key()),

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Kubesplaining Report{{ if .Snapshot.Metadata.ClusterName }} — {{ .Snapshot.Metadata.ClusterName }}{{ end }}</title>
+  <title>Kubesplaining Report{{ if .Snapshot.Metadata.ClusterName }}: {{ .Snapshot.Metadata.ClusterName }}{{ end }}</title>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
   <style>
     :root {
@@ -700,7 +700,7 @@
         {{ if .Narratives }}
         <div class="tldr">
           <strong>What the attack paths mean.</strong>
-          Individual findings don't tell the whole story — attackers chain them. This report detected
+          Individual findings don't tell the whole story. Attackers chain them. This report detected
           <strong>{{ len .Narratives }}</strong> attack {{ pluralize (len .Narratives) "chain" "chains" }} by looking at how rule IDs, subjects, and resources connect.
           The attack-paths diagram below makes those connections explicit; each chain is walked through in plain English further down.
         </div>
@@ -736,7 +736,7 @@
           {{ if .Narratives }}<li><strong>{{ len .Narratives }}</strong> attack {{ pluralize (len .Narratives) "chain" "chains" }} detected</li>{{ end }}
           {{ if .TopNamespaces }}<li><strong>{{ (index .TopNamespaces 0).Summary.Total }}</strong> findings in namespace <code>{{ (index .TopNamespaces 0).Label }}</code></li>{{ end }}
           {{ if .TopResources }}<li><strong>{{ (index .TopResources 0).Summary.Total }}</strong> findings on <code>{{ (index .TopResources 0).Label }}</code></li>{{ end }}
-          {{ if .Snapshot.Metadata.CollectionWarnings }}<li><strong>{{ len .Snapshot.Metadata.CollectionWarnings }}</strong> collection warnings — some signal may be missing</li>{{ end }}
+          {{ if .Snapshot.Metadata.CollectionWarnings }}<li><strong>{{ len .Snapshot.Metadata.CollectionWarnings }}</strong> collection warnings, so some signal may be missing</li>{{ end }}
         </ul>
       </div>
     </section>
@@ -755,7 +755,7 @@
           </div>
         </div>
         <div class="graph-header-row">
-          <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves — so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
+          <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves, so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
           {{ if .Graph.Truncated }}
           <p class="graph-truncated-notice"><span class="graph-truncated-badge">Showing {{ .Graph.Shown }} of {{ .Graph.TotalCaps }}</span>To keep the diagram readable, capabilities are capped at 10. The slate first guarantees one cap per impact category present in the cluster, then fills remaining slots by severity and score. The <strong>Findings</strong> tab has the complete list.</p>
           {{ end }}
@@ -772,7 +772,7 @@
           <button type="button" class="kp-chip kp-chip-reset" data-action="reset">Reset</button>
         </div>
         <div class="graph-wrap">
-          <svg class="attack-svg" viewBox="0 0 {{ .Graph.Width }} {{ .Graph.Height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Attack path graph — interactive">
+          <svg class="attack-svg" viewBox="0 0 {{ .Graph.Width }} {{ .Graph.Height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Attack path graph (interactive)">
             <defs>
               <linearGradient id="impact-crit" x1="0" x2="1" y1="0" y2="0">
                 <stop offset="0%" stop-color="#3a1018"/><stop offset="100%" stop-color="#1d0b10"/>
@@ -980,7 +980,7 @@
 
     {{ if .Modules }}
     <div class="findings-search" data-tab="findings">
-      <input type="search" id="findings-search-input" placeholder="Search findings — subject, resource, rule ID..." aria-label="Search findings" autocomplete="off" spellcheck="false" />
+      <input type="search" id="findings-search-input" placeholder="Search findings: subject, resource, rule ID..." aria-label="Search findings" autocomplete="off" spellcheck="false" />
       <kbd class="findings-search-hint" aria-hidden="true">/</kbd>
     </div>
     <div class="findings-filters" data-tab="findings" role="toolbar" aria-label="Filter findings" hidden>

--- a/internal/report/evidence_glossary.go
+++ b/internal/report/evidence_glossary.go
@@ -24,7 +24,7 @@ var dangerousVerbs = map[string]string{
 	"deletecollection": "Bulk-delete every object of this resource",
 	"patch":            "Mutate existing objects in place",
 	"update":           "Replace existing objects",
-	"*":                "Wildcard — every verb (get, list, create, update, delete, …)",
+	"*":                "Wildcard: every verb (get, list, create, update, delete, …)",
 }
 
 // sensitiveResources flags Kubernetes resources whose access is itself a high-impact
@@ -34,8 +34,8 @@ var sensitiveResources = map[string]string{
 	"pods/exec":                       "Remote shell into any pod",
 	"pods/attach":                     "Attach to a running container's stdio",
 	"pods/portforward":                "Tunnel arbitrary TCP into the cluster network",
-	"pods":                            "Workload primitive — create = run code on the cluster",
-	"nodes/proxy":                     "Direct kubelet access — bypasses API server authz",
+	"pods":                            "Workload primitive: create = run code on the cluster",
+	"nodes/proxy":                     "Direct kubelet access (bypasses API server authz)",
 	"clusterroles":                    "Cluster-scoped RBAC rules",
 	"clusterrolebindings":             "Cluster-scoped RBAC grants",
 	"roles":                           "Namespace-scoped RBAC rules",
@@ -43,20 +43,20 @@ var sensitiveResources = map[string]string{
 	"serviceaccounts":                 "Pod identities (and their tokens)",
 	"serviceaccounts/token":           "Mint short-lived ServiceAccount tokens",
 	"certificatesigningrequests":      "Issue X.509 certs honored by the API server",
-	"validatingwebhookconfigurations": "Admission policy — bypassing it disables enforcement",
-	"mutatingwebhookconfigurations":   "Admission policy — controls what enters the cluster",
+	"validatingwebhookconfigurations": "Admission policy: bypassing it disables enforcement",
+	"mutatingwebhookconfigurations":   "Admission policy: controls what enters the cluster",
 	"persistentvolumes":               "Cluster-scoped storage that can mount host paths",
-	"*":                               "Wildcard — every resource",
+	"*":                               "Wildcard: every resource",
 }
 
 // sensitiveAPIGroups annotates well-known API groups that carry RBAC-relevant power.
 // Empty group ("") is the core API; we render that as "core/v1" and skip the hint.
 var sensitiveAPIGroups = map[string]string{
-	"rbac.authorization.k8s.io":    "RBAC objects — write access ≈ cluster takeover",
-	"admissionregistration.k8s.io": "Admission webhooks — controls policy enforcement",
+	"rbac.authorization.k8s.io":    "RBAC objects (write access is roughly cluster takeover)",
+	"admissionregistration.k8s.io": "Admission webhooks (controls policy enforcement)",
 	"certificates.k8s.io":          "Issues cluster-trusted certificates",
 	"policy":                       "PodSecurityPolicy / PodDisruptionBudget",
-	"*":                            "Wildcard — every API group",
+	"*":                            "Wildcard: every API group",
 }
 
 // sensitiveHostPathHints annotates host paths whose mount into a container is a
@@ -64,25 +64,25 @@ var sensitiveAPIGroups = map[string]string{
 // up the path segments so e.g. "/var/run/docker.sock" matches even if scanned
 // against "/var/run/docker.sock/". Keys are lowercased and trimmed of trailing slashes.
 var sensitiveHostPathHints = map[string]string{
-	"/":                                   "Node root filesystem — full host takeover",
-	"/etc":                                "Node config — kubelet/CNI/auth files",
+	"/":                                   "Node root filesystem (full host takeover)",
+	"/etc":                                "Node config: kubelet/CNI/auth files",
 	"/etc/kubernetes":                     "Kubelet kubeconfig & PKI material",
-	"/etc/kubernetes/pki":                 "Cluster PKI — root CA private keys",
+	"/etc/kubernetes/pki":                 "Cluster PKI: root CA private keys",
 	"/var":                                "Node persistent state",
 	"/var/lib":                            "Persistent state for system daemons",
 	"/var/lib/kubelet":                    "Kubelet credentials & pod tokens for every pod on the node",
-	"/var/lib/docker":                     "Container engine state — image & layer access",
-	"/var/lib/containerd":                 "Container engine state — image & layer access",
-	"/var/log":                            "Node logs — symlinks let you read other pods' logs",
+	"/var/lib/docker":                     "Container engine state (image & layer access)",
+	"/var/lib/containerd":                 "Container engine state (image & layer access)",
+	"/var/log":                            "Node logs (symlinks let you read other pods' logs)",
 	"/var/run":                            "Container runtime sockets live here",
-	"/var/run/docker.sock":                "Docker socket — container engine takeover",
-	"/var/run/containerd/containerd.sock": "containerd socket — container engine takeover",
-	"/var/run/crio/crio.sock":             "CRI-O socket — container engine takeover",
+	"/var/run/docker.sock":                "Docker socket (container engine takeover)",
+	"/var/run/containerd/containerd.sock": "containerd socket (container engine takeover)",
+	"/var/run/crio/crio.sock":             "CRI-O socket (container engine takeover)",
 	"/run":                                "Runtime sockets & state",
-	"/run/containerd/containerd.sock":     "containerd socket — container engine takeover",
-	"/proc":                               "Host process tree — read /proc/1/root for full FS access",
-	"/sys":                                "Kernel interfaces — cgroup/namespace abuse",
-	"/dev":                                "Host devices — direct disk / kmem access",
+	"/run/containerd/containerd.sock":     "containerd socket (container engine takeover)",
+	"/proc":                               "Host process tree (read /proc/1/root for full FS access)",
+	"/sys":                                "Kernel interfaces (cgroup/namespace abuse)",
+	"/dev":                                "Host devices (direct disk / kmem access)",
 	"/root":                               "Root user home directory",
 	"/home":                               "User home directories",
 }
@@ -94,10 +94,10 @@ var sensitiveCIDRs = []struct {
 	CIDR string
 	Note string
 }{
-	{"0.0.0.0/0", "Entire IPv4 internet — egress here can exfiltrate to any host"},
-	{"::/0", "Entire IPv6 internet — egress here can exfiltrate to any host"},
-	{"169.254.169.254/32", "Cloud instance metadata service — can mint cloud credentials"},
-	{"169.254.0.0/16", "Link-local range (incl. cloud metadata service)"},
+	{"0.0.0.0/0", "Entire IPv4 internet: egress here can exfiltrate to any host"},
+	{"::/0", "Entire IPv6 internet: egress here can exfiltrate to any host"},
+	{"169.254.169.254/32", "Cloud instance metadata service (can mint cloud credentials)"},
+	{"169.254.0.0/16", "Link-local range (includes cloud metadata service)"},
 	{"10.0.0.0/8", "RFC1918 private range"},
 	{"172.16.0.0/12", "RFC1918 private range"},
 	{"192.168.0.0/16", "RFC1918 private range"},
@@ -109,21 +109,21 @@ var sensitiveCIDRs = []struct {
 // raw type string, we don't import corev1 just for this.
 var secretTypeLabels = map[string]string{
 	"Opaque":                              "Generic key/value secret",
-	"kubernetes.io/service-account-token": "Long-lived ServiceAccount token — holding it = acting as the SA",
+	"kubernetes.io/service-account-token": "Long-lived ServiceAccount token (holding it is acting as the SA)",
 	"kubernetes.io/dockercfg":             "Docker registry credentials (legacy format)",
 	"kubernetes.io/dockerconfigjson":      "Docker registry credentials",
 	"kubernetes.io/basic-auth":            "Basic-auth username + password",
 	"kubernetes.io/ssh-auth":              "SSH private key",
 	"kubernetes.io/tls":                   "TLS certificate + private key",
-	"bootstrap.kubernetes.io/token":       "Bootstrap token — joins new nodes to the cluster",
+	"bootstrap.kubernetes.io/token":       "Bootstrap token (joins new nodes to the cluster)",
 }
 
 // hostNamespaceHints explains what each pod-level "host*" boolean grants when set.
 var hostNamespaceHints = map[string]string{
-	"hostNetwork":              "Shares the node's network namespace — sees every pod's traffic, binds to node IPs",
-	"hostPID":                  "Shares the node's process namespace — can ptrace/kill node processes",
-	"hostIPC":                  "Shares the node's IPC namespace — reads other processes' shared memory",
-	"privileged":               "Disables nearly all container isolation — effective root on the node",
+	"hostNetwork":              "Shares the node's network namespace (sees every pod's traffic, binds to node IPs)",
+	"hostPID":                  "Shares the node's process namespace (can ptrace/kill node processes)",
+	"hostIPC":                  "Shares the node's IPC namespace (reads other processes' shared memory)",
+	"privileged":               "Disables nearly all container isolation (effective root on the node)",
 	"allowPrivilegeEscalation": "Lets a child process gain more privileges than its parent",
 	"runAsNonRoot":             "When false, the container can run as UID 0",
 }
@@ -136,10 +136,10 @@ func mutableImageHint(image string) string {
 	}
 	// No tag at all → defaults to :latest
 	if !strings.Contains(image[strings.LastIndex(image, "/")+1:], ":") {
-		return "No tag — pulls :latest, which is mutable"
+		return "No tag, so pulls :latest, which is mutable"
 	}
 	if strings.HasSuffix(image, ":latest") {
-		return ":latest is mutable — same tag can resolve to different images over time"
+		return ":latest is mutable: the same tag can resolve to different images over time"
 	}
 	return ""
 }

--- a/internal/report/evidence_render.go
+++ b/internal/report/evidence_render.go
@@ -153,7 +153,7 @@ func renderEvidenceRow(key string, val any, obj map[string]any) string {
 		fp := asString(val)
 		hint := ""
 		if strings.EqualFold(fp, "Ignore") {
-			hint = "Webhook failures are silently allowed — admission policy effectively off"
+			hint = "Webhook failures are silently allowed (admission policy effectively off)"
 		}
 		return plainRow("failurePolicy", "<code>"+template.HTMLEscapeString(fp)+"</code>", hint)
 	case "objectSelector":
@@ -311,7 +311,7 @@ func chipRow(label string, values []string, hint func(string) string, dangerOnWi
 		if dangerOnWildcard && v == "*" {
 			class += " wild"
 			if h == "" {
-				h = "Wildcard — every value"
+				h = "Wildcard: every value"
 			}
 		} else if h != "" {
 			class += " danger"
@@ -326,7 +326,7 @@ func chipRow(label string, values []string, hint func(string) string, dangerOnWi
 		b.WriteString(template.HTMLEscapeString(v))
 		b.WriteString(`</span>`)
 		if h != "" {
-			hints = append(hints, fmt.Sprintf("<code>%s</code> — %s",
+			hints = append(hints, fmt.Sprintf("<code>%s</code>: %s",
 				template.HTMLEscapeString(v), template.HTMLEscapeString(h)))
 		}
 	}
@@ -394,7 +394,7 @@ func apiGroupRow(values []string) string {
 		b.WriteString(template.HTMLEscapeString(display))
 		b.WriteString(`</span>`)
 		if h != "" {
-			hints = append(hints, fmt.Sprintf("<code>%s</code> — %s",
+			hints = append(hints, fmt.Sprintf("<code>%s</code>: %s",
 				template.HTMLEscapeString(display), template.HTMLEscapeString(h)))
 		}
 	}
@@ -531,7 +531,7 @@ func selectorRow(label string, val any) string {
 		return jsonFallbackRow(label, val)
 	}
 	if len(m) == 0 {
-		return plainRow(label, "<code>{}</code>", "Empty selector — matches everything")
+		return plainRow(label, "<code>{}</code>", "Empty selector: matches everything")
 	}
 	var sentences []string
 	if ml, ok := m["matchLabels"].(map[string]any); ok && len(ml) > 0 {

--- a/internal/report/glossary.go
+++ b/internal/report/glossary.go
@@ -54,24 +54,24 @@ var Glossary = map[string]GlossaryEntry{
 	"ServiceAccount": {
 		Title:  "ServiceAccount",
 		Short:  "An identity used by pods (not humans) to call the Kubernetes API.",
-		Long:   template.HTML(`<p>A <strong>ServiceAccount</strong> is an in-cluster identity assigned to pods. Every pod gets a token mounted at <code>/var/run/secrets/kubernetes.io/serviceaccount/token</code> — that token <em>is</em> the credential. If an attacker reads that file from inside a compromised container (or creates a pod that mounts the token), they can call the API <em>as</em> the ServiceAccount, with whatever permissions the SA has been granted.</p><p>This is the most common pivot in real-world Kubernetes attacks: compromise one pod, steal its token, ride the token to wherever its RBAC allows.</p>`),
+		Long:   template.HTML(`<p>A <strong>ServiceAccount</strong> is an in-cluster identity assigned to pods. Every pod gets a token mounted at <code>/var/run/secrets/kubernetes.io/serviceaccount/token</code>, and that token <em>is</em> the credential. If an attacker reads that file from inside a compromised container (or creates a pod that mounts the token), they can call the API <em>as</em> the ServiceAccount, with whatever permissions the SA has been granted.</p><p>This is the most common pivot in real-world Kubernetes attacks: compromise one pod, steal its token, ride the token to wherever its RBAC allows.</p>`),
 		DocURL: "https://kubernetes.io/docs/concepts/security/service-accounts/",
 	},
 	"Group": {
 		Title:  "Group",
-		Short:  "A label attached to authenticated identities — e.g. system:masters acts as cluster-admin.",
-		Long:   template.HTML(`<p>A <strong>Group</strong> is a string label associated with users or ServiceAccounts at authentication time. RoleBindings can target groups, so <em>everyone</em> in the group inherits the bound permissions. Two groups deserve special care:</p><ul><li><code>system:masters</code> — hardcoded as cluster-admin. Membership is permanent (you cannot un-grant it via RBAC).</li><li><code>system:authenticated</code> — every authenticated identity. Bind anything sensitive to this and you grant it to the world.</li></ul><p>Groups are assigned by the authenticator (OIDC claims, certificate organization fields, etc.), not stored in the API server, which means they don't appear in <code>kubectl get</code>.</p>`),
+		Short:  "A label attached to authenticated identities (for example, system:masters acts as cluster-admin).",
+		Long:   template.HTML(`<p>A <strong>Group</strong> is a string label associated with users or ServiceAccounts at authentication time. RoleBindings can target groups, so <em>everyone</em> in the group inherits the bound permissions. Two groups deserve special care:</p><ul><li><code>system:masters</code>: hardcoded as cluster-admin. Membership is permanent (you cannot un-grant it via RBAC).</li><li><code>system:authenticated</code>: every authenticated identity. Bind anything sensitive to this and you grant it to the world.</li></ul><p>Groups are assigned by the authenticator (OIDC claims, certificate organization fields, etc.), not stored in the API server, which means they don't appear in <code>kubectl get</code>.</p>`),
 		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings",
 	},
 	"User": {
 		Title:  "User",
 		Short:  "A human (or external automation) authenticated by certs, OIDC, or static tokens.",
-		Long:   template.HTML(`<p>A <strong>User</strong> in Kubernetes is whoever the authenticator says they are — there is no User object in the API. Identity comes from a client certificate's CN, an OIDC <code>sub</code> claim, a webhook, or a static token. RBAC then targets that identity by name. If you see "User foo" in a finding, foo is whatever string the authentication layer produced.</p>`),
+		Long:   template.HTML(`<p>A <strong>User</strong> in Kubernetes is whoever the authenticator says they are. There is no User object in the API. Identity comes from a client certificate's CN, an OIDC <code>sub</code> claim, a webhook, or a static token. RBAC then targets that identity by name. If you see "User foo" in a finding, foo is whatever string the authentication layer produced.</p>`),
 		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/authentication/",
 	},
 	"Pod": {
 		Title:  "Pod",
-		Short:  "The smallest schedulable unit — one or more containers sharing a network and storage namespace.",
+		Short:  "The smallest schedulable unit: one or more containers sharing a network and storage namespace.",
 		Long:   template.HTML(`<p>A <strong>Pod</strong> wraps one or more containers that share an IP, hostname, and volumes. From an attacker's perspective, a pod is a foothold: the API token mounted into it grants the pod's ServiceAccount permissions; if the pod is privileged or mounts the host filesystem, it's also a path to escape onto the node.</p>`),
 		DocURL: "https://kubernetes.io/docs/concepts/workloads/pods/",
 	},
@@ -83,28 +83,28 @@ var Glossary = map[string]GlossaryEntry{
 	},
 	"DaemonSet": {
 		Title: "DaemonSet",
-		Short: "Runs a copy of a pod on every node (often privileged — log collectors, CNI agents).",
-		Long:  template.HTML(`<p>A <strong>DaemonSet</strong> schedules one pod per node, typically for cluster infrastructure (CNI, log shipping, node monitoring). DaemonSets are frequent targets because they often need <code>hostNetwork</code>, <code>hostPath</code>, or <code>privileged</code> to do their job — which makes them ideal for attackers if compromised.</p>`),
+		Short: "Runs a copy of a pod on every node (often privileged: log collectors, CNI agents).",
+		Long:  template.HTML(`<p>A <strong>DaemonSet</strong> schedules one pod per node, typically for cluster infrastructure (CNI, log shipping, node monitoring). DaemonSets are frequent targets because they often need <code>hostNetwork</code>, <code>hostPath</code>, or <code>privileged</code> to do their job, which makes them ideal for attackers if compromised.</p>`),
 	},
 	"StatefulSet": {
 		Title: "StatefulSet",
-		Short: "Pods with stable identities and persistent storage — databases, queues.",
-		Long:  template.HTML(`<p>A <strong>StatefulSet</strong> gives each pod a stable DNS name and dedicated PersistentVolume. Compromise here often means access to durable application data — databases, message queues, caches.</p>`),
+		Short: "Pods with stable identities and persistent storage: databases, queues.",
+		Long:  template.HTML(`<p>A <strong>StatefulSet</strong> gives each pod a stable DNS name and dedicated PersistentVolume. Compromise here often means access to durable application data: databases, message queues, caches.</p>`),
 	},
 	"ReplicaSet": {
 		Title: "ReplicaSet",
 		Short: "Maintains a stable set of pod replicas. Usually managed by a Deployment.",
-		Long:  template.HTML(`<p>A <strong>ReplicaSet</strong> keeps a target number of identical pods running. You normally don't manage these directly — a Deployment owns them.</p>`),
+		Long:  template.HTML(`<p>A <strong>ReplicaSet</strong> keeps a target number of identical pods running. You normally don't manage these directly; a Deployment owns them.</p>`),
 	},
 	"Job": {
 		Title: "Job",
-		Short: "Runs a pod (or pods) to completion — batch tasks, migrations.",
+		Short: "Runs a pod (or pods) to completion: batch tasks, migrations.",
 		Long:  template.HTML(`<p>A <strong>Job</strong> executes one or more pods that must complete successfully. Jobs are a common attacker mechanism for one-shot privilege use ("create a Job that mounts the host filesystem, do the thing, exit").</p>`),
 	},
 	"Secret": {
 		Title:  "Secret",
-		Short:  "Stores credentials — TLS keys, registry creds, API tokens, ServiceAccount tokens.",
-		Long:   template.HTML(`<p>A <strong>Secret</strong> holds sensitive data: registry pull credentials, TLS private keys, ServiceAccount tokens. Secrets are base64-encoded, <em>not</em> encrypted by default — anyone with <code>get</code> on the Secret resource can read the contents in cleartext. <code>get</code>/<code>list</code>/<code>watch</code> on Secrets in <code>kube-system</code> is effectively cluster-admin: that namespace holds the controller-manager and kube-scheduler tokens.</p>`),
+		Short:  "Stores credentials: TLS keys, registry creds, API tokens, ServiceAccount tokens.",
+		Long:   template.HTML(`<p>A <strong>Secret</strong> holds sensitive data: registry pull credentials, TLS private keys, ServiceAccount tokens. Secrets are base64-encoded, <em>not</em> encrypted by default. Anyone with <code>get</code> on the Secret resource can read the contents in cleartext. <code>get</code>/<code>list</code>/<code>watch</code> on Secrets in <code>kube-system</code> is effectively cluster-admin: that namespace holds the controller-manager and kube-scheduler tokens.</p>`),
 		DocURL: "https://kubernetes.io/docs/concepts/configuration/secret/",
 	},
 	"ConfigMap": {
@@ -114,14 +114,14 @@ var Glossary = map[string]GlossaryEntry{
 	},
 	"ClusterRole": {
 		Title:  "ClusterRole",
-		Short:  "A cluster-wide bag of (verbs × resources) permissions — granted via a binding.",
-		Long:   template.HTML(`<p>A <strong>ClusterRole</strong> is a named set of permissions ("can <code>get</code>/<code>list</code> on <code>pods</code> across the cluster"). It does nothing on its own — it must be granted to a subject through a ClusterRoleBinding (cluster-wide) or RoleBinding (one namespace).</p><p>The infamous <code>cluster-admin</code> ClusterRole grants <code>verbs: ["*"]</code> on <code>resources: ["*"]</code> in <code>apiGroups: ["*"]</code> — total control.</p>`),
+		Short:  "A cluster-wide bag of (verbs × resources) permissions, granted via a binding.",
+		Long:   template.HTML(`<p>A <strong>ClusterRole</strong> is a named set of permissions ("can <code>get</code>/<code>list</code> on <code>pods</code> across the cluster"). It does nothing on its own; it must be granted to a subject through a ClusterRoleBinding (cluster-wide) or RoleBinding (one namespace).</p><p>The infamous <code>cluster-admin</code> ClusterRole grants <code>verbs: ["*"]</code> on <code>resources: ["*"]</code> in <code>apiGroups: ["*"]</code>, which is total control.</p>`),
 		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
 	},
 	"ClusterRoleBinding": {
 		Title:  "ClusterRoleBinding",
 		Short:  "Grants a ClusterRole's permissions to a subject across the entire cluster.",
-		Long:   template.HTML(`<p>A <strong>ClusterRoleBinding</strong> assigns a ClusterRole to subjects (Users, Groups, ServiceAccounts) at cluster scope — not just one namespace. A binding to <code>cluster-admin</code> here means the subject can do anything anywhere. Always look at <em>both</em> what role is bound <em>and</em> who it is bound to.</p>`),
+		Long:   template.HTML(`<p>A <strong>ClusterRoleBinding</strong> assigns a ClusterRole to subjects (Users, Groups, ServiceAccounts) at cluster scope, not just one namespace. A binding to <code>cluster-admin</code> here means the subject can do anything anywhere. Always look at <em>both</em> what role is bound <em>and</em> who it is bound to.</p>`),
 		DocURL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
 	},
 	"Role": {
@@ -132,64 +132,64 @@ var Glossary = map[string]GlossaryEntry{
 	"RoleBinding": {
 		Title: "RoleBinding",
 		Short: "Grants a Role (or ClusterRole) to a subject, scoped to one namespace.",
-		Long:  template.HTML(`<p>A <strong>RoleBinding</strong> assigns permissions inside a single namespace. It can reference a Role from the same namespace or a ClusterRole — when it references a ClusterRole, the permissions still only apply inside the binding's namespace.</p>`),
+		Long:  template.HTML(`<p>A <strong>RoleBinding</strong> assigns permissions inside a single namespace. It can reference a Role from the same namespace or a ClusterRole. When it references a ClusterRole, the permissions still only apply inside the binding's namespace.</p>`),
 	},
 	"Namespace": {
 		Title: "Namespace",
-		Short: "A logical partition for resources — most policies, quotas, and RBAC scope to one.",
+		Short: "A logical partition for resources: most policies, quotas, and RBAC scope to one.",
 		Long:  template.HTML(`<p>A <strong>Namespace</strong> divides cluster resources by team, environment, or application. RoleBindings, NetworkPolicies, ResourceQuotas, and most admission rules apply at namespace scope. Compromising one workload in a namespace often gives lateral access to the rest of that namespace's resources.</p>`),
 	},
 	"hostPath": {
 		Title:  "hostPath volume",
-		Short:  "Mounts a directory from the underlying node into the pod — a classic container-escape vector.",
+		Short:  "Mounts a directory from the underlying node into the pod (a classic container-escape vector).",
 		Long:   template.HTML(`<p>A <strong>hostPath</strong> volume bind-mounts a path from the host node into the container. Sensitive paths like <code>/</code>, <code>/etc</code>, <code>/var/run/docker.sock</code>, or <code>/var/lib/kubelet</code> turn the pod into a node-takeover primitive: an attacker inside the pod can write systemd units, read the kubelet's credentials, or directly invoke the container runtime to start privileged containers on the host.</p>`),
 		DocURL: "https://kubernetes.io/docs/concepts/storage/volumes/#hostpath",
 	},
 	"PrivilegedContainer": {
 		Title:  "Privileged container",
-		Short:  "Runs with kernel-level access to the host — equivalent to root on the node.",
+		Short:  "Runs with kernel-level access to the host (equivalent to root on the node).",
 		Long:   template.HTML(`<p>Setting <code>securityContext.privileged: true</code> disables most container isolation: the container gets every Linux capability, can access all host devices, and can mount host filesystems. From a privileged container an attacker can escape to the node trivially (<code>nsenter</code>, mount the host's <code>/</code>, write a SUID binary, etc.).</p>`),
 		DocURL: "https://kubernetes.io/docs/concepts/security/pod-security-standards/",
 	},
 	"hostNetwork": {
 		Title: "hostNetwork",
-		Short: "Pod shares the node's network namespace — sees and binds host ports.",
+		Short: "Pod shares the node's network namespace, so it sees and binds host ports.",
 		Long:  template.HTML(`<p>With <code>hostNetwork: true</code>, the pod sees the host's network interfaces directly. It can reach the kubelet on <code>localhost:10250</code>, sniff or spoof traffic between other workloads on that node, and bind privileged ports without going through the CNI.</p>`),
 	},
 	"hostPID": {
 		Title: "hostPID",
-		Short: "Pod sees and can signal every process on the node — including the kubelet.",
+		Short: "Pod sees and can signal every process on the node, including the kubelet.",
 		Long:  template.HTML(`<p>With <code>hostPID: true</code>, the pod's PID namespace is the host's. It can <code>ps</code> all processes (including the kubelet), read <code>/proc/&lt;pid&gt;/environ</code> for credentials, and join other processes' namespaces with <code>nsenter</code>.</p>`),
 	},
 	"RunAsRoot": {
 		Title: "Container runs as root (UID 0)",
-		Short: "No runAsNonRoot constraint — kernel exploits and breakout primitives apply.",
+		Short: "No runAsNonRoot constraint, so kernel exploits and breakout primitives apply.",
 		Long:  template.HTML(`<p>Containers that run as UID 0 are not automatically dangerous, but they remove a layer of defence. Combined with capabilities or hostPath, root-in-container becomes root-on-node much more easily.</p>`),
 	},
 	"Capabilities": {
 		Title: "Linux capabilities",
-		Short: "Fine-grained kernel privileges — SYS_ADMIN, NET_ADMIN, etc. are container-escape primitives.",
+		Short: "Fine-grained kernel privileges: SYS_ADMIN, NET_ADMIN, and similar are container-escape primitives.",
 		Long:  template.HTML(`<p>Linux <strong>capabilities</strong> split root's powers into ~40 buckets. <code>SYS_ADMIN</code> alone is enough to mount filesystems and break out of most container runtimes. <code>NET_ADMIN</code> allows traffic redirection. <code>SYS_PTRACE</code> lets a container read other processes' memory. The principle is: drop everything, add only what is needed.</p>`),
 	},
 	"NetworkPolicy": {
 		Title: "NetworkPolicy",
-		Short: "Cluster-internal firewall — without one, every pod can talk to every other pod.",
+		Short: "Cluster-internal firewall. Without one, every pod can talk to every other pod.",
 		Long:  template.HTML(`<p>A <strong>NetworkPolicy</strong> restricts which pods can talk to which. The default in Kubernetes is <em>allow-all</em>: a pod with no NetworkPolicies covering it can reach every pod in the cluster, including the API server, etcd via metrics endpoints, and internal services. Lateral movement after pod compromise depends on whether NetworkPolicies are enforced.</p>`),
 	},
 	"AdmissionWebhook": {
 		Title: "Admission webhook",
-		Short: "A pluggable validator/mutator for API requests — failurePolicy: Ignore is a security gap.",
-		Long:  template.HTML(`<p>An <strong>admission webhook</strong> intercepts API requests before they are persisted, allowing custom policy. If a security-critical webhook has <code>failurePolicy: Ignore</code>, an outage of the webhook backend silently disables enforcement — attackers can race a webhook restart and slip through.</p>`),
+		Short: "A pluggable validator/mutator for API requests; failurePolicy: Ignore is a security gap.",
+		Long:  template.HTML(`<p>An <strong>admission webhook</strong> intercepts API requests before they are persisted, allowing custom policy. If a security-critical webhook has <code>failurePolicy: Ignore</code>, an outage of the webhook backend silently disables enforcement, and attackers can race a webhook restart and slip through.</p>`),
 	},
 	"kube-system": {
 		Title: "kube-system namespace",
-		Short: "Holds the control plane's ServiceAccounts and tokens — read-access here is cluster-admin.",
-		Long:  template.HTML(`<p>The <strong>kube-system</strong> namespace contains tokens for the controller-manager, kube-scheduler, and other privileged controllers. Anyone who can <code>get</code>/<code>list</code>/<code>watch</code> Secrets in kube-system can read those tokens and act as those controllers — which is effectively cluster-admin.</p>`),
+		Short: "Holds the control plane's ServiceAccounts and tokens. Read-access here is cluster-admin.",
+		Long:  template.HTML(`<p>The <strong>kube-system</strong> namespace contains tokens for the controller-manager, kube-scheduler, and other privileged controllers. Anyone who can <code>get</code>/<code>list</code>/<code>watch</code> Secrets in kube-system can read those tokens and act as those controllers, which is effectively cluster-admin.</p>`),
 	},
 	"system:masters": {
 		Title: "system:masters group",
 		Short: "Hardcoded as cluster-admin. Membership cannot be revoked through RBAC.",
-		Long:  template.HTML(`<p>The <strong>system:masters</strong> group is special-cased in the API server: members bypass RBAC and act as cluster-admin. The membership comes from the authenticator (typically certificate <code>O=system:masters</code>) and <em>cannot</em> be removed by deleting bindings — it is wired in below the RBAC layer.</p>`),
+		Long:  template.HTML(`<p>The <strong>system:masters</strong> group is special-cased in the API server: members bypass RBAC and act as cluster-admin. The membership comes from the authenticator (typically certificate <code>O=system:masters</code>) and <em>cannot</em> be removed by deleting bindings; it is wired in below the RBAC layer.</p>`),
 	},
 }
 
@@ -198,7 +198,7 @@ var Glossary = map[string]GlossaryEntry{
 var Techniques = map[string]TechniqueExplainer{
 	"impersonate_system_masters": {
 		Title: "Impersonation of system:masters",
-		Plain: template.HTML(`<p>The <code>impersonate</code> verb on <code>groups: ["*"]</code> (or explicitly on <code>system:masters</code>) lets the holder send requests as the hard-coded <code>system:masters</code> group. The kube-apiserver short-circuits authorization for that group — every API call succeeds regardless of RBAC.</p><p>This is the worst-case impersonation grant: it bypasses the cluster's entire RBAC layer rather than borrowing another principal's permissions.</p>`),
+		Plain: template.HTML(`<p>The <code>impersonate</code> verb on <code>groups: ["*"]</code> (or explicitly on <code>system:masters</code>) lets the holder send requests as the hard-coded <code>system:masters</code> group. The kube-apiserver short-circuits authorization for that group, so every API call succeeds regardless of RBAC.</p><p>This is the worst-case impersonation grant: it bypasses the cluster's entire RBAC layer rather than borrowing another principal's permissions.</p>`),
 		Mitre: "T1078.004 — Cloud Accounts",
 		AttackerSteps: []AttackerStep{
 			{Note: "Confirm the bypass works by querying as system:masters", Cmd: "kubectl auth can-i --list --as=system:masters --as-group=system:masters"},
@@ -216,7 +216,7 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"impersonate": {
 		Title: "RBAC impersonation",
-		Plain: template.HTML(`<p>Kubernetes has a built-in "act as another user" feature — the <code>impersonate</code> verb on <code>users</code>, <code>groups</code>, or <code>serviceaccounts</code>. Anyone with that verb can submit requests as <em>any</em> identity, bypassing whatever permissions they don't have themselves.</p><p>Granting <code>impersonate</code> on <code>groups</code> = <code>["*"]</code> is equivalent to cluster-admin: the holder can impersonate <code>system:masters</code>.</p>`),
+		Plain: template.HTML(`<p>Kubernetes has a built-in "act as another user" feature: the <code>impersonate</code> verb on <code>users</code>, <code>groups</code>, or <code>serviceaccounts</code>. Anyone with that verb can submit requests as <em>any</em> identity, bypassing whatever permissions they don't have themselves.</p><p>Granting <code>impersonate</code> on <code>groups</code> = <code>["*"]</code> is equivalent to cluster-admin: the holder can impersonate <code>system:masters</code>.</p>`),
 		Mitre: "T1078.004 — Cloud Accounts",
 		AttackerSteps: []AttackerStep{
 			{Note: "Confirm impersonation works", Cmd: "kubectl auth can-i --list --as=system:masters"},
@@ -226,7 +226,7 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"bind_or_escalate": {
 		Title: "RBAC bind/escalate bypass",
-		Plain: template.HTML(`<p>RBAC has a guardrail: you can only grant permissions you yourself hold. Two verbs override that guardrail — <code>bind</code> (on a Role/ClusterRole) and <code>escalate</code> (also on Roles). Holding either lets the attacker create a binding to a Role they don't have themselves — including <code>cluster-admin</code>.</p>`),
+		Plain: template.HTML(`<p>RBAC has a guardrail: you can only grant permissions you yourself hold. Two verbs override that guardrail: <code>bind</code> (on a Role/ClusterRole) and <code>escalate</code> (also on Roles). Holding either lets the attacker create a binding to a Role they don't have themselves, including <code>cluster-admin</code>.</p>`),
 		Mitre: "T1098.003 — Account Manipulation: Additional Cloud Roles",
 		AttackerSteps: []AttackerStep{
 			{Note: "Bind a chosen ServiceAccount to cluster-admin", Cmd: "kubectl create clusterrolebinding pwn --clusterrole=cluster-admin --serviceaccount=ns:me"},
@@ -235,7 +235,7 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"pod_create_token_theft": {
 		Title: "Pod creation → ServiceAccount token theft",
-		Plain: template.HTML(`<p>Anyone who can create pods in a namespace can mount any ServiceAccount in that namespace into the pod. Cluster-scoped pod-create lets you mount any ServiceAccount in <em>any</em> namespace. Once the pod is running, the attacker reads <code>/var/run/secrets/kubernetes.io/serviceaccount/token</code> from inside it — and now holds a token for that SA.</p><p>This is the single most common privilege-escalation pattern in production Kubernetes.</p>`),
+		Plain: template.HTML(`<p>Anyone who can create pods in a namespace can mount any ServiceAccount in that namespace into the pod. Cluster-scoped pod-create lets you mount any ServiceAccount in <em>any</em> namespace. Once the pod is running, the attacker reads <code>/var/run/secrets/kubernetes.io/serviceaccount/token</code> from inside it, and now holds a token for that SA.</p><p>This is the single most common privilege-escalation pattern in production Kubernetes.</p>`),
 		Mitre: "T1528 — Steal Application Access Token",
 		AttackerSteps: []AttackerStep{
 			{Note: "Spin up a pod that mounts the privileged ServiceAccount's token", Cmd: "kubectl run thief --image=alpine --serviceaccount=privileged-sa --command -- sleep infinity"},
@@ -254,7 +254,7 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"token_request": {
 		Title: "TokenRequest minting",
-		Plain: template.HTML(`<p>The <code>create</code> verb on <code>serviceaccounts/token</code> mints a fresh, valid token for any ServiceAccount in scope — no pod required. Cleaner than the pod-creation route and harder to spot in audit logs.</p>`),
+		Plain: template.HTML(`<p>The <code>create</code> verb on <code>serviceaccounts/token</code> mints a fresh, valid token for any ServiceAccount in scope, with no pod required. Cleaner than the pod-creation route and harder to spot in audit logs.</p>`),
 		Mitre: "T1528 — Steal Application Access Token",
 		AttackerSteps: []AttackerStep{
 			{Note: "Mint a fresh 24h token for any ServiceAccount in scope", Cmd: "kubectl create token <sa> --duration=24h --bound-object-kind=Pod --bound-object-name=irrelevant"},
@@ -263,11 +263,11 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"bound_to_cluster_admin": {
 		Title: "Direct cluster-admin binding",
-		Plain: template.HTML(`<p>The subject is bound directly to the <code>cluster-admin</code> ClusterRole through a ClusterRoleBinding. No chain needed — they are already cluster-admin. The only question is whether the subject itself can be compromised.</p>`),
+		Plain: template.HTML(`<p>The subject is bound directly to the <code>cluster-admin</code> ClusterRole through a ClusterRoleBinding. No chain is needed; they are already cluster-admin. The only question is whether the subject itself can be compromised.</p>`),
 		Mitre: "T1078 — Valid Accounts",
 		AttackerSteps: []AttackerStep{
 			{Note: "Enumerate every subject already bound to cluster-admin", Cmd: "kubectl get clusterrolebinding -o json | jq '.items[] | select(.roleRef.name==\"cluster-admin\") | .subjects'"},
-			{Note: "Compromise any subject in that list — done."},
+			{Note: "Compromise any subject in that list. Done."},
 		},
 	},
 	"wildcard_permission": {
@@ -277,7 +277,7 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"modify_role_binding": {
 		Title: "RoleBinding write access",
-		Plain: template.HTML(`<p><code>create</code>/<code>update</code>/<code>patch</code> on <code>rolebindings</code> or <code>clusterrolebindings</code> lets the attacker bind themselves to any role — typically cluster-admin. They don't need the role's permissions today, only the ability to change bindings.</p>`),
+		Plain: template.HTML(`<p><code>create</code>/<code>update</code>/<code>patch</code> on <code>rolebindings</code> or <code>clusterrolebindings</code> lets the attacker bind themselves to any role, typically cluster-admin. They don't need the role's permissions today, only the ability to change bindings.</p>`),
 		Mitre: "T1098 — Account Manipulation",
 		AttackerSteps: []AttackerStep{
 			{Note: "Append yourself as a subject on an existing high-privilege binding", Cmd: "kubectl patch clusterrolebinding existing-binding --type=json -p='[{\"op\":\"add\",\"path\":\"/subjects/-\",\"value\":{\"kind\":\"ServiceAccount\",\"name\":\"me\",\"namespace\":\"ns\"}}]'"},
@@ -285,7 +285,7 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"read_secrets": {
 		Title: "Secrets read access",
-		Plain: template.HTML(`<p><code>get</code>/<code>list</code>/<code>watch</code> on Secrets in kube-system or cluster-wide reads the controller-manager, scheduler, and node-bootstrap tokens — every credential needed to act as the control plane.</p>`),
+		Plain: template.HTML(`<p><code>get</code>/<code>list</code>/<code>watch</code> on Secrets in kube-system or cluster-wide reads the controller-manager, scheduler, and node-bootstrap tokens: every credential needed to act as the control plane.</p>`),
 		Mitre: "T1552 — Unsecured Credentials",
 		AttackerSteps: []AttackerStep{
 			{Note: "Dump every ServiceAccount token stored in kube-system", Cmd: "kubectl get secret -n kube-system -o json | jq -r '.items[] | select(.type==\"kubernetes.io/service-account-token\") | .data.token' | base64 -d"},
@@ -302,7 +302,7 @@ var Techniques = map[string]TechniqueExplainer{
 		Mitre: "T1611 — Escape to Host",
 		AttackerSteps: []AttackerStep{
 			{Note: "From inside the privileged pod, drop into PID 1's namespaces on the host", Cmd: "nsenter -t 1 -m -u -i -n -p -- /bin/sh"},
-			{Note: "Steal the kubelet's client cert — the node's identity to the API server", Cmd: "cat /var/lib/kubelet/pki/kubelet-client-current.pem"},
+			{Note: "Steal the kubelet's client cert (the node's identity to the API server)", Cmd: "cat /var/lib/kubelet/pki/kubelet-client-current.pem"},
 			{Note: "Pivot to other pods on the same node via the container runtime socket", Cmd: "crictl --runtime-endpoint unix:///run/containerd/containerd.sock ps"},
 		},
 	},
@@ -312,7 +312,7 @@ var Techniques = map[string]TechniqueExplainer{
 var Categories = map[string]CategoryExplainer{
 	string(models.CategoryPrivilegeEscalation): {
 		Title: "Privilege Escalation",
-		Plain: template.HTML(`<p>An identity that started with limited permissions ends up acting as cluster-admin (or <code>system:masters</code>, or the kubelet on a node). Privilege escalation is the gateway impact — every other category becomes possible once an attacker has it.</p>`),
+		Plain: template.HTML(`<p>An identity that started with limited permissions ends up acting as cluster-admin (or <code>system:masters</code>, or the kubelet on a node). Privilege escalation is the gateway impact: every other category becomes possible once an attacker has it.</p>`),
 		Examples: []string{
 			"A compromised application pod's ServiceAccount mints a cluster-admin token via TokenRequest.",
 			"A namespace-admin abuses bind/escalate to grant themselves cluster-admin.",
@@ -321,7 +321,7 @@ var Categories = map[string]CategoryExplainer{
 	},
 	string(models.CategoryLateralMovement): {
 		Title: "Lateral Reach",
-		Plain: template.HTML(`<p>The attacker spreads sideways — across namespaces, across nodes, or out of the pod onto cluster-internal services. NetworkPolicy gaps, default-allow service meshes, and over-broad ServiceAccounts in shared namespaces all enable this.</p>`),
+		Plain: template.HTML(`<p>The attacker spreads sideways: across namespaces, across nodes, or out of the pod onto cluster-internal services. NetworkPolicy gaps, default-allow service meshes, and over-broad ServiceAccounts in shared namespaces all enable this.</p>`),
 		Examples: []string{
 			"From a compromised pod, reach the API server, etcd metrics endpoints, or internal databases that have no NetworkPolicy.",
 			"hostNetwork pods can sniff or spoof traffic for every other pod on the same node.",
@@ -329,7 +329,7 @@ var Categories = map[string]CategoryExplainer{
 	},
 	string(models.CategoryDataExfiltration): {
 		Title: "Data Exfiltration",
-		Plain: template.HTML(`<p>Reading data the attacker should not see — Secrets, ConfigMap-stored credentials, application data in PersistentVolumes, or audit logs that reveal internal structure.</p>`),
+		Plain: template.HTML(`<p>Reading data the attacker should not see: Secrets, ConfigMap-stored credentials, application data in PersistentVolumes, or audit logs that reveal internal structure.</p>`),
 		Examples: []string{
 			"Reading every Secret in kube-system to harvest controller credentials.",
 			"Mounting a PersistentVolume from a database StatefulSet.",
@@ -338,7 +338,7 @@ var Categories = map[string]CategoryExplainer{
 	},
 	string(models.CategoryInfrastructureModification): {
 		Title: "Control Bypass",
-		Plain: template.HTML(`<p>The attacker turns off, weakens, or works around the cluster's policy enforcement — admission webhooks, Pod Security admission, OPA/Gatekeeper, or audit configuration. After this, follow-on actions become invisible to defenders.</p>`),
+		Plain: template.HTML(`<p>The attacker turns off, weakens, or works around the cluster's policy enforcement: admission webhooks, Pod Security admission, OPA/Gatekeeper, or audit configuration. After this, follow-on actions become invisible to defenders.</p>`),
 		Examples: []string{
 			"Patching a `ValidatingWebhookConfiguration` to `failurePolicy: Ignore`, then deleting the backing service.",
 			"Removing a Pod Security label from a namespace to allow privileged pods.",
@@ -346,7 +346,7 @@ var Categories = map[string]CategoryExplainer{
 	},
 	string(models.CategoryDefenseEvasion): {
 		Title: "Detection Evasion",
-		Plain: template.HTML(`<p>The attacker hides their tracks — disabling audit logging, deleting events, rolling back resource versions, or abusing legitimate-looking patterns (impersonation, service accounts) so the activity blends in.</p>`),
+		Plain: template.HTML(`<p>The attacker hides their tracks: disabling audit logging, deleting events, rolling back resource versions, or abusing legitimate-looking patterns (impersonation, service accounts) so the activity blends in.</p>`),
 		Examples: []string{
 			"Using `--as=system:serviceaccount:kube-system:replicaset-controller` to impersonate a high-volume controller and disappear in audit log noise.",
 			"Deleting Events that record the privileged pod's creation.",

--- a/internal/report/narratives.go
+++ b/internal/report/narratives.go
@@ -44,7 +44,7 @@ func buildNarratives(findings []models.Finding) []NarrativeCard {
 		steps := []NarrativeStep{
 			subjectListStep("An attacker gains code execution in a workload co-scheduled with, or targeting, one of:",
 				"An attacker gains code execution in a workload co-scheduled with, or targeting, %s.", resList),
-			{Text: "The workload is configured to trust the host in one or more ways — privileged mode grants all capabilities; a hostPath of / mounts the node's root filesystem; hostPID/hostIPC share the host's process and IPC namespaces."},
+			{Text: "The workload is configured to trust the host in one or more ways. Privileged mode grants all capabilities; a hostPath of / mounts the node's root filesystem; hostPID/hostIPC share the host's process and IPC namespaces."},
 			{Text: "Any one of these alone is enough for a straightforward container escape: write into the host filesystem, exec through /proc/1, or interact with the kubelet's unix socket."},
 			{Text: "From there, the attacker reads projected tokens for every other pod on the node and pivots into the cluster with those identities."},
 		}
@@ -82,7 +82,7 @@ func buildNarratives(findings []models.Finding) []NarrativeCard {
 		steps := []NarrativeStep{
 			subjectListStep("The attacker lands on a workload that mounts one of the following service accounts (or phishes a kubeconfig bound to one):",
 				"The attacker lands on a workload that mounts %s, or phishes a kubeconfig bound to it.", dualSubjects),
-			{Text: "That identity holds cluster-wide get/list on secrets — including service-account tokens in every namespace. The attacker lists kube-system secrets and reads tokens belonging to powerful controllers."},
+			{Text: "That identity holds cluster-wide get/list on secrets, which includes service-account tokens in every namespace. The attacker lists kube-system secrets and reads tokens belonging to powerful controllers."},
 			{Text: "Even without the token read, the same identity can create pods cluster-wide. The attacker schedules a pod that mounts the target service account, execs in, and acts as it."},
 			{Text: "Either path converges on a cluster-admin-equivalent identity; all policies, secrets, and workloads are now under attacker control."},
 		}
@@ -103,12 +103,12 @@ func buildNarratives(findings []models.Finding) []NarrativeCard {
 			steps = append(steps, NarrativeStep{Text: "The webhook that should block dangerous pods fails open: failurePolicy: Ignore means any backend outage (or a targeted denial-of-service) silently disables enforcement for the window the attacker needs."})
 		}
 		if slices.Contains(presentAdmission, "KUBE-ADMISSION-003") {
-			steps = append(steps, NarrativeStep{Text: "Its namespace selector excludes at least one sensitive namespace — workloads placed there skip admission entirely."})
+			steps = append(steps, NarrativeStep{Text: "Its namespace selector excludes at least one sensitive namespace, so workloads placed there skip admission entirely."})
 		}
 		if slices.Contains(presentAdmission, "KUBE-ADMISSION-002") {
 			steps = append(steps, NarrativeStep{Text: "The webhook keys off a workload-controlled label. Omit the label and admission doesn't apply."})
 		}
-		steps = append(steps, NarrativeStep{Text: "Any one of the above is a full bypass of the admission gate you thought was catching misconfigurations — every other chain in this report becomes easier to execute."})
+		steps = append(steps, NarrativeStep{Text: "Any one of the above is a full bypass of the admission gate you thought was catching misconfigurations. In practice, this means every other chain in this report becomes easier to execute."})
 		narratives = append(narratives, NarrativeCard{
 			Title:    "Admission gap → silent enforcement bypass",
 			Severity: "HIGH",
@@ -123,13 +123,13 @@ func buildNarratives(findings []models.Finding) []NarrativeCard {
 	if len(presentNetwork) > 0 {
 		steps := []NarrativeStep{}
 		if slices.Contains(presentNetwork, "KUBE-NETPOL-COVERAGE-001") {
-			steps = append(steps, NarrativeStep{Text: "Namespaces with no NetworkPolicies treat every pod as reachable from every other pod — there is no default-deny, so a compromised workload can reach every service on every pod."})
+			steps = append(steps, NarrativeStep{Text: "Namespaces with no NetworkPolicies treat every pod as reachable from every other pod. There is no default-deny, so a compromised workload can reach every service on every pod."})
 		}
 		if slices.Contains(presentNetwork, "KUBE-NETPOL-WEAKNESS-001") {
 			steps = append(steps, NarrativeStep{Text: "An allow-from-all-namespaces policy is effectively no policy: traffic from any namespace matches, including attacker-controlled namespaces."})
 		}
 		if slices.Contains(presentNetwork, "KUBE-NETPOL-WEAKNESS-002") {
-			steps = append(steps, NarrativeStep{Text: "Egress 0.0.0.0/0 gives the attacker free outbound reach — stolen tokens, secrets, and staging data leave the cluster with nothing in the way."})
+			steps = append(steps, NarrativeStep{Text: "Egress 0.0.0.0/0 gives the attacker free outbound reach. Stolen tokens, secrets, and staging data leave the cluster with nothing in the way."})
 		}
 		steps = append(steps, NarrativeStep{Text: "Combined, the attacker sweeps every pod in the cluster for vulnerable services and exfiltrates data without tripping a segmentation boundary."})
 		narratives = append(narratives, NarrativeCard{


### PR DESCRIPTION
## Summary

- Smooth the report's body prose toward the explanatory cadence used by [Datadog Security Labs' Kubernetes Security Fundamentals series](https://securitylabs.datadoghq.com/articles/kubernetes-security-fundamentals-part-1/) (light adapt: keep the existing "an attacker does X / they run Y" walkthrough voice, soften staccato em-dash beats, add a few `this means that...` / `in practice` bridges where a reader new to a Kubernetes API would benefit).
- Eliminate `—` from finding `Description`, `Impact`, `AttackScenario`, `Remediation`, `RemediationSteps`, and `Scope.Detail` strings across all 7 analyzer modules (~250 substitutions).
- Apply the same sweep to the report-layer educational copy (`glossary.go` Glossary/Techniques/Categories, `evidence_glossary.go` chip/hint tables, `evidence_render.go` rendered HTML chips, `narratives.go` auto-detected attack-chain walkthroughs) and the HTML template (`report.html.tmpl` headline copy, browser title, search placeholder, aria labels).
- Em-dashes inside `models.Reference{Title: ...}` strings (which mirror upstream page titles like `"Kubernetes — RBAC Good Practices"`) and MITRE ATT&CK technique labels (`"T1078 — Valid Accounts"`) are preserved as identifiers, per the plan.
- Rule IDs, severities, MITRE mappings, reference URLs, scoring, and finding structure are unchanged. The `AttackScenario` / `RemediationSteps` step counts and imperative form are preserved.

## Test plan

- [x] `make build` — compiles cleanly.
- [x] `make lint` — `gofmt -l` and `go vet` clean.
- [x] `make test` — all packages pass; no test edits were needed (the existing prose-substring asserts check `formatBindingRef`-produced kind+name tokens, which are interpolated via `%s` and survive the rewrite).
- [x] Bundled-snapshot scan: `./bin/kubesplaining scan --input-file testdata/snapshots/minimal-risky.json` renders 20 findings cleanly; eyeball check on three finding cards (RBAC, PodSec, privesc) confirms no staccato em-dash beats in body prose.
- [x] Em-dash budget check: `rg ' — '` over `internal/analyzer/` and `internal/report/` shows only intentional Reference Titles, MITRE labels, and source-code comments.
- [x] CI matrix (Linux + macOS) — let GitHub Actions run.
- [ ] `make e2e` — kind-based end-to-end scan; not affected by prose, but exercises report writers end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)