### PR TITLE
fix(privesc): no cluster-admin path for namespace-scoped grants (#48)

### DIFF
--- a/docs/findings.md
+++ b/docs/findings.md
@@ -87,6 +87,7 @@ These findings are emitted **per `(source subject, sink)` pair** found by BFS on
 | KUBE-PRIVESC-PATH-SYSTEM-MASTERS | CRITICAL (9.6) | `<subject>` can reach system:masters in N hop(s) | Impersonation chain ending in the `system:masters` group |
 | KUBE-PRIVESC-PATH-NODE-ESCAPE | CRITICAL (9.4) | `<subject>` can reach node escape in N hop(s) | Ability to create/exec a pod with privileged / hostPID / hostNetwork / hostIPC / sensitive hostPath |
 | KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS | HIGH (8.6) | `<subject>` can reach kube-system secrets in N hop(s) | Cluster-wide or kube-system `get`/`list` on secrets |
+| KUBE-PRIVESC-PATH-NAMESPACE-ADMIN | HIGH (7.6) | `<subject>` can reach namespace-admin in `<ns>` in N hop(s) | Namespace-scoped `create rolebindings` or `bind/escalate roles` (one sink per affected namespace) |
 
 Edge techniques that can appear in a hop chain: `KUBE-PRIVESC-001` (pod create), `-005` (secrets read), `-008` (impersonate), `-009` (bind/escalate), `-010` (rolebinding modify), `-012` (nodes/proxy), `-014` (serviceaccounts/token), `-017` (wildcard), plus `KUBE-ESCAPE-00{1,2,3,4,5,6,8}` / `KUBE-HOSTPATH-001` for the pod-escape terminal edge. `system:*` subjects are skipped as traversable intermediates so paths do not launder through the control plane.
 

--- a/internal/analyzer/privesc/analyzer.go
+++ b/internal/analyzer/privesc/analyzer.go
@@ -61,24 +61,31 @@ func findingFromPath(path models.EscalationPath) models.Finding {
 		category = models.CategoryDataExfiltration
 	}
 
-	content := contentForTarget(path.Source, target, path.Hops)
+	content := contentForTarget(path.Source, target, path.TargetNamespace, path.Hops)
 
 	evidence, _ := json.Marshal(map[string]any{
-		"target":        string(target),
-		"hop_count":     len(path.Hops),
-		"techniques":    uniqueTechniques(path.Hops),
-		"first_action":  firstAction(path.Hops),
-		"chain_summary": chainSummary(path.Hops),
+		"target":           string(target),
+		"target_namespace": path.TargetNamespace,
+		"hop_count":        len(path.Hops),
+		"techniques":       uniqueTechniques(path.Hops),
+		"first_action":     firstAction(path.Hops),
+		"chain_summary":    chainSummary(path.Hops),
 	})
 
 	id := fmt.Sprintf("%s:%s:%s", ruleID, path.Source.Key(), target)
+	if path.TargetNamespace != "" {
+		// Namespace-admin paths to different namespaces from the same source must be distinct
+		// findings, so keep the namespace in the deterministic finding ID.
+		id = fmt.Sprintf("%s:%s", id, path.TargetNamespace)
+	}
 	references := make([]string, 0, len(content.LearnMore))
 	for _, ref := range content.LearnMore {
 		references = append(references, ref.URL)
 	}
 
 	subject := path.Source
-	return models.Finding{
+	tags := []string{"module:privesc", "target:" + string(target)}
+	finding := models.Finding{
 		ID:               id,
 		RuleID:           ruleID,
 		Severity:         severity,
@@ -97,15 +104,25 @@ func findingFromPath(path models.EscalationPath) models.Finding {
 		LearnMore:        content.LearnMore,
 		MitreTechniques:  content.MitreTechniques,
 		EscalationPath:   path.Hops,
-		Tags:             []string{"module:privesc", "target:" + string(target)},
+		Tags:             tags,
 	}
+	if target == models.TargetNamespaceAdmin && path.TargetNamespace != "" {
+		// Anchor the finding to the namespace it compromises so the report's resource column,
+		// the dedupe key (RuleID + SubjectKey + ResourceKey), and SARIF physical-location all
+		// surface which namespace is at risk.
+		finding.Resource = &models.ResourceRef{Kind: "Namespace", Name: path.TargetNamespace, Namespace: path.TargetNamespace}
+		finding.Namespace = path.TargetNamespace
+	}
+	return finding
 }
 
 // contentForTarget dispatches to the matching content builder based on the path's terminal sink.
-func contentForTarget(source models.SubjectRef, target models.EscalationTarget, hops []models.EscalationHop) ruleContent {
+func contentForTarget(source models.SubjectRef, target models.EscalationTarget, targetNamespace string, hops []models.EscalationHop) ruleContent {
 	switch target {
 	case models.TargetClusterAdmin:
 		return contentClusterAdminPath(source, hops)
+	case models.TargetNamespaceAdmin:
+		return contentNamespaceAdminPath(source, targetNamespace, hops)
 	case models.TargetNodeEscape:
 		return contentNodeEscapePath(source, hops)
 	case models.TargetKubeSystemSecrets:
@@ -131,6 +148,10 @@ func targetScoring(target models.EscalationTarget, hops int) (models.Severity, f
 		base, severity, ruleID = 8.6, models.SeverityHigh, "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS"
 	case models.TargetSystemMasters:
 		base, severity, ruleID = 9.6, models.SeverityCritical, "KUBE-PRIVESC-PATH-SYSTEM-MASTERS"
+	case models.TargetNamespaceAdmin:
+		// Namespace-admin is a real privesc but bounded to a single namespace, so it scores
+		// below cluster-admin but above the generic fallback.
+		base, severity, ruleID = 7.6, models.SeverityHigh, "KUBE-PRIVESC-PATH-NAMESPACE-ADMIN"
 	default:
 		base, severity, ruleID = 7.0, models.SeverityHigh, "KUBE-PRIVESC-PATH-GENERIC"
 	}
@@ -173,6 +194,8 @@ func targetLabel(target models.EscalationTarget) string {
 		return "kube-system secrets"
 	case models.TargetSystemMasters:
 		return "system:masters"
+	case models.TargetNamespaceAdmin:
+		return "namespace-admin"
 	default:
 		return string(target)
 	}

--- a/internal/analyzer/privesc/analyzer_test.go
+++ b/internal/analyzer/privesc/analyzer_test.go
@@ -2,6 +2,7 @@ package privesc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
@@ -126,6 +127,263 @@ func TestAnalyzerFindsPodEscapeChain(t *testing.T) {
 	}
 	if !sawNodeEscape {
 		t.Fatalf("expected multi-hop node-escape path from deployer SA, findings=%v", findings)
+	}
+}
+
+func TestNamespaceScopedRBACDoesNotEmitClusterAdmin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		roleRule     rbacv1.PolicyRule
+		bannedRuleID string
+	}{
+		{
+			name: "modify_role_binding via RoleBinding",
+			roleRule: rbacv1.PolicyRule{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"rolebindings"},
+				Verbs:     []string{"create", "update", "patch"},
+			},
+			bannedRuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+		},
+		{
+			name: "bind_or_escalate via RoleBinding",
+			roleRule: rbacv1.PolicyRule{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"roles"},
+				Verbs:     []string{"bind", "escalate"},
+			},
+			bannedRuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+		},
+		{
+			name: "impersonate users via RoleBinding (dead RBAC, no path)",
+			roleRule: rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"users"},
+				Verbs:     []string{"impersonate"},
+			},
+			bannedRuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+		},
+		{
+			name: "impersonate groups via RoleBinding (dead RBAC, no system:masters path)",
+			roleRule: rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"groups"},
+				Verbs:     []string{"impersonate"},
+			},
+			bannedRuleID: "KUBE-PRIVESC-PATH-SYSTEM-MASTERS",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			snapshot := models.Snapshot{
+				Resources: models.SnapshotResources{
+					Namespaces: []corev1.Namespace{
+						{ObjectMeta: objectMeta("dev", "")},
+					},
+					ServiceAccounts: []corev1.ServiceAccount{
+						{ObjectMeta: objectMeta("dev-sa", "dev")},
+					},
+					Roles: []rbacv1.Role{
+						{
+							ObjectMeta: objectMeta("ns-rule", "dev"),
+							Rules:      []rbacv1.PolicyRule{tc.roleRule},
+						},
+					},
+					RoleBindings: []rbacv1.RoleBinding{
+						{
+							ObjectMeta: objectMeta("ns-rule-binding", "dev"),
+							RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "ns-rule"},
+							Subjects: []rbacv1.Subject{
+								{Kind: "ServiceAccount", Name: "dev-sa", Namespace: "dev"},
+							},
+						},
+					},
+				},
+			}
+
+			findings, err := New().Analyze(context.Background(), snapshot)
+			if err != nil {
+				t.Fatalf("Analyze() error = %v", err)
+			}
+
+			for _, f := range findings {
+				if f.Subject == nil || f.Subject.Name != "dev-sa" || f.Subject.Namespace != "dev" {
+					continue
+				}
+				if f.RuleID == tc.bannedRuleID {
+					t.Fatalf("namespace-scoped grant produced unexpected %s finding for dev/dev-sa: %+v", tc.bannedRuleID, f)
+				}
+			}
+		})
+	}
+}
+
+func TestNamespaceScopedRBACEmitsNamespaceAdminPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		roleRule rbacv1.PolicyRule
+	}{
+		{
+			name: "modify_role_binding via RoleBinding emits namespace-admin",
+			roleRule: rbacv1.PolicyRule{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"rolebindings"},
+				Verbs:     []string{"create", "update", "patch"},
+			},
+		},
+		{
+			name: "bind_or_escalate via RoleBinding emits namespace-admin",
+			roleRule: rbacv1.PolicyRule{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"roles"},
+				Verbs:     []string{"bind", "escalate"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			snapshot := models.Snapshot{
+				Resources: models.SnapshotResources{
+					Namespaces: []corev1.Namespace{
+						{ObjectMeta: objectMeta("dev", "")},
+					},
+					ServiceAccounts: []corev1.ServiceAccount{
+						{ObjectMeta: objectMeta("dev-sa", "dev")},
+					},
+					Roles: []rbacv1.Role{
+						{
+							ObjectMeta: objectMeta("ns-rule", "dev"),
+							Rules:      []rbacv1.PolicyRule{tc.roleRule},
+						},
+					},
+					RoleBindings: []rbacv1.RoleBinding{
+						{
+							ObjectMeta: objectMeta("ns-rule-binding", "dev"),
+							RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "ns-rule"},
+							Subjects: []rbacv1.Subject{
+								{Kind: "ServiceAccount", Name: "dev-sa", Namespace: "dev"},
+							},
+						},
+					},
+				},
+			}
+
+			findings, err := New().Analyze(context.Background(), snapshot)
+			if err != nil {
+				t.Fatalf("Analyze() error = %v", err)
+			}
+
+			var match *models.Finding
+			for i, f := range findings {
+				if f.Subject == nil || f.Subject.Name != "dev-sa" {
+					continue
+				}
+				if f.RuleID == "KUBE-PRIVESC-PATH-NAMESPACE-ADMIN" {
+					match = &findings[i]
+					break
+				}
+			}
+			if match == nil {
+				t.Fatalf("expected KUBE-PRIVESC-PATH-NAMESPACE-ADMIN finding for dev/dev-sa, got findings=%+v", findings)
+			}
+			if match.Resource == nil || match.Resource.Kind != "Namespace" || match.Resource.Name != "dev" {
+				t.Fatalf("expected namespace-admin finding to be anchored to Namespace/dev, got resource=%+v", match.Resource)
+			}
+			if match.Namespace != "dev" {
+				t.Fatalf("expected finding.Namespace = dev, got %q", match.Namespace)
+			}
+			if match.Severity != models.SeverityHigh {
+				t.Fatalf("expected severity HIGH for namespace-admin, got %q", match.Severity)
+			}
+		})
+	}
+}
+
+func TestNamespaceScopedImpersonateServiceAccountsEmitsPerSATarget(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: objectMeta("team-a", "")},
+				{ObjectMeta: objectMeta("team-b", "")},
+			},
+			ServiceAccounts: []corev1.ServiceAccount{
+				{ObjectMeta: objectMeta("impersonator", "team-a")},
+				{ObjectMeta: objectMeta("victim", "team-a")},
+				{ObjectMeta: objectMeta("out-of-scope", "team-b")},
+			},
+			Roles: []rbacv1.Role{
+				{
+					ObjectMeta: objectMeta("impersonate-sa", "team-a"),
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"serviceaccounts"}, Verbs: []string{"impersonate"}},
+					},
+				},
+			},
+			RoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: objectMeta("impersonate-sa-binding", "team-a"),
+					RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "impersonate-sa"},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "impersonator", Namespace: "team-a"},
+					},
+				},
+			},
+		},
+	}
+
+	graph := BuildGraph(snapshot)
+
+	const fromImpersonator = "subject:ServiceAccount/team-a/impersonator"
+	var sawTeamAEdge bool
+	for _, edge := range graph.Edges {
+		if edge.From != fromImpersonator {
+			continue
+		}
+		if edge.To == sinkClusterAdmin || edge.To == sinkSystemMasters {
+			t.Fatalf("namespace-scoped impersonate serviceaccounts must not reach a cluster-wide sink: %+v", *edge)
+		}
+		if edge.Action != "impersonate_serviceaccount" {
+			continue
+		}
+		switch edge.To {
+		case "subject:ServiceAccount/team-a/victim", "subject:ServiceAccount/team-a/default":
+			sawTeamAEdge = true
+		case "subject:ServiceAccount/team-b/out-of-scope", "subject:ServiceAccount/team-b/default":
+			t.Fatalf("namespace-scoped impersonate edge leaked into team-b: %+v", *edge)
+		case fromImpersonator:
+			t.Fatalf("self-edge emitted: %+v", *edge)
+		}
+	}
+	if !sawTeamAEdge {
+		var dump []string
+		for _, edge := range graph.Edges {
+			dump = append(dump, fmt.Sprintf("%+v", *edge))
+		}
+		t.Fatalf("expected at least one impersonate_serviceaccount edge to a team-a SA, got edges=%v", dump)
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	for _, f := range findings {
+		if f.Subject != nil && f.Subject.Name == "impersonator" && f.RuleID == "KUBE-PRIVESC-PATH-CLUSTER-ADMIN" {
+			t.Fatalf("namespace-scoped impersonate serviceaccounts produced cluster-admin finding: %+v", f)
+		}
 	}
 }
 

--- a/internal/analyzer/privesc/content.go
+++ b/internal/analyzer/privesc/content.go
@@ -68,6 +68,15 @@ func scopeForPath(source models.SubjectRef, target models.EscalationTarget) mode
 	}
 }
 
+// scopeForNamespaceAdmin returns the namespace-scoped Scope for a namespace-admin path,
+// naming both the source subject and the namespace it can take over.
+func scopeForNamespaceAdmin(source models.SubjectRef, namespace string) models.Scope {
+	return models.Scope{
+		Level:  models.ScopeNamespace,
+		Detail: fmt.Sprintf("Source `%s` → namespace-admin in `%s`: every workload, Secret, and ConfigMap inside `%s` becomes attacker-controlled", source.Key(), namespace, namespace),
+	}
+}
+
 // hopNarrative renders one hop into a natural-prose sentence describing what the
 // attacker does at that step. The output goes into Finding.AttackScenario, which
 // the report template wraps in an <ol> — so we deliberately omit any "Step N:"
@@ -335,6 +344,42 @@ func contentSystemMastersPath(source models.SubjectRef, hops []models.Escalation
 			refNSAHardening,
 		},
 		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1098, mitreT1556, mitreT1068},
+	}
+}
+
+func contentNamespaceAdminPath(source models.SubjectRef, namespace string, hops []models.EscalationHop) ruleContent {
+	hopCount := len(hops)
+	steps := make([]string, 0, hopCount+2)
+	steps = append(steps, fmt.Sprintf("Attacker compromises any workload or credential bound to `%s` (RCE, leaked token, malicious image).", source.Key()))
+	for _, hop := range hops {
+		steps = append(steps, hopNarrative(hop))
+	}
+	steps = append(steps, fmt.Sprintf("Final step: the attacker holds an identity that can `verbs:[*]` on `resources:[*]` inside `%s`. They read every Secret and ConfigMap in `%s`, exec into every pod, mount every PersistentVolume, and plant a backdoor RoleBinding (or a privileged DaemonSet on a namespace-scoped tenant operator) for persistence.", namespace, namespace))
+	return ruleContent{
+		Title: fmt.Sprintf("`%s` can reach **namespace-admin in `%s`** in %d hop(s)", source.Key(), namespace, hopCount),
+		Scope: scopeForNamespaceAdmin(source, namespace),
+		Description: fmt.Sprintf("Subject `%s` has a privesc path that ends at namespace-admin inside `%s`. The chain leans on a namespace-scoped RBAC primitive — typically `create rolebindings` (KUBE-PRIVESC-010) or `bind/escalate roles` (KUBE-PRIVESC-009) granted by a `RoleBinding` — which lets the subject bind itself (or any subject it controls) to a powerful ClusterRole *within this namespace*. The result is full API control inside `%s` but, importantly, it does **not** by itself reach cluster-admin: the binding cannot mutate cluster-scoped resources, and the bound ClusterRole's verbs apply only inside the binding's namespace.\n\n"+
+			"The chain (each step uses an explicit RBAC verb the engine validated against the snapshot):\n%s\n\n"+
+			"Namespace-admin is a real and frequently underweighted privesc class. In multi-tenant clusters where each tenant lives in its own namespace, namespace-admin == tenant takeover: every other tenant workload running in the same namespace, every Secret stored there, every PVC bound there. It also commonly chains *out* of the namespace — a controller's ServiceAccount inside this namespace may be cluster-scoped, and once the attacker can mint a binding for it locally they can pivot via that SA's cluster-wide reach. Treat namespace-admin findings as one investigation away from cluster-admin, not as \"safe because bounded\".",
+			source.Key(), namespace, namespace, formatHopList(hops)),
+		Impact:         fmt.Sprintf("Compromise of `%s` yields full takeover of `%s`: every Secret/ConfigMap is readable, every pod is exec-able, every workload runs as whatever ServiceAccount the attacker chooses. If any in-namespace ServiceAccount is itself bound cluster-wide (controllers, operators, sidecars with elevated SAs), this also becomes a stepping stone to cluster-admin.", source.Key(), namespace),
+		AttackScenario: steps,
+		Remediation:    fmt.Sprintf("Break the chain at the weakest hop and tighten RBAC writes inside `%s`: %s.", namespace, hopsRemediation(hops)),
+		RemediationSteps: []string{
+			fmt.Sprintf("Confirm the chain with `kubectl auth can-i create rolebindings -n %s --as=system:serviceaccount:%s:%s` (and `bind/escalate` on roles) — both should return `no` for any non-admin workload.", namespace, source.Namespace, source.Name),
+			fmt.Sprintf("Identify the lowest-cost hop to break (typically %s); removing one mid-chain hop kills the entire path.", hopsRemediation(hops)),
+			fmt.Sprintf("Audit Roles in `%s` granting RBAC writes: `kubectl get role -n %s -o json | jq '.items[] | select(.rules[]? | .resources[]? | contains(\"rolebindings\") or contains(\"roles\"))'`. Most workloads should have zero RBAC write rights.", namespace, namespace),
+			"Move RBAC management to GitOps (Argo CD/Flux) so any RoleBinding change requires a PR. The GitOps controller should be the only namespace-local identity with RBAC write access.",
+			fmt.Sprintf("Wire admission policy: a Kyverno or OPA Gatekeeper rule that fails any new RoleBinding in `%s` whose `roleRef` points at `cluster-admin`, `admin`, or any ClusterRole matching `*system:*` outside an explicit allowlist.", namespace),
+		},
+		LearnMore: []models.Reference{
+			refHackTricksRBAC,
+			refRBACGoodPrac,
+			{Title: "Kubernetes — RBAC: Restrictions on role-binding creation/update", URL: "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update"},
+			refMSThreatMatrix,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1078_004, mitreT1098, mitreT1068},
 	}
 }
 

--- a/internal/analyzer/privesc/graph.go
+++ b/internal/analyzer/privesc/graph.go
@@ -12,11 +12,12 @@ import (
 )
 
 const (
-	sinkClusterAdmin      = "sink:cluster_admin"
-	sinkKubeSystemSecrets = "sink:kube_system_secrets"
-	sinkNodeEscape        = "sink:node_escape"
-	sinkSystemMasters     = "sink:system_masters"
-	sinkTokenMint         = "sink:token_mint"
+	sinkClusterAdmin         = "sink:cluster_admin"
+	sinkKubeSystemSecrets    = "sink:kube_system_secrets"
+	sinkNodeEscape           = "sink:node_escape"
+	sinkSystemMasters        = "sink:system_masters"
+	sinkTokenMint            = "sink:token_mint"
+	sinkNamespaceAdminPrefix = "sink:namespace_admin:"
 )
 
 // nodeID returns the canonical graph-node ID for a subject.
@@ -95,7 +96,12 @@ func addEdgesForRule(
 		return
 	}
 
-	if matchesResourceVerb(rule, []string{"rolebindings", "clusterrolebindings"}, []string{"create", "update", "patch"}) {
+	// modify_role_binding: cluster-scoped grants reach cluster-admin (write to any (Cluster)RoleBinding
+	// → bind to any role anywhere). Namespace-scoped grants on `rolebindings` reach namespace-admin in
+	// the binding's namespace (the subject can RoleBind itself to any ClusterRole, scoped to that ns).
+	// Namespace-scoped grants on `clusterrolebindings` are dead RBAC (clusterrolebindings is a
+	// cluster-scoped resource and the authorizer never allows the verb to succeed via a RoleBinding).
+	if clusterScope && matchesResourceVerb(rule, []string{"rolebindings", "clusterrolebindings"}, []string{"create", "update", "patch"}) {
 		addEdge(graph, from, sinkClusterAdmin, &models.EscalationEdge{
 			Technique:   "KUBE-PRIVESC-010",
 			Action:      "modify_role_binding",
@@ -103,8 +109,20 @@ func addEdgesForRule(
 			Description: "can create or mutate role bindings to grant itself any role",
 		})
 	}
+	if !clusterScope && matchesResourceVerb(rule, []string{"rolebindings"}, []string{"create", "update", "patch"}) {
+		sink := ensureNamespaceAdminSink(graph, rule.Namespace)
+		addEdge(graph, from, sink, &models.EscalationEdge{
+			Technique:   "KUBE-PRIVESC-010",
+			Action:      "modify_role_binding",
+			Permission:  verbResource(rule, "rolebindings"),
+			Description: fmt.Sprintf("can create or mutate RoleBindings in namespace %s to grant itself any role within %s", rule.Namespace, rule.Namespace),
+		})
+	}
 
-	if matchesResourceVerb(rule, []string{"roles", "clusterroles"}, []string{"bind", "escalate"}) {
+	// bind/escalate on (cluster)roles: same scope reasoning as modify_role_binding. Namespace-scoped
+	// grants on `roles` let the subject bind any ClusterRole inside the binding's namespace; on
+	// `clusterroles` they're dead RBAC.
+	if clusterScope && matchesResourceVerb(rule, []string{"roles", "clusterroles"}, []string{"bind", "escalate"}) {
 		addEdge(graph, from, sinkClusterAdmin, &models.EscalationEdge{
 			Technique:   "KUBE-PRIVESC-009",
 			Action:      "bind_or_escalate",
@@ -112,23 +130,63 @@ func addEdgesForRule(
 			Description: "can bypass RBAC escalation checks via bind/escalate",
 		})
 	}
+	if !clusterScope && matchesResourceVerb(rule, []string{"roles"}, []string{"bind", "escalate"}) {
+		sink := ensureNamespaceAdminSink(graph, rule.Namespace)
+		addEdge(graph, from, sink, &models.EscalationEdge{
+			Technique:   "KUBE-PRIVESC-009",
+			Action:      "bind_or_escalate",
+			Permission:  verbResource(rule, "roles"),
+			Description: fmt.Sprintf("can bypass RBAC escalation checks via bind/escalate within namespace %s", rule.Namespace),
+		})
+	}
 
-	if matchesResourceVerb(rule, []string{"users", "groups", "serviceaccounts"}, []string{"impersonate"}) {
+	// impersonate users/groups: users and groups are not namespaced K8s objects, so a RoleBinding
+	// granting these verbs is dead RBAC (the authorizer never lets it succeed). Only emit the
+	// cluster-admin edge for cluster-scoped grants.
+	if clusterScope && matchesResourceVerb(rule, []string{"users", "groups"}, []string{"impersonate"}) {
 		addEdge(graph, from, sinkClusterAdmin, &models.EscalationEdge{
 			Technique:   "KUBE-PRIVESC-008",
 			Action:      "impersonate",
-			Permission:  verbResource(rule, "users|groups|serviceaccounts"),
+			Permission:  verbResource(rule, "users|groups"),
 			Description: "can impersonate another identity",
 		})
 	}
 
-	if matchesResourceVerb(rule, []string{"groups"}, []string{"impersonate"}) {
+	if clusterScope && matchesResourceVerb(rule, []string{"groups"}, []string{"impersonate"}) {
 		addEdge(graph, from, sinkSystemMasters, &models.EscalationEdge{
 			Technique:   "KUBE-PRIVESC-008",
 			Action:      "impersonate_system_masters",
 			Permission:  verbResource(rule, "groups"),
 			Description: "can impersonate the system:masters group, bypassing all RBAC",
 		})
+	}
+
+	// impersonate serviceaccounts: cluster-scoped grants reach any SA cluster-wide (including
+	// kube-system controllers), so we treat that as cluster-admin. Namespace-scoped grants only
+	// reach SAs in the binding's namespace — model those as per-target edges so multi-hop chains
+	// can still surface a real path if one of those SAs reaches a sink.
+	if matchesResourceVerb(rule, []string{"serviceaccounts"}, []string{"impersonate"}) {
+		if clusterScope {
+			addEdge(graph, from, sinkClusterAdmin, &models.EscalationEdge{
+				Technique:   "KUBE-PRIVESC-008",
+				Action:      "impersonate",
+				Permission:  verbResource(rule, "serviceaccounts"),
+				Description: "can impersonate any ServiceAccount cluster-wide",
+			})
+		} else {
+			for _, target := range podCreateTargets(false, rule.Namespace, subjectsByNs) {
+				if target.Key() == subject.Key() {
+					continue
+				}
+				ensureSubjectNode(graph, target)
+				addEdge(graph, from, nodeID(target), &models.EscalationEdge{
+					Technique:   "KUBE-PRIVESC-008",
+					Action:      "impersonate_serviceaccount",
+					Permission:  verbResource(rule, "serviceaccounts"),
+					Description: fmt.Sprintf("can impersonate ServiceAccount %s/%s", target.Namespace, target.Name),
+				})
+			}
+		}
 	}
 
 	if matchesResourceVerb(rule, []string{"secrets"}, []string{"get", "list", "watch"}) {
@@ -282,6 +340,22 @@ func isSensitiveHostPath(path string) bool {
 // addSink registers a terminal target node in the graph.
 func addSink(graph *models.EscalationGraph, id string, target models.EscalationTarget) {
 	graph.Nodes[id] = &models.EscalationNode{ID: id, IsSink: true, Target: target}
+}
+
+// ensureNamespaceAdminSink lazily registers (and returns the ID of) the per-namespace
+// "namespace-admin in <ns>" sink. Each namespace gets its own sink node so a subject
+// with namespace-scoped grants in multiple namespaces produces one finding per namespace.
+func ensureNamespaceAdminSink(graph *models.EscalationGraph, namespace string) string {
+	id := sinkNamespaceAdminPrefix + namespace
+	if _, ok := graph.Nodes[id]; !ok {
+		graph.Nodes[id] = &models.EscalationNode{
+			ID:              id,
+			IsSink:          true,
+			Target:          models.TargetNamespaceAdmin,
+			TargetNamespace: namespace,
+		}
+	}
+	return id
 }
 
 // ensureSubjectNode inserts a subject node into the graph if it does not already exist.

--- a/internal/analyzer/privesc/pathfinder.go
+++ b/internal/analyzer/privesc/pathfinder.go
@@ -43,7 +43,10 @@ func FindPaths(graph *models.EscalationGraph, maxDepth int) []models.EscalationP
 				continue
 			}
 			seen[key] = true
-			paths = append(paths, buildPath(graph, sourceNode.Subject, graph.Nodes[targetID].Target, chain))
+			targetNode := graph.Nodes[targetID]
+			path := buildPath(graph, sourceNode.Subject, targetNode.Target, chain)
+			path.TargetNamespace = targetNode.TargetNamespace
+			paths = append(paths, path)
 		}
 	}
 
@@ -53,6 +56,9 @@ func FindPaths(graph *models.EscalationGraph, maxDepth int) []models.EscalationP
 		}
 		if paths[i].Target != paths[j].Target {
 			return paths[i].Target < paths[j].Target
+		}
+		if paths[i].TargetNamespace != paths[j].TargetNamespace {
+			return paths[i].TargetNamespace < paths[j].TargetNamespace
 		}
 		return len(paths[i].Hops) < len(paths[j].Hops)
 	})

--- a/internal/models/escalation.go
+++ b/internal/models/escalation.go
@@ -6,6 +6,7 @@ type EscalationTarget string
 const (
 	TargetClusterAdmin      EscalationTarget = "cluster_admin_equivalent"
 	TargetKubeSystemSecrets EscalationTarget = "kube_system_secrets"
+	TargetNamespaceAdmin    EscalationTarget = "namespace_admin"
 	TargetNodeEscape        EscalationTarget = "node_escape"
 	TargetSystemMasters     EscalationTarget = "system_masters"
 	TargetTokenMint         EscalationTarget = "token_mint"
@@ -19,11 +20,12 @@ type EscalationGraph struct {
 
 // EscalationNode represents either a subject (with Subject populated) or a terminal sink (IsSink=true) in the graph.
 type EscalationNode struct {
-	ID       string           `json:"id"`
-	Subject  SubjectRef       `json:"subject,omitempty"`
-	IsSystem bool             `json:"is_system,omitempty"` // built-in control-plane subjects; not traversed during path search
-	IsSink   bool             `json:"is_sink,omitempty"`
-	Target   EscalationTarget `json:"target,omitempty"` // set only when IsSink is true
+	ID              string           `json:"id"`
+	Subject         SubjectRef       `json:"subject,omitempty"`
+	IsSystem        bool             `json:"is_system,omitempty"` // built-in control-plane subjects; not traversed during path search
+	IsSink          bool             `json:"is_sink,omitempty"`
+	Target          EscalationTarget `json:"target,omitempty"`           // set only when IsSink is true
+	TargetNamespace string           `json:"target_namespace,omitempty"` // populated only when Target == TargetNamespaceAdmin to identify which namespace the sink represents
 }
 
 // EscalationEdge is a directed labeled edge describing how one subject can obtain another subject's identity or reach a sink.
@@ -39,7 +41,8 @@ type EscalationEdge struct {
 
 // EscalationPath is one source → sink chain returned by path search, with each hop annotated.
 type EscalationPath struct {
-	Source SubjectRef       `json:"source"`
-	Target EscalationTarget `json:"target"`
-	Hops   []EscalationHop  `json:"hops"`
+	Source          SubjectRef       `json:"source"`
+	Target          EscalationTarget `json:"target"`
+	TargetNamespace string           `json:"target_namespace,omitempty"` // populated only when Target == TargetNamespaceAdmin
+	Hops            []EscalationHop  `json:"hops"`
 }

--- a/internal/report/glossary.go
+++ b/internal/report/glossary.go
@@ -224,9 +224,19 @@ var Techniques = map[string]TechniqueExplainer{
 			{Note: "Pin permanent cluster-admin for an attacker-controlled user", Cmd: "kubectl --as=system:masters create clusterrolebinding pwn --clusterrole=cluster-admin --user=attacker"},
 		},
 	},
+	"impersonate_serviceaccount": {
+		Title: "Namespace-scoped ServiceAccount impersonation",
+		Plain: template.HTML(`<p>The <code>impersonate</code> verb on <code>serviceaccounts</code>, granted by a namespace-scoped <strong>RoleBinding</strong>, lets the holder act as any ServiceAccount that lives <em>in the binding's namespace</em>. The reach is bounded — they can't impersonate SAs in other namespaces, and they can't impersonate users or groups — but it's still a token-free credential-borrow that inherits whatever cluster-wide permissions the impersonated SA happens to have.</p><p>Real exposure depends on what the SAs in the namespace can do: an in-namespace controller SA bound to a powerful ClusterRole becomes a stepping stone out of the namespace.</p>`),
+		Mitre: "T1078.004 — Cloud Accounts",
+		AttackerSteps: []AttackerStep{
+			{Note: "List the SAs you can impersonate (every SA in the binding's namespace)", Cmd: "kubectl get sa -n <ns>"},
+			{Note: "Borrow a target SA's identity and probe its reach", Cmd: "kubectl auth can-i --list --as=system:serviceaccount:<ns>:<target-sa>"},
+			{Note: "Read whatever the impersonated SA can read (Secrets, ConfigMaps, etc.)", Cmd: "kubectl --as=system:serviceaccount:<ns>:<target-sa> get secrets -A"},
+		},
+	},
 	"bind_or_escalate": {
 		Title: "RBAC bind/escalate bypass",
-		Plain: template.HTML(`<p>RBAC has a guardrail: you can only grant permissions you yourself hold. Two verbs override that guardrail: <code>bind</code> (on a Role/ClusterRole) and <code>escalate</code> (also on Roles). Holding either lets the attacker create a binding to a Role they don't have themselves, including <code>cluster-admin</code>.</p>`),
+		Plain: template.HTML(`<p>RBAC has a guardrail: you can only grant permissions you yourself hold. Two verbs override that guardrail: <code>bind</code> (on a Role/ClusterRole) and <code>escalate</code> (also on Roles). Holding either lets the attacker create a binding to a Role they don't have themselves, including <code>cluster-admin</code>.</p><p>Scope matters. Granted by a ClusterRoleBinding the reach is cluster-wide; granted by a RoleBinding it bounds the bypass to the binding's namespace — namespace-admin instead of cluster-admin, but still a complete takeover of every workload, Secret, and ConfigMap in that namespace.</p>`),
 		Mitre: "T1098.003 — Account Manipulation: Additional Cloud Roles",
 		AttackerSteps: []AttackerStep{
 			{Note: "Bind a chosen ServiceAccount to cluster-admin", Cmd: "kubectl create clusterrolebinding pwn --clusterrole=cluster-admin --serviceaccount=ns:me"},
@@ -277,10 +287,11 @@ var Techniques = map[string]TechniqueExplainer{
 	},
 	"modify_role_binding": {
 		Title: "RoleBinding write access",
-		Plain: template.HTML(`<p><code>create</code>/<code>update</code>/<code>patch</code> on <code>rolebindings</code> or <code>clusterrolebindings</code> lets the attacker bind themselves to any role, typically cluster-admin. They don't need the role's permissions today, only the ability to change bindings.</p>`),
+		Plain: template.HTML(`<p><code>create</code>/<code>update</code>/<code>patch</code> on <code>rolebindings</code> or <code>clusterrolebindings</code> lets the attacker bind themselves to any role, typically cluster-admin. They don't need the role's permissions today, only the ability to change bindings.</p><p>Scope matters. Granted at cluster scope (via a ClusterRoleBinding, or with cluster-wide reach on <code>rolebindings</code>) the reach is cluster-admin equivalent. Granted by a RoleBinding the reach is bounded to that one namespace — full namespace-admin, but the bound ClusterRole's verbs apply only inside the binding's namespace.</p>`),
 		Mitre: "T1098 — Account Manipulation",
 		AttackerSteps: []AttackerStep{
 			{Note: "Append yourself as a subject on an existing high-privilege binding", Cmd: "kubectl patch clusterrolebinding existing-binding --type=json -p='[{\"op\":\"add\",\"path\":\"/subjects/-\",\"value\":{\"kind\":\"ServiceAccount\",\"name\":\"me\",\"namespace\":\"ns\"}}]'"},
+			{Note: "Or, when only namespace-scoped, RoleBind yourself to cluster-admin within the namespace", Cmd: "kubectl create rolebinding pwn -n <ns> --clusterrole=cluster-admin --serviceaccount=<ns>:me"},
 		},
 	},
 	"read_secrets": {

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -129,7 +129,8 @@ EXPECTED_RULES=(
   KUBE-SA-DEFAULT-001 KUBE-SA-DEFAULT-002 KUBE-SA-PRIVILEGED-001 KUBE-SA-PRIVILEGED-002
   KUBE-SA-DAEMONSET-001
   KUBE-PRIVESC-PATH-CLUSTER-ADMIN KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS
-  KUBE-PRIVESC-PATH-NODE-ESCAPE KUBE-PRIVESC-PATH-SYSTEM-MASTERS KUBE-PRIVESC-PATH-GENERIC
+  KUBE-PRIVESC-PATH-NODE-ESCAPE KUBE-PRIVESC-PATH-SYSTEM-MASTERS
+  KUBE-PRIVESC-PATH-NAMESPACE-ADMIN KUBE-PRIVESC-PATH-GENERIC
 )
 
 missing=()
@@ -144,6 +145,28 @@ if (( ${#missing[@]} > 0 )); then
   exit 1
 fi
 ok "all ${#EXPECTED_RULES[@]} expected rule IDs present"
+
+# Regression guard for issue #48: a namespace-scoped RoleBinding granting
+# `create rolebindings` MUST NOT produce a cluster-admin path finding. The
+# finding ID concatenates ruleID + subject Key + target, so a single grep
+# pinpoints the exact false positive without needing jq.
+NS_SUBJECT_KEY="ServiceAccount/rbac-ns-fixtures/sa-ns-rolebinding-mutate"
+NS_FP_ID_PREFIX="KUBE-PRIVESC-PATH-CLUSTER-ADMIN:${NS_SUBJECT_KEY}:"
+if rg -q "\"id\":\s*\"${NS_FP_ID_PREFIX}" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+  echo "regression: namespace-scoped RoleBinding produced KUBE-PRIVESC-PATH-CLUSTER-ADMIN (issue #48)" >&2
+  exit 1
+fi
+ok "no cluster-admin false positive for namespace-scoped RoleBinding"
+
+# The same fixture must instead produce KUBE-PRIVESC-PATH-NAMESPACE-ADMIN, naming
+# the namespace it can take over. The finding ID encodes the target namespace as
+# the last segment after a fourth `:`.
+NS_OK_ID="KUBE-PRIVESC-PATH-NAMESPACE-ADMIN:${NS_SUBJECT_KEY}:namespace_admin:rbac-ns-fixtures"
+if ! rg -q "\"id\":\s*\"${NS_OK_ID}\"" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+  echo "missing: namespace-scoped RoleBinding did not produce expected KUBE-PRIVESC-PATH-NAMESPACE-ADMIN finding for ${NS_SUBJECT_KEY} → rbac-ns-fixtures" >&2
+  exit 1
+fi
+ok "namespace-admin path emitted for namespace-scoped RoleBinding"
 
 if [[ "${KEEP_CLUSTER}" == "1" ]]; then
   step "Wiring kubectl context"

--- a/testdata/e2e/vulnerable.yaml
+++ b/testdata/e2e/vulnerable.yaml
@@ -413,6 +413,45 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 ---
+# Namespace-scoped RoleBinding: regression guard for issue #48. Granting
+# `create rolebindings` via a RoleBinding only confers namespace-admin in
+# `rbac-ns-fixtures`, NOT cluster-admin. The e2e script asserts that
+# KUBE-PRIVESC-PATH-CLUSTER-ADMIN is NOT emitted for sa-ns-rolebinding-mutate.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rbac-ns-fixtures
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-ns-rolebinding-mutate
+  namespace: rbac-ns-fixtures
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: r-ns-rolebinding-mutate
+  namespace: rbac-ns-fixtures
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rb-ns-rolebinding-mutate
+  namespace: rbac-ns-fixtures
+subjects:
+  - kind: ServiceAccount
+    name: sa-ns-rolebinding-mutate
+    namespace: rbac-ns-fixtures
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: r-ns-rolebinding-mutate
+---
 # === MODULE: podsec / escape (extra fixtures in `vulnerable` namespace) ===
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes #48.

## Summary

- **The false positive (the bug):** three edge constructors in the privesc graph (`modify_role_binding`, `bind_or_escalate`, `impersonate users|groups|serviceaccounts`) ignored `EffectiveRule.Namespace` and unconditionally pointed at `sink:cluster_admin`. A `RoleBinding` in namespace `dev` granting `create rolebindings` produced `KUBE-PRIVESC-PATH-CLUSTER-ADMIN` even though the subject is at most namespace-admin in `dev`. Each edge is now gated on `clusterScope`, matching the pattern already in use for secrets-read (graph.go:135) and arbitrary-token-mint (graph.go:202). For namespace-scoped `impersonate serviceaccounts`, the analyzer now emits per-SA target edges scoped to the binding's namespace (action `impersonate_serviceaccount`) so chains through those SAs still surface.

- **Namespace-admin as a real target (the enhancement):** rather than silently drop the namespace-scoped escalation cases (\`create rolebindings\` and \`bind/escalate roles\` granted via a `RoleBinding`), they now reach a per-namespace `sink:namespace_admin:<ns>` node. New `EscalationTarget` constant `TargetNamespaceAdmin`, new `KUBE-PRIVESC-PATH-NAMESPACE-ADMIN` rule (HIGH, base 7.6), dedicated content copy that names the affected namespace and explains why \"bounded\" doesn't mean \"safe\" (in-namespace controllers commonly chain back out to cluster-admin), and refreshed `bind_or_escalate` / `modify_role_binding` technique explainers to acknowledge the namespace-scoped variant. Findings anchor to the affected `Namespace` so the report's resource column, dedupe key, and SARIF physical-location all surface which namespace is at risk.

## Validation against the issue's reproduction

The exact manifest in the issue body now produces:

- `KUBE-PRIVESC-010` (rbac analyzer's overbroad-permission rule, scoped to `Namespace dev only`) — unchanged, correctly flags the dangerous RBAC grant
- `KUBE-PRIVESC-PATH-NAMESPACE-ADMIN:ServiceAccount/dev/dev-sa:namespace_admin:dev` titled ``ServiceAccount/dev/dev-sa can reach **namespace-admin in `dev`** in 1 hop(s)``
- **No** `KUBE-PRIVESC-PATH-CLUSTER-ADMIN` ✓

The existing CRB-based fixtures in `testdata/e2e/vulnerable.yaml` continue to legitimately produce cluster-admin / system-masters / kube-system-secrets / node-escape paths.

## Test plan

- [x] `make lint` clean
- [x] `make test` — all packages green; new tests `TestNamespaceScopedRBACDoesNotEmitClusterAdmin`, `TestNamespaceScopedRBACEmitsNamespaceAdminPath`, `TestNamespaceScopedImpersonateServiceAccountsEmitsPerSATarget` all pass
- [x] Manual reproduction with `scan-resource` against the issue's exact YAML returns no cluster-admin finding and emits the expected namespace-admin path
- [x] `make e2e` — boots `kind`, applies the updated `vulnerable.yaml`, runs both the existing `EXPECTED_RULES` presence loop (now including `KUBE-PRIVESC-PATH-NAMESPACE-ADMIN`) and the new presence + absence assertions for the namespaced `sa-ns-rolebinding-mutate` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)