### PR TITLE
docs: add exclusions schema reference and refresh stale doc claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ First public release.
 
 Kubesplaining is a Kubernetes security assessment CLI inspired by Salesforce's [Cloudsplaining](https://github.com/salesforce/cloudsplaining). It reads a live cluster (or a previously captured snapshot) and analyzes it against a library of techniques, emitting a prioritized list of findings as HTML, JSON, CSV, or SARIF.
 
-The differentiator is **graph-based privilege-escalation path detection**: BFS from every non-system RBAC subject to four escalation sinks (cluster-admin, system:masters, node-escape, kube-system-secrets), with the full hop chain attached to every finding. See the [hosted example report](https://0hardik1.github.io/Kubesplaining/) for what the output actually looks like.
+The differentiator is **graph-based privilege-escalation path detection**: BFS from every non-system RBAC subject to five escalation sinks (cluster-admin, system:masters, node-escape, kube-system-secrets, token-mint), with the full hop chain attached to every finding. See the [hosted example report](https://0hardik1.github.io/kubesplaining/) for what the output actually looks like.
 
 ### Added
 
@@ -23,7 +23,7 @@ The differentiator is **graph-based privilege-escalation path detection**: BFS f
   - **admission** (3) — webhooks with `failurePolicy: Ignore`, objectSelector bypass surface, sensitive-namespace exemptions.
   - **secrets** (4) — legacy SA token secrets, credential-like ConfigMap keys, CoreDNS tampering risk, kube-system Opaque secrets.
   - **serviceaccount** (4) — privileged SAs, default-SA RBAC, DaemonSet token blast-radius, workload-mounted SA risk correlation.
-  - **privesc** (4 sinks) — multi-hop BFS to cluster-admin / system:masters / node-escape / kube-system-secrets with chain-length severity attenuation.
+  - **privesc** (5 sinks) — multi-hop BFS to cluster-admin / system:masters / node-escape / kube-system-secrets / token-mint with chain-length severity attenuation.
 
 - **Cluster-wide attack-path analysis.** `internal/analyzer/privesc/` builds a directed graph of RBAC subjects + sinks + pod-escape edges, BFS's from every non-`system:*` subject up to `--max-privesc-depth` (default 5), and emits one finding per (source, sink) pair with the full hop chain as `EscalationPath`.
 
@@ -45,14 +45,14 @@ The differentiator is **graph-based privilege-escalation path detection**: BFS f
 
 - Comprehensive [README](README.md) with install paths, quickstart, comparison table vs. kube-bench / kubescape / KubiScan / rbac-tool.
 - Full rule catalog and roadmap in [`docs/findings.md`](docs/findings.md) and [`PLAN.md`](PLAN.md).
-- Live demo report at <https://0hardik1.github.io/Kubesplaining/> regenerated on every push to `main`.
+- Live demo report at <https://0hardik1.github.io/kubesplaining/> regenerated on every push to `main`.
 
 ### Security
 
 - Read-only access is sufficient for the full analysis. No admission webhook registration, no CRD install, no agent pods.
-- Secrets are collected as metadata only. ConfigMap `Data` is preserved (keys + values) so analyzers can pattern-match credential-like keys; opt in to raw secret values explicitly with `--include-secret-values`.
+- Secrets are collected as `SecretMetadata` only — raw secret values are never read. ConfigMap data is redacted by the collector (keys preserved, values blanked) so analyzers can pattern-match credential-like key names without ever storing the payloads.
 - Forbidden/Unauthorized list errors are downgraded to `CollectionWarnings` rather than aborting — locked-down clusters still produce a useful partial-snapshot report.
 - Vulnerability disclosure: GitHub Private Vulnerability Reporting only. See [SECURITY.md](SECURITY.md).
 
-[Unreleased]: https://github.com/0hardik1/Kubesplaining/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/0hardik1/Kubesplaining/releases/tag/v1.0.0
+[Unreleased]: https://github.com/0hardik1/kubesplaining/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/0hardik1/kubesplaining/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Kubesplaining is a Go CLI for Kubernetes security assessment, modeled on Salesforce's Cloudsplaining. It reads cluster state (live or from a snapshot file) and emits scored findings as HTML, JSON, CSV, or SARIF.
 
-The single source-of-truth for *what* the tool does and every implemented/planned rule is `README.md`. The implementation roadmap and current status of every spec item is in `PLAN.md`. The full functional spec is `KUBESPLAINING_SPEC.md`. Read the README first when picking up a new task — it lists every rule ID, severity, and the analyzer file that owns it.
+`README.md` is the operator-facing overview. The comprehensive per-rule catalog (rule IDs, severity, detection logic, remediation, owning analyzer file) lives in [`docs/findings.md`](docs/findings.md) — read that first when adding or renaming a rule. The architectural deep-dive is in [`docs/architecture.md`](docs/architecture.md), the exclusions YAML schema in [`docs/exclusions.md`](docs/exclusions.md). The implementation roadmap and current status of every spec item is in `PLAN.md`. The full functional spec is `KUBESPLAINING_SPEC.md`.
 
 ## Common commands
 
@@ -46,13 +46,13 @@ Four-stage pipeline: **connection → collection → analysis → report**. The 
 
 ```
 cmd/kubesplaining/main.go            # entrypoint, ldflags-injected version
-└── internal/cli/                     # cobra commands: download, scan, scan-resource, report, create-exclusions, version
+└── internal/cli/                     # cobra commands: download, scan, scan-resource, report, create-exclusions-file, version
     └── internal/connection/          # client-go credentials resolution
     └── internal/collector/           # parallel API listing → models.Snapshot (single ~657-line collector.go)
     └── internal/manifest/            # offline alternative to collector: reads a YAML/JSON manifest into a Snapshot for `scan-resource`
     └── internal/analyzer/            # the engine + 7 modules; see below
-    └── internal/exclusions/          # YAML-driven post-analysis muting (annotates Excluded=true, never drops)
-    └── internal/report/              # html/json/csv/sarif writers; report.go is large because HTML/CSS/JS is embedded
+    └── internal/exclusions/          # YAML-driven post-analysis muting; matched findings are dropped from output (see docs/exclusions.md for schema)
+    └── internal/report/              # html/json/csv/sarif writers; HTML rendering is split across summary.go, evidence_render.go, attack_graph.go, glossary.go (each 400-850 lines because all CSS/JS is embedded)
     └── internal/scoring/             # composite formula + clamp + threshold helper, shared by analyzers and engine
     └── internal/permissions/         # aggregate.go: collapses (Cluster)RoleBindings × (Cluster)Roles into per-subject EffectiveRules
     └── internal/models/              # Snapshot, Finding, Severity, EscalationGraph/Path/Hop — the cross-package vocabulary
@@ -80,12 +80,12 @@ The seven modules live under `internal/analyzer/{rbac,podsec,network,admission,s
 
 ### `privesc` is the differentiator
 
-`internal/analyzer/privesc/` builds a directed graph (`graph.go`) where nodes are RBAC subjects plus synthetic sinks (`cluster-admin`, `system:masters`, `node-escape`, `kube-system-secrets`). Edges are RBAC techniques (impersonate, bind/escalate, pod-create-then-token-theft, etc.). `pathfinder.go` BFS's from every non-`system:*` subject up to `MaxDepth` (default 5, flag: `--max-privesc-depth`), and `analyzer.go` emits one finding per `(source, sink)` pair with the full hop chain as `EscalationPath`. Severity is attenuated by chain length: `score = base − 0.5 × (hops − 1)`, hops ≥ 3 drop one severity bucket. `system:*` subjects are skipped as intermediate hops to prevent paths from laundering through the control plane.
+`internal/analyzer/privesc/` builds a directed graph (`graph.go`) where nodes are RBAC subjects plus five synthetic sinks (`cluster_admin`, `kube_system_secrets`, `node_escape`, `system_masters`, `token_mint`). Edges are RBAC techniques (impersonate, bind/escalate, pod-create-then-token-theft, token mint, etc.). `pathfinder.go` BFS's from every non-`system:*` subject up to `MaxDepth` (default 5, flag: `--max-privesc-depth`), and `analyzer.go` emits one finding per `(source, sink)` pair with the full hop chain as `EscalationPath`. Severity is attenuated by chain length: `score = base − 0.5 × (hops − 1)` (then clamped to `[1, 10]`), and hops ≥ 3 drop one severity bucket. Subjects flagged `IsSystem` (built-in `system:*`) are skipped as intermediate hops — they're only valid as terminal sinks via explicit edges — so paths can't launder through the control plane.
 
 ### Data flow contract
 
 - `models.Snapshot` is plain JSON-serializable. `collector.WriteSnapshot` / `collector.ReadSnapshot` round-trip it. The `download` command writes one; `scan --input-file` and the e2e script consume one.
-- Secrets are collected as `SecretMetadata` only — **raw secret values are never read**. ConfigMap `Data` is preserved (keys + values) so analyzers can pattern-match credential-like keys; do not change this without re-reading the privacy notes in `README.md`.
+- Secrets are collected as `SecretMetadata` only — **raw secret values are never read**. ConfigMaps go through `redactConfigMapValues` in the collector: **keys are preserved, values are blanked to empty strings** so analyzers can pattern-match credential-like key names without ever storing the payloads. Do not change this without re-reading the privacy notes in `README.md`.
 - Forbidden/Unauthorized list errors in the collector are **downgraded to warnings** and recorded in `Snapshot.Metadata.CollectionWarnings` / `PermissionsMissing`. Don't promote these to fatal — locked-down clusters depend on partial-snapshot behavior.
 - `permissions.Aggregate(snapshot)` is the canonical way to get effective RBAC per subject; the `rbac` and `serviceaccount` analyzers both use it. Don't re-traverse bindings/roles ad hoc.
 
@@ -101,9 +101,9 @@ score = base × exploitability × blast_radius + chain_modifier
 
 ### Findings
 
-Every analyzer emits `models.Finding` with a stable `RuleID` (`KUBE-<MODULE>-<NUMBER>`). Rule IDs are referenced from [`docs/findings.md`](docs/findings.md), the e2e assertions in `scripts/kind-e2e.sh`, and likely downstream consumers — treat them as a public surface. New rule IDs should follow the existing prefix scheme (`KUBE-PRIVESC-`, `KUBE-ESCAPE-`, `KUBE-PODSEC-`, `KUBE-NETPOL-`, `KUBE-ADMISSION-`, `KUBE-SECRETS-`, `KUBE-CONFIGMAP-`, `KUBE-SA-`, `KUBE-RBAC-OVERBROAD-`, `KUBE-PRIVESC-PATH-`).
+Every analyzer emits `models.Finding` with a stable `RuleID`. Rule IDs are referenced from [`docs/findings.md`](docs/findings.md), the e2e assertions in `scripts/kind-e2e.sh`, and likely downstream consumers — treat them as a public surface. The naming convention is `KUBE-<AREA>-<SUFFIX>`, where the suffix is either a zero-padded number (`KUBE-ESCAPE-001`) or, for privesc graph paths, a descriptive sink name (`KUBE-PRIVESC-PATH-CLUSTER-ADMIN`). Multi-segment areas are common when a module covers several axes — e.g. `KUBE-PODSEC-APE-001`, `KUBE-PODSEC-ROOT-001`, `KUBE-NETPOL-COVERAGE-001`, `KUBE-NETPOL-WEAKNESS-001`, `KUBE-SA-DEFAULT-001`, `KUBE-SA-PRIVILEGED-001`. Other prefixes in use today: `KUBE-PRIVESC-`, `KUBE-ESCAPE-`, `KUBE-CONTAINERD-SOCKET-`, `KUBE-HOSTPATH-`, `KUBE-IMAGE-LATEST-`, `KUBE-ADMISSION-`, `KUBE-SECRETS-`, `KUBE-CONFIGMAP-`, `KUBE-RBAC-OVERBROAD-`. See [`docs/findings.md`](docs/findings.md) for the authoritative list.
 
-`Finding.ID` is the deterministic per-instance key (`RULE:ns:name`); `RuleID` is shared across instances of the same rule. Exclusions never delete findings — they set `Excluded=true` + `ExclusionReason` so the report can still display them.
+`Finding.ID` is the deterministic per-instance key (`RULE:ns:name`); `RuleID` is shared across instances of the same rule. Exclusions are evaluated *after* analysis: `exclusions.Apply` drops matched findings from the output slice (the matcher sets `Excluded=true` + `ExclusionReason` on the in-memory copy first, but the field isn't surfaced to the report writer because the finding is gone). The `standard` preset is auto-applied; pass `--exclusions-preset=none` to opt out. See [`docs/exclusions.md`](docs/exclusions.md) for the YAML schema.
 
 ### Report-layer educational content (`internal/report/glossary.go`)
 
@@ -128,4 +128,4 @@ When you add a rule that targets a new resource/subject Kind, or a new privesc A
 
 ## Module/dependency notes
 
-Module path is `github.com/0hardik1/kubesplaining` and `go.mod` requires Go 1.26. Core deps: `spf13/cobra` for the CLI, `k8s.io/{api,apimachinery,client-go}` v0.35.x for cluster types and access. There is no separate `go-yaml` direct dep — `gopkg.in/yaml.v3` is used for the exclusions file loader.
+Module path is `github.com/0hardik1/kubesplaining` and `go.mod` requires Go 1.26. Core deps: `spf13/cobra` for the CLI, `k8s.io/{api,apimachinery,client-go}` v0.36.x for cluster types and access. There is no separate `go-yaml` direct dep — `gopkg.in/yaml.v3` is used for the exclusions file loader.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ Examples:
 
 ## Adding a rule
 
-Every analyzer emits `models.Finding` with a stable `RuleID` of the form `KUBE-<MODULE>-<NUMBER>` (e.g. `KUBE-PRIVESC-001`, `KUBE-ESCAPE-005`). RuleIDs are a public surface — they are referenced from [`docs/findings.md`](docs/findings.md), the e2e assertions in `scripts/kind-e2e.sh`, and likely downstream consumers — so don't rename them once shipped.
+Every analyzer emits `models.Finding` with a stable `RuleID` of the form `KUBE-<AREA>-<SUFFIX>`. The suffix is usually a zero-padded number (`KUBE-PRIVESC-001`, `KUBE-ESCAPE-005`); for privesc graph paths it's a descriptive sink name (`KUBE-PRIVESC-PATH-CLUSTER-ADMIN`). Multi-segment areas are common when a module covers several axes — e.g. `KUBE-PODSEC-APE-001`, `KUBE-NETPOL-COVERAGE-001`, `KUBE-SA-DEFAULT-001`. RuleIDs are a public surface — they are referenced from [`docs/findings.md`](docs/findings.md), the e2e assertions in `scripts/kind-e2e.sh`, and likely downstream consumers — so don't rename them once shipped.
 
 When adding a rule:
 
-1. Pick the next free number under the appropriate prefix (`KUBE-PRIVESC-`, `KUBE-ESCAPE-`, `KUBE-PODSEC-`, `KUBE-NETPOL-`, `KUBE-ADMISSION-`, `KUBE-SECRETS-`, `KUBE-CONFIGMAP-`, `KUBE-SA-*-`, `KUBE-RBAC-OVERBROAD-`, `KUBE-PRIVESC-PATH-`).
+1. Pick the next free number under the matching prefix. Existing prefixes today: `KUBE-PRIVESC-`, `KUBE-PRIVESC-PATH-`, `KUBE-ESCAPE-`, `KUBE-CONTAINERD-SOCKET-`, `KUBE-HOSTPATH-`, `KUBE-PODSEC-APE-`, `KUBE-PODSEC-ROOT-`, `KUBE-IMAGE-LATEST-`, `KUBE-NETPOL-COVERAGE-`, `KUBE-NETPOL-WEAKNESS-`, `KUBE-ADMISSION-`, `KUBE-SECRETS-`, `KUBE-CONFIGMAP-`, `KUBE-SA-DEFAULT-`, `KUBE-SA-PRIVILEGED-`, `KUBE-SA-DAEMONSET-`, `KUBE-RBAC-OVERBROAD-`. See [`docs/findings.md`](docs/findings.md) for the authoritative list.
 2. Implement the detection in the matching `internal/analyzer/<module>/analyzer.go`.
 3. Add a table-driven test in the same package (`*_test.go`).
 4. If the rule should produce findings against the e2e fixture, update `testdata/e2e/vulnerable.yaml` and the `rg -q` assertions in `scripts/kind-e2e.sh`.
@@ -63,6 +63,6 @@ The four-stage pipeline (`connection → collection → analysis → report`) an
 
 ## Where to file issues
 
-- Bugs / feature requests: [GitHub Issues](https://github.com/0hardik1/Kubesplaining/issues) — pick the matching template.
-- Open-ended questions / show-and-tell: [GitHub Discussions](https://github.com/0hardik1/Kubesplaining/discussions).
+- Bugs / feature requests: [GitHub Issues](https://github.com/0hardik1/kubesplaining/issues) — pick the matching template.
+- Open-ended questions / show-and-tell: [GitHub Discussions](https://github.com/0hardik1/kubesplaining/discussions).
 - Security: see [SECURITY.md](SECURITY.md) (GitHub Private Vulnerability Reporting only).

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Layer custom rules on top with `--exclusions-file path.yml`. The user file is **
 kubesplaining create-exclusions-file --preset standard --output-file exclusions.yml
 ```
 
-See [internal/exclusions/](internal/exclusions/) for the YAML schema (Global / RBAC / PodSecurity / NetworkPolicy sections, all matchers support shell-style globs).
+See [docs/exclusions.md](docs/exclusions.md) for the full YAML schema (Global / RBAC / PodSecurity / NetworkPolicy sections, all matchers support shell-style globs).
 
 To audit what the defaults are hiding, re-run with `--exclusions-preset=none` and diff.
 
@@ -344,6 +344,7 @@ The `standard` preset suppresses control-plane noise (kube-system, system:*, kub
 
 - **Full rule catalog** (implemented + planned): [docs/findings.md](docs/findings.md)
 - **Architecture deep-dive** (per-stage walkthrough, scoring, data model): [docs/architecture.md](docs/architecture.md)
+- **Exclusions YAML schema** (presets, sections, glob semantics): [docs/exclusions.md](docs/exclusions.md)
 - **Roadmap & status**: [PLAN.md](PLAN.md)
 - **Releases & changelog**: [CHANGELOG.md](CHANGELOG.md) / [GitHub Releases](https://github.com/0hardik1/kubesplaining/releases)
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Security fixes are backported to the latest minor release line on `main`.
 
 ## Reporting a vulnerability
 
-**Please use [GitHub Private Vulnerability Reporting](https://github.com/0hardik1/Kubesplaining/security/advisories/new) — it is the only supported channel.**
+**Please use [GitHub Private Vulnerability Reporting](https://github.com/0hardik1/kubesplaining/security/advisories/new) — it is the only supported channel.**
 
 Open the link above, or in the repo navigate to the **Security** tab → **Advisories** → **Report a vulnerability**. The report stays private to the maintainers, sits inside GitHub's audit log, and lets us coordinate a CVE before public disclosure if one is warranted.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,4 +105,6 @@ No admission webhooks, CRDs, or agent pods are installed. The tool is safe to po
 
 ## Exclusions ([internal/exclusions/](../internal/exclusions/))
 
-Exclusions are applied **after** analysis — they annotate `Finding.Excluded = true` rather than dropping the finding. The report writer hides excluded findings from the summary tally but keeps them available in the raw JSON output, so audit trails are preserved. The YAML schema (Global / RBAC / PodSecurity / NetworkPolicy sections, all matchers support shell-style globs) is documented inline in `internal/exclusions/loader.go`.
+Exclusions are applied **after** analysis. `exclusions.Apply` walks each finding through the matcher; on a hit, the finding is dropped from the slice the report writer sees. The `standard` preset is auto-applied even without `--exclusions-file` so control-plane noise (kube-system, `system:*`, `kubeadm:*`) doesn't bury actionable findings; pass `--exclusions-preset=none` to opt out. User-supplied YAML loaded with `--exclusions-file` is merged on top of the preset rather than replacing it.
+
+The full schema — `global` / `rbac` / `pod_security` / `network_policy` sections, glob semantics, evaluation order — is in [docs/exclusions.md](exclusions.md).

--- a/docs/exclusions.md
+++ b/docs/exclusions.md
@@ -1,0 +1,184 @@
+# Exclusions YAML Schema
+
+Exclusions mute findings before they surface in reports. The CLI builds the active exclusion config from two sources: a built-in **preset** chosen with `--exclusions-preset` (default `standard`), and an optional **user file** passed with `--exclusions-file`. The user file is *merged on top* of the preset — your rules layer onto the defaults, they do not replace them.
+
+This doc is the schema reference. For the operator-level overview (when to use which preset, how to audit defaults), see the [README's Exclusions section](../README.md#exclusions).
+
+## Top-level shape
+
+```yaml
+global:           # cross-module rules — apply to every analyzer's findings
+  ...
+rbac:             # only checked against findings tagged module:rbac
+  ...
+pod_security:     # only checked against findings tagged module:pod_security
+  ...
+network_policy:   # only checked against findings tagged module:network_policy
+  ...
+```
+
+All four sections are optional, and within each section every field is optional. Set only what you need; missing fields silently match nothing.
+
+Module-scoped sections (`rbac`, `pod_security`, `network_policy`) only run against findings emitted by their own analyzer, identified by a `module:<name>` tag on the finding. Putting a `pod_security:` rule will not accidentally suppress an RBAC finding, and vice versa.
+
+## Pattern matching
+
+String fields described as "glob" use Go's [`path.Match`](https://pkg.go.dev/path#Match) semantics:
+
+| Pattern | Meaning |
+| --- | --- |
+| `*` | Matches any run of characters except `/`. |
+| `?` | Matches exactly one character. |
+| `[abc]` / `[a-z]` | Matches one character from the set / range. |
+
+Patterns also fall back to exact-string equality, so a literal value like `cluster-admin` matches only `cluster-admin`. Empty patterns never match anything.
+
+A few worked examples:
+
+- `kube-*` matches `kube-system`, `kube-public`, `kube-node-lease`.
+- `system:*` matches `system:masters`, `system:authenticated`.
+- `prod-?` matches `prod-1` but not `prod-12`.
+
+Fields described as "exact" (notably `kind` on subject/workload exclusions and `check` on check exclusions) compare with `==`.
+
+## `global` — cross-module exclusions
+
+| Key | Type | Matches |
+| --- | --- | --- |
+| `exclude_namespaces` | `[]string` (glob) | The finding's namespace, or the namespace of its Subject or Resource. |
+| `exclude_service_accounts` | `[]string` (glob) | When the Subject is a `ServiceAccount`: the bare name, `ns:name`, or `ns/name`. |
+| `exclude_cluster_roles` | `[]string` (glob) | When the Resource is an `RBACRule`: the role name. |
+| `exclude_finding_ids` | `[]string` (glob) | Both the shared `RuleID` (e.g. `KUBE-PRIVESC-001`) and the per-instance `ID` (`RULE:ns:name`). |
+| `exclude_subjects` | `[]SubjectExclusion` | Any finding whose Subject matches every set field on the entry. |
+
+`SubjectExclusion` has these fields:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `kind` | `string` (exact) | `User`, `Group`, or `ServiceAccount`. Empty = match any kind. |
+| `name` | `string` (glob) | Empty = match any name. |
+| `namespace` | `string` (glob) | Empty = match any namespace. |
+| `reason` | `string` | Surfaced as the exclusion reason in logs/audit output. |
+
+## `rbac` — RBAC-module exclusions
+
+Only checked against findings tagged `module:rbac` (everything emitted by the RBAC analyzer).
+
+| Key | Type | Matches |
+| --- | --- | --- |
+| `exclude_subjects` | `[]SubjectExclusion` | Same shape as `global.exclude_subjects`. |
+
+The module-scoped form is useful when you want to silence an SA in RBAC findings only, while still seeing it flagged by, say, the privesc graph.
+
+## `pod_security` — Pod Security module exclusions
+
+Only checked against findings tagged `module:pod_security`.
+
+| Key | Type | Matches |
+| --- | --- | --- |
+| `exclude_workloads` | `[]WorkloadExclusion` | A specific workload by Kind + name + namespace. |
+| `exclude_checks` | `[]CheckExclusion` | A specific control (e.g. `hostNetwork`, or a `KUBE-PODSEC-*` rule ID), optionally scoped to a namespace. |
+
+`WorkloadExclusion`:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `kind` | `string` (exact) | `Pod`, `Deployment`, `DaemonSet`, `StatefulSet`, `Job`, `CronJob`. Empty = any kind. |
+| `name` | `string` (glob) | Empty = match any name. |
+| `name_pattern` | `string` (glob) | Equivalent to `name` (both go through the glob matcher). Either field works; `name_pattern` reads more naturally when you're using wildcards. |
+| `namespace` | `string` (glob) | Empty = match any namespace. |
+| `reason` | `string` | Surfaced as the exclusion reason. |
+
+`CheckExclusion`:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `check` | `string` (exact) | Either the full `RuleID` (e.g. `KUBE-PODSEC-APE-001`) or the value following `check:` in the finding's tag list (e.g. `hostNetwork` matches the `check:hostNetwork` tag). |
+| `namespace` | `string` (glob) | Limits the exclusion to findings in the matching namespace. Empty = any namespace. |
+| `reason` | `string` | Surfaced as the exclusion reason. |
+
+## `network_policy` — Network module exclusions
+
+Only checked against findings tagged `module:network_policy`.
+
+| Key | Type | Matches |
+| --- | --- | --- |
+| `exclude_namespaces` | `[]string` (glob) | The finding's namespace, or the namespace of its Subject or Resource. |
+
+## Order of evaluation
+
+A finding is checked against sections in this order: `global` → `rbac` → `pod_security` → `network_policy`. The first matching entry wins, the finding is dropped from the output, and the matching reason is recorded — either the entry's `reason` field, or a generic label such as `matched global.exclude_namespaces` when no reason is set.
+
+## Presets and merging
+
+`--exclusions-preset` selects the built-in baseline:
+
+| Preset | What it suppresses |
+| --- | --- |
+| `standard` (default) | Namespaces `kube-system` / `kube-public` / `kube-node-lease` / `gatekeeper-system`; service accounts `system:*` and `kube-system:*`; cluster roles and subjects matching `system:*` / `kubeadm:*`; a `hostNetwork` check exclusion in `kube-system`. |
+| `minimal` | Just `kube-public` / `kube-node-lease` namespaces, `system:*` service accounts, `system:*` cluster roles. |
+| `none` (alias `strict`) | Empty config — every finding surfaces, including control-plane noise. |
+
+When `--exclusions-file` is also passed, the user file is merged on top: string slices are concatenated and deduped (preserving preset entries), struct slices are concatenated as-is. The merged config is what the analyzer sees — there is no per-rule precedence between preset and user file beyond ordering.
+
+To start a user file from a preset, use `create-exclusions-file`:
+
+```bash
+kubesplaining create-exclusions-file --preset standard --output-file exclusions.yml
+
+# Pre-populate any kube-* / *-system namespaces discovered in a snapshot:
+kubesplaining create-exclusions-file --preset standard \
+  --from-snapshot snapshot.json --output-file exclusions.yml
+```
+
+## Complete example
+
+```yaml
+global:
+  exclude_namespaces:
+    - kube-system
+    - kube-public
+    - prometheus
+  exclude_service_accounts:
+    - system:*
+    - argocd:argocd-application-controller
+  exclude_cluster_roles:
+    - system:*
+    - kubeadm:*
+  exclude_finding_ids:
+    - KUBE-PRIVESC-005    # secret reads accepted in this cluster, see ticket-1234
+  exclude_subjects:
+    - kind: Group
+      name: system:*
+      reason: Built-in Kubernetes group
+
+rbac:
+  exclude_subjects:
+    - kind: ServiceAccount
+      name: cert-manager
+      namespace: cert-manager
+      reason: Vendor SA, reviewed Q1 2026
+
+pod_security:
+  exclude_workloads:
+    - kind: DaemonSet
+      name_pattern: node-exporter-*
+      namespace: monitoring
+      reason: Prometheus node exporter, hostPath required
+  exclude_checks:
+    - check: hostNetwork
+      namespace: kube-system
+      reason: System networking components require host networking
+
+network_policy:
+  exclude_namespaces:
+    - kube-system
+    - kube-public
+    - kube-node-lease
+```
+
+## Where to look in the code
+
+- [`internal/exclusions/config.go`](../internal/exclusions/config.go) — struct definitions and the built-in presets.
+- [`internal/exclusions/matcher.go`](../internal/exclusions/matcher.go) — match rules, glob semantics, evaluation order.
+- [`internal/cli/exclusions_helper.go`](../internal/cli/exclusions_helper.go) — how `--exclusions-preset` and `--exclusions-file` are combined.


### PR DESCRIPTION
## Summary
- Adds `docs/exclusions.md` — the YAML schema reference that the README and `docs/architecture.md` previously linked at a directory of Go files. Covers sections (global / rbac / pod_security / network_policy), glob semantics (`path.Match`), evaluation order, preset + user-file merge behavior, and a complete example.
- Refreshes a sweep of stale claims across README, `docs/architecture.md`, CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md, and SECURITY.md so contributor- and user-facing docs match the current code.
- Normalizes all GitHub URLs from capital-K `Kubesplaining` to canonical lowercase `kubesplaining`.

## Notable factual fixes (not just link updates)

- **Exclusions behavior**: `docs/architecture.md` and CLAUDE.md both claimed exclusions annotate `Excluded=true` rather than dropping findings. `exclusions.Apply` actually drops matched findings from the output slice (the matcher sets `Excluded` on the in-memory copy first, but the finding never reaches the report writer).
- **Privesc sinks**: docs listed 4 sinks; there are 5 (`cluster_admin`, `kube_system_secrets`, `node_escape`, `system_masters`, `token_mint`). Verified via `git show v1.0.0:internal/analyzer/privesc/graph.go` — `token_mint` shipped in v1.0.0, so the v1.0.0 CHANGELOG entry was wrong at release.
- **ConfigMap privacy**: CHANGELOG and CLAUDE.md said ConfigMap `Data` is preserved (keys + values). The collector calls `redactConfigMapValues` which keeps keys but blanks values to `""`. Privacy-relevant — corrected.
- **`--include-secret-values` flag**: documented in v1.0.0 CHANGELOG but never existed in the codebase. Removed the reference.
- **`RuleID` format**: docs claimed `KUBE-<MODULE>-<NUMBER>`, but real IDs include multi-segment areas (`KUBE-PODSEC-APE-001`, `KUBE-NETPOL-COVERAGE-001`, `KUBE-SA-DEFAULT-001`) and descriptive privesc-path suffixes (`KUBE-PRIVESC-PATH-CLUSTER-ADMIN`). Updated CLAUDE.md and CONTRIBUTING.md accordingly.
- **`internal/report` size claim**: CLAUDE.md said `report.go` is large because HTML/CSS/JS is embedded; `report.go` is now 86 lines, with rendering split across `summary.go` (584), `evidence_render.go` (848), `attack_graph.go` (571), and `glossary.go` (425). Updated.
- **k8s deps**: CLAUDE.md said `v0.35.x`, `go.mod` is on `v0.36.x`. Updated.

## Test plan
- [x] All internal links in CLAUDE.md, README.md, `docs/*.md`, CHANGELOG.md, CONTRIBUTING.md, SECURITY.md resolve to existing files.
- [x] No remaining capital-K `Kubesplaining` in any GitHub or GitHub Pages URL.
- [x] Markdown only — no Go code touched, so `make test` / `make lint` are unaffected.
- [x] Render `docs/exclusions.md` on GitHub to confirm tables and code blocks display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)