### PR TITLE
feat: prettier scan output with HTML report banner and styled e2e script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ kubesplaining scan                          # writes ./kubesplaining-report/
 open kubesplaining-report/report.html       # macOS; xdg-open on Linux
 ```
 
+Already cloned the repo? `make scan` builds the binary (Hermit auto-downloads the pinned Go toolchain) and runs it against your current `kubectl` context in one step — no separate install needed. Pass extra flags via `ARGS`, e.g. `make scan ARGS="--severity-threshold high --only-modules privesc"`.
+
 For air-gapped or audit workflows, capture a snapshot first and analyze it offline:
 
 ```bash

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/report"
+)
+
+// isTTY reports whether w is a terminal-attached *os.File so ANSI styling is safe.
+// Anything else (pipes, files, captured stdout under `make e2e`'s `tee`) gets plain text.
+func isTTY(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return stat.Mode()&os.ModeCharDevice != 0
+}
+
+type styler struct{ on bool }
+
+func (s styler) wrap(code, text string) string {
+	if !s.on {
+		return text
+	}
+	return "\x1b[" + code + "m" + text + "\x1b[0m"
+}
+
+func (s styler) green(t string) string  { return s.wrap("32", t) }
+func (s styler) blue(t string) string   { return s.wrap("34", t) }
+func (s styler) bold(t string) string   { return s.wrap("1", t) }
+func (s styler) dim(t string) string    { return s.wrap("2", t) }
+func (s styler) bgreen(t string) string { return s.wrap("1;32", t) }
+
+// printScanResults emits the per-file lines, the machine-readable summary, and
+// (TTY only) a banner pointing at the HTML report. When stdout is piped or
+// redirected, the original `wrote %s` / `findings: total=...` format is preserved
+// so CI parsers and the e2e script keep working.
+func printScanResults(w io.Writer, written []string, summary report.Summary) error {
+	s := styler{on: isTTY(w)}
+
+	for _, path := range written {
+		var line string
+		if s.on {
+			line = fmt.Sprintf("  %s %s\n", s.green("✓"), path)
+		} else {
+			line = fmt.Sprintf("wrote %s\n", path)
+		}
+		if _, err := fmt.Fprint(w, line); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "findings: total=%d critical=%d high=%d medium=%d low=%d info=%d\n",
+		summary.Total, summary.Critical, summary.High, summary.Medium, summary.Low, summary.Info); err != nil {
+		return err
+	}
+	if !s.on {
+		return nil
+	}
+
+	rule := strings.Repeat("═", 71)
+	counts := fmt.Sprintf("%d findings · %d critical · %d high · %d medium · %d low · %d info",
+		summary.Total, summary.Critical, summary.High, summary.Medium, summary.Low, summary.Info)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n%s\n", s.bgreen(rule))
+	fmt.Fprintf(&b, "  %s\n", s.bgreen("✓ Scan complete"))
+	fmt.Fprintf(&b, "  %s\n", s.dim(counts))
+	fmt.Fprintf(&b, "%s\n", s.bgreen(rule))
+
+	htmlPath := ""
+	for _, p := range written {
+		if strings.HasSuffix(p, "report.html") {
+			htmlPath = p
+			break
+		}
+	}
+	if htmlPath != "" {
+		abs, err := filepath.Abs(htmlPath)
+		if err != nil {
+			abs = htmlPath
+		}
+		fmt.Fprintf(&b, "\n  %s\n", s.bold("Open the HTML report"))
+		fmt.Fprintf(&b, "    %s\n", s.blue("file://"+abs))
+		fmt.Fprintf(&b, "    %s\n", s.dim("open "+htmlPath))
+	}
+	if _, err := fmt.Fprint(w, b.String()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -83,13 +83,7 @@ func NewReportCmd() *cobra.Command {
 			}
 
 			summary := report.BuildSummary(filtered)
-			for _, path := range written {
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", path); err != nil {
-					return err
-				}
-			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "findings: total=%d critical=%d high=%d medium=%d low=%d info=%d\n",
-				summary.Total, summary.Critical, summary.High, summary.Medium, summary.Low, summary.Info); err != nil {
+			if err := printScanResults(cmd.OutOrStdout(), written, summary); err != nil {
 				return err
 			}
 

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -77,13 +77,7 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 			}
 
 			summary := report.BuildSummary(findings)
-			for _, path := range written {
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", path); err != nil {
-					return err
-				}
-			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "findings: total=%d critical=%d high=%d medium=%d low=%d info=%d\n",
-				summary.Total, summary.Critical, summary.High, summary.Medium, summary.Low, summary.Info); err != nil {
+			if err := printScanResults(cmd.OutOrStdout(), written, summary); err != nil {
 				return err
 			}
 

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -8,6 +8,22 @@ KUBECONFIG_PATH="${KUBECONFIG:-${ROOT_DIR}/.tmp/kubeconfig}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-1}"
 USER_KUBECONFIG="${USER_KUBECONFIG:-${HOME}/.kube/config}"
 
+# ANSI colors when stdout is a terminal and NO_COLOR is not set; plain text under CI / pipes.
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+  C_RESET=$'\e[0m'
+  C_BOLD=$'\e[1m'
+  C_DIM=$'\e[2m'
+  C_GREEN=$'\e[32m'
+  C_BLUE=$'\e[34m'
+  C_CYAN=$'\e[36m'
+else
+  C_RESET=""; C_BOLD=""; C_DIM=""; C_GREEN=""; C_BLUE=""; C_CYAN=""
+fi
+
+step()      { printf "\n%s▶ %s%s\n" "${C_BOLD}${C_CYAN}" "$*" "${C_RESET}"; }
+ok()        { printf "  %s✓%s %s\n" "${C_GREEN}" "${C_RESET}" "$*"; }
+prefix_ok() { sed "s/^/  ${C_GREEN}✓${C_RESET} /"; }
+
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "missing required command: $1" >&2
@@ -38,37 +54,66 @@ cleanup() {
 
 trap cleanup EXIT
 
+step "Creating kind cluster: ${KIND_CLUSTER_NAME}"
 # Always start fresh: tear down any prior cluster of the same name, including
 # the stale entry in the user's default kubeconfig from a previous run.
 kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
 if [[ -f "${USER_KUBECONFIG}" ]]; then
   KUBECONFIG="${USER_KUBECONFIG}" kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
 fi
-kind create cluster --name "${KIND_CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PATH}" --wait 90s
+# Stream kind's progress (it already prints `✓ Ensuring node image`, `✓ Preparing
+# nodes`, etc.), indented under our section header. We strip kind's trailing
+# marketing block — we set the kubectl context ourselves further down, and the
+# "Have a question / Thanks" lines are noise in this script.
+kind create cluster --name "${KIND_CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PATH}" --wait 90s 2>&1 \
+  | sed -E -e '/^Set kubectl context/d' \
+            -e '/^You can now use/d' \
+            -e '/^kubectl cluster-info/d' \
+            -e '/^Have a question/d' \
+            -e '/^Thanks/d' \
+            -e '/^[[:space:]]*$/d' \
+            -e 's/^/    /'
+ok "cluster ready"
 
-kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f "${ROOT_DIR}/testdata/e2e/vulnerable.yaml"
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/risky-app -n vulnerable --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/host-ns-app -n vulnerable --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/socket-mounts-app -n vulnerable --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/generic-hostpath-app -n vulnerable --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/root-runner -n vulnerable --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/wildcard-app -n rbac-fixtures --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/imp-app -n rbac-fixtures --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status ds/daemon-app -n rbac-fixtures --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/unmatched -n flat-network --timeout=120s
-kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deploy/ingress-app -n ingress-only --timeout=120s
+step "Applying vulnerable manifests"
+kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f "${ROOT_DIR}/testdata/e2e/vulnerable.yaml" | prefix_ok
 
+step "Waiting for workloads to roll out"
+ROLLOUTS=(
+  "deploy/risky-app:vulnerable"
+  "deploy/host-ns-app:vulnerable"
+  "deploy/socket-mounts-app:vulnerable"
+  "deploy/generic-hostpath-app:vulnerable"
+  "deploy/root-runner:vulnerable"
+  "deploy/wildcard-app:rbac-fixtures"
+  "deploy/imp-app:rbac-fixtures"
+  "ds/daemon-app:rbac-fixtures"
+  "deploy/unmatched:flat-network"
+  "deploy/ingress-app:ingress-only"
+)
+for entry in "${ROLLOUTS[@]}"; do
+  obj="${entry%%:*}"
+  ns="${entry##*:}"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status "${obj}" -n "${ns}" --timeout=120s >/dev/null
+  ok "${obj} (${ns})"
+done
+
+step "Capturing snapshot"
 "${ROOT_DIR}/bin/kubesplaining" download \
   --kubeconfig "${KUBECONFIG_PATH}" \
-  --output-file "${ROOT_DIR}/.tmp/e2e-snapshot.json"
+  --output-file "${ROOT_DIR}/.tmp/e2e-snapshot.json" | prefix_ok
 
+step "Running kubesplaining scan"
 # Use the default "standard" exclusions preset so the e2e mirrors how users run
 # the tool: built-in kube-system / system:* / kubeadm:* noise is suppressed.
+SCAN_LOG="${ROOT_DIR}/.tmp/e2e-scan.log"
 "${ROOT_DIR}/bin/kubesplaining" scan \
   --input-file "${ROOT_DIR}/.tmp/e2e-snapshot.json" \
   --output-dir "${ROOT_DIR}/.tmp/e2e-report" \
-  --output-format html,json,csv
+  --output-format html,json,csv | tee "${SCAN_LOG}" | prefix_ok
+SUMMARY_LINE=$(grep -m1 "^findings:" "${SCAN_LOG}" 2>/dev/null || echo "")
 
+step "Verifying expected rule IDs"
 EXPECTED_RULES=(
   KUBE-PRIVESC-001 KUBE-PRIVESC-003 KUBE-PRIVESC-005 KUBE-PRIVESC-008 KUBE-PRIVESC-009
   KUBE-PRIVESC-010 KUBE-PRIVESC-012 KUBE-PRIVESC-014 KUBE-PRIVESC-017
@@ -98,15 +143,36 @@ if (( ${#missing[@]} > 0 )); then
   printf '  - %s\n' "${missing[@]}" >&2
   exit 1
 fi
-echo "all ${#EXPECTED_RULES[@]} expected rule IDs present"
+ok "all ${#EXPECTED_RULES[@]} expected rule IDs present"
 
 if [[ "${KEEP_CLUSTER}" == "1" ]]; then
+  step "Wiring kubectl context"
   mkdir -p "$(dirname "${USER_KUBECONFIG}")"
   touch "${USER_KUBECONFIG}"
   KUBECONFIG="${USER_KUBECONFIG}" kind export kubeconfig --name "${KIND_CLUSTER_NAME}" >/dev/null
-  echo "kubectl context set to kind-${KIND_CLUSTER_NAME} in ${USER_KUBECONFIG}"
-  echo "  try: kubectl get pods -A"
-  echo "  to remove: make delete"
+  ok "kubectl context: kind-${KIND_CLUSTER_NAME}"
+  ok "kubeconfig: ${USER_KUBECONFIG}"
 fi
 
-echo "kind e2e completed successfully"
+REPORT_HTML="${ROOT_DIR}/.tmp/e2e-report/report.html"
+REPORT_REL="${REPORT_HTML#"${ROOT_DIR}/"}"
+REPORT_URL="file://${REPORT_HTML}"
+RULE="═══════════════════════════════════════════════════════════════════════"
+
+printf "\n%s%s%s\n" "${C_BOLD}${C_GREEN}" "${RULE}" "${C_RESET}"
+printf "  %s✓ kubesplaining e2e complete%s\n" "${C_BOLD}${C_GREEN}" "${C_RESET}"
+if [[ -n "${SUMMARY_LINE}" ]]; then
+  printf "  %s%s%s\n" "${C_DIM}" "${SUMMARY_LINE}" "${C_RESET}"
+fi
+printf "%s%s%s\n\n" "${C_BOLD}${C_GREEN}" "${RULE}" "${C_RESET}"
+
+printf "  %sOpen the HTML report%s\n" "${C_BOLD}" "${C_RESET}"
+printf "    %s%s%s\n" "${C_BLUE}" "${REPORT_URL}" "${C_RESET}"
+printf "    %sopen %s%s\n\n" "${C_DIM}" "${REPORT_REL}" "${C_RESET}"
+
+printf "  %sPoke at the cluster%s\n" "${C_BOLD}" "${C_RESET}"
+printf "    %skubectl get pods -A%s\n" "${C_DIM}" "${C_RESET}"
+printf "    %skubectl --context kind-%s get clusterrolebindings%s\n\n" "${C_DIM}" "${KIND_CLUSTER_NAME}" "${C_RESET}"
+
+printf "  %sTear it down%s\n" "${C_BOLD}" "${C_RESET}"
+printf "    %smake delete%s\n" "${C_DIM}" "${C_RESET}"


### PR DESCRIPTION
## Summary

- `kubesplaining scan` / `kubesplaining report` now print TTY-aware styled output: a green ✓ per `wrote ...` line and a final banner with the `file://` URL of the HTML report. Piped/CI output is unchanged (`wrote %s` / `findings: total=...`), so the e2e script's `tee | grep` and any external parsers keep working.
- `scripts/kind-e2e.sh` gets `▶` section headers, ✓-prefixed status lines, and a green-bordered closing banner that surfaces the report URL plus follow-ups (`kubectl get pods -A`, `make delete`). kind's own substeps (`✓ Ensuring node image`, `✓ Preparing nodes`, …) now stream live under the cluster-create header instead of being silenced.
- README adds a one-liner pointing contributors/evaluators at `make scan` as the from-clone quickstart shortcut (Hermit auto-downloads Go, builds, runs against current kubectl context).

Implementation lives in a new `internal/cli/output.go` shared by `scan` and `report`. TTY detection is `*os.File` + `os.ModeCharDevice` (no new deps; `golang.org/x/term` was indirect-only and stays unused).

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -l` clean
- [x] `golangci-lint` clean (pre-commit hook)
- [x] Verified TTY path via `script -q /dev/null kubesplaining scan ...` — checkmarks, banner, and `file://` URL render
- [x] Verified piped path via `kubesplaining scan ... | cat` — original `wrote ...` / `findings: total=...` format preserved
- [x] Verified the kind-output sed filter against simulated kind progress lines
- [x] Run `make e2e` end-to-end on a fresh clone to confirm the live experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)