### PR TITLE
feat(report): mobile attack-path modal with per-entry path cards

### DIFF
--- a/internal/report/assets/graph.js
+++ b/internal/report/assets/graph.js
@@ -405,6 +405,12 @@
 
   var lastFocused = null;
   var walkState = null;
+  // navStack remembers the entry node when the user drilled into a capability via
+  // the entry panel's path cards, so the cap panel can render a "← Back to {entry}"
+  // link. Cleared on direct SVG node clicks and on closePanel so a stale entry never
+  // leaks across sessions.
+  var navStack = null;
+  var backdrop = document.querySelector('.kp-backdrop');
 
   function $$(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
 
@@ -615,6 +621,104 @@
     });
   }
 
+  // impactForCap walks a capability node's outgoing edge to find the impact node it
+  // leads to. Capabilities have exactly one outgoing edge (cap → impact) per the
+  // build in attack_graph.go, so a linear scan over EdgeIDs is correct and cheap.
+  function impactForCap(capNode) {
+    var ids = (capNode && capNode.EdgeIDs) || [];
+    for (var i = 0; i < ids.length; i++) {
+      var e = edgeIndex[ids[i]];
+      if (e && e.From === capNode.ID) {
+        var dest = nodeIndex[e.To];
+        if (dest && dest.Kind === 'impact') return dest;
+      }
+    }
+    return null;
+  }
+
+  // renderEntryPaths builds the "N attack paths from here" section for an entry node.
+  // It walks the entry's outgoing edges to find each connected capability, sorts them
+  // by severity so the worst paths surface first, and renders one tappable card per
+  // capability. Tapping a card calls openPanel(cap, …, { fromEntry: entry }) which
+  // sets navStack so the cap panel can show a "← Back to {entry}" affordance.
+  // Returns null when the entry has no connected capabilities (defensive — should not
+  // happen in practice since entries only exist because they spawned at least one cap).
+  function renderEntryPaths(entry) {
+    var ids = (entry && entry.EdgeIDs) || [];
+    var caps = [];
+    for (var i = 0; i < ids.length; i++) {
+      var e = edgeIndex[ids[i]];
+      if (!e || e.From !== entry.ID) continue;
+      var cap = nodeIndex[e.To];
+      if (cap && cap.Kind === 'capability') caps.push({ cap: cap, edge: e });
+    }
+    if (!caps.length) return null;
+    var rank = { crit: 0, high: 1, med: 2, low: 3 };
+    caps.sort(function(a, b) {
+      var ra = rank[a.cap.Severity] != null ? rank[a.cap.Severity] : 9;
+      var rb = rank[b.cap.Severity] != null ? rank[b.cap.Severity] : 9;
+      return ra - rb;
+    });
+
+    var heading = caps.length === 1 ? '1 attack path from here' : caps.length + ' attack paths from here';
+    var sec = el('section', { class: 'kp-section kp-paths-section' }, [
+      el('h4', { text: heading }),
+      el('p', { class: 'kp-paths-hint', text: 'Each card is one way an attacker abuses this entry point. Tap to walk through the technique step-by-step.' })
+    ]);
+    caps.forEach(function(it) {
+      var cap = it.cap;
+      var impact = impactForCap(cap);
+      var sev = cap.Severity || 'med';
+      var card = el('button', { type: 'button', class: 'kp-path-card kp-path-card-' + sev, attrs: { 'aria-label': 'Open attack path: ' + (cap.Title || '') } });
+      var hd = el('div', { class: 'kp-path-card-hd' });
+      hd.appendChild(el('span', { class: 'kp-sev-badge kp-sev-' + sev, text: severityLabel(sev) }));
+      if (cap.RuleID) hd.appendChild(el('span', { class: 'kp-rule mono', text: cap.RuleID }));
+      card.appendChild(hd);
+      var titleEl = el('div', { class: 'kp-path-card-title' });
+      renderInline(cap.Title || '', titleEl);
+      card.appendChild(titleEl);
+      var meta = el('div', { class: 'kp-path-card-meta' });
+      if (impact && impact.Title) {
+        meta.appendChild(el('span', { class: 'kp-path-arrow', text: '→' }));
+        meta.appendChild(el('span', { class: 'kp-path-impact', text: impact.Title }));
+      }
+      if (cap.Hops && cap.Hops.length) {
+        var hopText = cap.Hops.length + '-step chain';
+        meta.appendChild(el('span', { class: 'kp-path-hops', text: hopText }));
+      }
+      if (meta.firstChild) card.appendChild(meta);
+      var cta = el('span', { class: 'kp-path-cta', text: 'Walk the path →' });
+      card.appendChild(cta);
+      card.addEventListener('click', function() {
+        openPanel(cap, card, { fromEntry: entry });
+      });
+      sec.appendChild(card);
+    });
+    return sec;
+  }
+
+  // renderBackLink prepends a "← Back to {entry}" button to the panel body when the
+  // user drilled into the current capability via an entry path-card. Idempotent —
+  // safely callable on every renderPanel pass; only emits when navStack is set and
+  // the rendered node isn't the entry itself (defensive guard).
+  function renderBackLink(node) {
+    if (!navStack) return;
+    if (node.Kind === 'entry') return;
+    if (navStack.ID === node.ID) return;
+    var entry = navStack;
+    var back = el('button', { type: 'button', class: 'kp-back-link' });
+    back.appendChild(el('span', { class: 'kp-back-arrow', text: '←' }));
+    back.appendChild(document.createTextNode(' Back to '));
+    var strong = document.createElement('strong');
+    renderInline(entry.Title || 'entry point', strong);
+    back.appendChild(strong);
+    back.addEventListener('click', function() {
+      // Returning to the entry resets the nav context — entry is the new root.
+      openPanel(entry, back);
+    });
+    panelBody.appendChild(back);
+  }
+
   // renderPanel composes the side-panel content for one node. All Finding-derived strings go
   // through textContent (via the el() helper) so untrusted content never reaches innerHTML.
   // Glossary/technique/category prose is HTML pre-vetted by Go and is allowed via 'html'.
@@ -622,6 +726,8 @@
     panelBody.innerHTML = '';
     panelTitle.textContent = '';
     renderInline(node.Title || 'Detail', panelTitle);
+
+    renderBackLink(node);
 
     var hd = el('div', { class: 'kp-panel-meta' });
     if (node.Severity) hd.appendChild(el('span', { class: 'kp-sev-badge kp-sev-' + node.Severity, text: severityLabel(node.Severity) }));
@@ -643,6 +749,15 @@
         sec.appendChild(el('div', { class: 'kp-doc-link' }, [doc]));
       }
       panelBody.appendChild(sec);
+    }
+
+    // For entry-point nodes, list every connected attack path as a tappable card.
+    // This is the "modal that maps out the attack path" UX — on phones the panel is
+    // a full-screen sheet, so the user lands on this list directly after tapping
+    // the entry. On desktop the same list appears in the side panel.
+    if (node.Kind === 'entry') {
+      var pathSec = renderEntryPaths(node);
+      if (pathSec) panelBody.appendChild(pathSec);
     }
 
     var category = node.RiskCategory && payload.Categories ? payload.Categories[node.RiskCategory] : null;
@@ -783,20 +898,41 @@
     panelBody.appendChild(toBox);
   }
 
-  function openPanel(node, originEl) {
+  // openPanel renders a node's detail into the side panel / mobile sheet and shows it.
+  // opts.fromEntry: when set, records the entry node so the rendered cap panel can
+  // show a "← Back to {entry}" link. Any other call path (direct SVG node click,
+  // navigating back to the entry) clears navStack so we never carry a stale link
+  // across an unrelated open.
+  function openPanel(node, originEl, opts) {
     walkState = null;
+    navStack = (opts && opts.fromEntry) ? opts.fromEntry : null;
     renderPanel(node);
     panel.hidden = false;
     panel.classList.add('kp-open');
+    if (backdrop) {
+      backdrop.hidden = false;
+      // Two ticks so the transition fires after the element is laid out.
+      requestAnimationFrame(function() { backdrop.classList.add('kp-backdrop-on'); });
+    }
+    document.body.classList.add('kp-modal-open');
     highlightNode(node);
     if (originEl) lastFocused = originEl;
     if (panelClose) panelClose.focus();
+    // Reset internal scroll on re-open so a long previous panel doesn't strand
+    // the user mid-content when a fresh node opens.
+    panel.scrollTop = 0;
   }
 
   function closePanel() {
     panel.hidden = true;
     panel.classList.remove('kp-open');
     walkState = null;
+    navStack = null;
+    if (backdrop) {
+      backdrop.classList.remove('kp-backdrop-on');
+      backdrop.hidden = true;
+    }
+    document.body.classList.remove('kp-modal-open');
     clearHighlights();
     if (lastFocused) { try { lastFocused.focus(); } catch (e) {} }
   }
@@ -902,6 +1038,11 @@
   });
 
   if (panelClose) panelClose.addEventListener('click', closePanel);
+  // Explicit backdrop click handler. The document-level mousedown handler further down
+  // also closes on outside-click, but it doesn't always fire reliably on iOS Safari for
+  // taps on otherwise-empty <div> overlays. A direct click handler on the backdrop is
+  // the no-surprises path.
+  if (backdrop) backdrop.addEventListener('click', closePanel);
   document.addEventListener('keydown', function(ev) {
     if (ev.key === 'Escape' && panel.classList.contains('kp-open')) closePanel();
   });

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -275,10 +275,64 @@
     .kp-tt-tag { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; padding: 1px 2px; margin-right: 5px; border-radius: 999px; background: rgba(106,183,255,0.12); color: var(--accent); border: 1px solid rgba(106,183,255,0.25); vertical-align: middle; }
     .kp-tt-hint { margin-top: 6px; color: var(--accent); font-size: 11px; opacity: 0.8; }
 
+    /* "Attack paths from here" cards inside an entry-point panel. Each card is a button
+       so the whole surface is the tap target — important on phones where users thumb-scroll
+       and a tiny "View" link would be a miss. The left severity stripe (border-left-color)
+       carries severity at a glance so users can prioritize without reading the badge. */
+    .kp-paths-section { margin-top: 16px; }
+    .kp-paths-hint { color: var(--text-mut); font-size: 12.5px; line-height: 1.55; margin: 0 0 10px; }
+    .kp-path-card { display: block; width: 100%; min-height: 44px; text-align: left; font: inherit; color: var(--text); padding: 12px 14px; margin: 0 0 10px; background: rgba(255,255,255,0.025); border: 1px solid var(--border); border-left: 3px solid var(--border-strong); border-radius: 12px; cursor: pointer; transition: background 0.12s ease, border-color 0.12s ease, transform 0.12s ease; }
+    .kp-path-card:last-child { margin-bottom: 0; }
+    .kp-path-card:hover { background: rgba(255,255,255,0.05); border-color: var(--border-strong); }
+    .kp-path-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .kp-path-card:active { transform: scale(0.995); }
+    .kp-path-card-crit { border-left-color: var(--critical); }
+    .kp-path-card-high { border-left-color: var(--high); }
+    .kp-path-card-med  { border-left-color: var(--medium); }
+    .kp-path-card-hd { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-bottom: 6px; }
+    .kp-path-card-title { font-size: 13.5px; font-weight: 600; line-height: 1.4; color: var(--text); margin-bottom: 6px; word-break: break-word; }
+    .kp-path-card-meta { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; font-size: 12px; color: var(--text-mut); margin-bottom: 8px; }
+    .kp-path-arrow { color: var(--high); font-weight: 700; }
+    .kp-path-impact { color: var(--text); }
+    .kp-path-hops { padding: 2px 8px; border-radius: 999px; background: rgba(106,183,255,0.10); color: #bedbff; border: 1px solid rgba(106,183,255,0.22); font-size: 11px; }
+    .kp-path-cta { display: inline-block; font-size: 12px; font-weight: 600; color: var(--accent); letter-spacing: 0.02em; }
+
+    /* Back-to-entry breadcrumb. Appears at the top of a capability panel only when the
+       user reached it by tapping a path card from an entry view — direct SVG node clicks
+       and the close button both clear navStack, so we never show stale breadcrumbs. */
+    .kp-back-link { display: inline-flex; align-items: center; gap: 6px; font: inherit; font-size: 12.5px; color: var(--text-mut); background: transparent; border: 1px dashed var(--border); border-radius: 999px; padding: 5px 11px; margin: 0 0 12px; cursor: pointer; transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease; }
+    .kp-back-link:hover { color: var(--text); border-color: var(--border-strong); background: rgba(255,255,255,0.04); }
+    .kp-back-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .kp-back-arrow { color: var(--accent); font-weight: 700; }
+    .kp-back-link strong { color: var(--text); font-weight: 600; word-break: break-word; }
+
+    /* Backdrop overlay. Hidden on desktop (no overlay needed when the panel is a side
+       rail), faded in only at the mobile breakpoint via the @media block below. */
+    .kp-backdrop { position: fixed; inset: 0; background: rgba(7, 11, 22, 0.0); z-index: 49; opacity: 0; pointer-events: none; transition: opacity 0.18s ease, background-color 0.18s ease; }
+    .kp-backdrop.kp-backdrop-on { opacity: 1; }
+
     @media (max-width: 1180px) {
       .kp-detail { position: relative; top: auto; right: auto; width: 100%; max-width: 100%; margin-top: 12px; transform: translateY(8px); }
       .kp-detail.kp-open { transform: translateY(0); }
     }
+
+    /* Phone bottom-sheet treatment. Below 720px the side panel becomes a true full-screen
+       modal: slides up from the bottom, sticky header so close is always thumb-reachable,
+       backdrop dims the page, and body scroll is locked so the page underneath doesn't
+       slide while the user reads the sheet. The 720px breakpoint is intentional —
+       720–1180px (tablets) keep the inline-below-SVG layout where horizontal real estate
+       is enough that a sheet would feel heavy. */
+    @media (max-width: 720px) {
+      .kp-detail { position: fixed; inset: 0; top: 0; right: 0; left: 0; bottom: 0; width: 100vw; max-width: 100vw; max-height: 100vh; height: 100vh; margin: 0; padding: 0 18px calc(env(safe-area-inset-bottom, 0px) + 24px); border-radius: 0; border-left: 1px solid var(--border-strong); border-right: 1px solid var(--border-strong); border-bottom: 0; box-shadow: 0 -10px 40px rgba(0,0,0,0.7); transform: translateY(100%); transition: transform 0.24s cubic-bezier(0.2, 0.8, 0.2, 1); overflow-y: auto; -webkit-overflow-scrolling: touch; z-index: 70; }
+      .kp-detail.kp-open { transform: translateY(0); }
+      .kp-detail-hd { position: sticky; top: 0; background: var(--surface); padding: 14px 0 10px; margin: 0 -18px 12px; padding-left: 18px; padding-right: 18px; z-index: 1; border-bottom: 1px solid var(--border); }
+      .kp-detail-hd h3 { font-size: 15px; }
+      .kp-detail-close { width: 36px; height: 36px; font-size: 22px; }
+      .kp-backdrop { background: rgba(7, 11, 22, 0.6); pointer-events: auto; backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px); }
+      .kp-path-card { padding: 14px 14px; min-height: 56px; }
+      .kp-path-card-title { font-size: 14px; }
+    }
+    body.kp-modal-open { overflow: hidden; }
 
     .narratives { display: grid; grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); gap: 16px; }
     /* Narrative card: severity badge is the first child and pinned to the top-left corner
@@ -870,6 +924,7 @@
         </div>
       </div>
 
+      <div class="kp-backdrop" hidden aria-hidden="true"></div>
       <aside class="kp-detail" hidden role="dialog" aria-modal="false" aria-labelledby="kp-detail-title">
         <header class="kp-detail-hd">
           <h3 id="kp-detail-title">Click a node</h3>


### PR DESCRIPTION
## Summary
- Tapping an entry-point on a phone (≤720px) now opens a full-screen bottom sheet listing every attack path originating there as a tappable card (severity badge, rule ID, impact lane, hop count).
- Drilling into a capability shows a `← Back to {entry}` breadcrumb so users can move between paths without losing context. Desktop side rail (>1180px) gains the same enriched path-list content.
- Sheet has a dimmed backdrop, sticky header, locked body scroll, and explicit backdrop-tap-to-close. Tablets (720–1180px) keep the existing inline-below-graph layout.
- No Go changes — entry `EdgeIDs` and capability `Hops` were already exposed on `GraphPayload`.

Before: tapping an entry only dimmed the graph; the connected capability nodes sat off-screen on the 1080-px-wide canvas, so users had to horizontally scroll the SVG and mentally trace bezier edges.

## Test plan
- [x] `make build` and `make test` pass; `make lint` clean
- [x] Verified at iPhone-14 viewport (390×844) with `agent-browser`: entry tap opens sheet → 3 path cards render → tapping a card transitions to capability detail with back link → back link returns to entry view → backdrop tap closes sheet and unlocks body scroll
- [x] Verified at desktop (1440×900): side rail still slides in fixed-position at 580px wide with the enriched path-cards content
- [x] Eyeball check on real iOS Safari / Android Chrome before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)