### PR TITLE
feat(admission): detect policy engines, emit no-engine posture finding

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,11 +25,12 @@ In parallel (capped by `--parallelism`), lists every supported resource kind and
 - **RBAC** — Roles, ClusterRoles, RoleBindings, ClusterRoleBindings.
 - **Workloads** — Pods, Deployments, DaemonSets, StatefulSets, Jobs, CronJobs.
 - **Networking** — NetworkPolicies, Services, Ingresses.
-- **Admission** — ValidatingWebhookConfigurations, MutatingWebhookConfigurations.
+- **Admission** — ValidatingWebhookConfigurations, MutatingWebhookConfigurations, ValidatingAdmissionPolicies, ValidatingAdmissionPolicyBindings.
+- **Policy engines (CRDs, optional)** — Kyverno `(Cluster)Policy`, Gatekeeper `ConstraintTemplate`. Listed via the dynamic client when `Discovery().ServerGroups()` reports the API group is served; absent CRDs are not errors.
 - **Identity** — ServiceAccounts, Secrets (metadata only — raw values are never read), ConfigMaps.
 - **Platform** — Nodes, Namespaces.
 
-Forbidden / Unauthorized errors are **downgraded to warnings**, not fatal — a partial snapshot still produces useful output. This matters in locked-down clusters where the scanning credential cannot list everything.
+Forbidden / Unauthorized errors are **downgraded to warnings**, not fatal — a partial snapshot still produces useful output. This matters in locked-down clusters where the scanning credential cannot list everything. NoMatch / NotFound errors (CRDs not installed for Kyverno or Gatekeeper, VAP not served on older clusters) are also recorded as warnings rather than `missing_permissions`, since the resource genuinely does not exist on the cluster.
 
 The snapshot is a plain JSON file. `kubesplaining download` writes it; `kubesplaining scan --input-file` consumes it. This separation means you can capture a snapshot on a jumphost and analyze it offline, or diff snapshots over time.
 
@@ -101,6 +102,14 @@ Most analyzers currently emit a hand-picked `Score` directly; the engine's corre
 ## Access requirements
 
 Kubesplaining needs **cluster-wide read** on the resource kinds listed under Stage 2. A suitable ClusterRole is a subset of the built-in `view` role plus `get`/`list` on RBAC objects and webhook configurations. Forbidden listings are recorded as `missing_permissions` warnings in the snapshot and do not abort the run; the affected modules just operate on a partial view.
+
+For Phase 2's policy-engine detection, also grant `get`/`list` on:
+
+- `validatingadmissionpolicies.admissionregistration.k8s.io` and `validatingadmissionpolicybindings.admissionregistration.k8s.io` (in-tree, GA in v1.30)
+- `clusterpolicies.kyverno.io` and `policies.kyverno.io` (only required if Kyverno is installed)
+- `constrainttemplates.templates.gatekeeper.sh` (only required if Gatekeeper is installed)
+
+If RBAC is missing for one of these, the resource is recorded in `missing_permissions` and `KUBE-ADMISSION-NO-POLICY-ENGINE-001` may fire even though an engine is actually installed — grant access for accurate detection.
 
 No admission webhooks, CRDs, or agent pods are installed. The tool is safe to point at production.
 

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -60,6 +60,15 @@ Each rule produces zero or more findings against a given snapshot.
 | KUBE-ADMISSION-001 | HIGH | Security-critical webhook uses `failurePolicy: Ignore` | Webhook targets pods/workloads but fails open | Use `failurePolicy: Fail` for security webhooks |
 | KUBE-ADMISSION-002 | MEDIUM | Webhook can be bypassed via object labels | `objectSelector` keys on a workload-controlled label | Move rule to fields the workload cannot forge |
 | KUBE-ADMISSION-003 | MEDIUM | Webhook excludes sensitive namespaces | `namespaceSelector` exempts `kube-system` / `*-system` | Confirm exemption is intentional, narrow if not |
+| KUBE-ADMISSION-NO-POLICY-ENGINE-001 | MEDIUM | Cluster has no PSA enforce labels and no detected policy engine | No namespace carries `pod-security.kubernetes.io/enforce=baseline\|restricted` AND zero ValidatingAdmissionPolicy / Kyverno / Gatekeeper resources observed | Apply PSA labels per namespace, install Kyverno/Gatekeeper, or author ValidatingAdmissionPolicy resources |
+
+#### Admission tags
+
+These appear on `Finding.Tags` (visible in JSON, CSV, and SARIF output) and describe the relationship between a finding and the cluster's admission controls. None change the score.
+
+- `admission:audit-psa-<level>` / `admission:warn-psa-<level>` — the finding's namespace has a PSA `audit` or `warn` label at the given level. PSA logs the violation but does not block the workload, so the finding stays at full severity.
+- `admission:mitigated-psa-<level>` — `--admission-mode=attenuate` dropped the finding's severity by one bucket because the namespace's PSA `enforce` label would block the spec.
+- `admission:policy-engine-detected:<engine>` — appended when an admission policy engine (`kyverno`, `gatekeeper`, `vap`) was observed in the snapshot but kubesplaining didn't evaluate its rules. One tag per detected engine. Score is unchanged. Findings already suppressed by PSA do not receive this tag (they're gone from the slice before this stage runs).
 
 ### Secrets & ConfigMaps ([internal/analyzer/secrets/analyzer.go](../internal/analyzer/secrets/analyzer.go))
 

--- a/internal/analyzer/admission/analyzer.go
+++ b/internal/analyzer/admission/analyzer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/0hardik1/kubesplaining/internal/analyzer/admission/mitigation"
 	"github.com/0hardik1/kubesplaining/internal/models"
 	"github.com/0hardik1/kubesplaining/internal/scoring"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -60,7 +61,74 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		}
 	}
 
+	// Cluster-wide posture check. The engine stage applyPolicyEnginePresenceTags
+	// strips this finding when --admission-mode=off, so the analyzer can stay
+	// admission-unaware: emit unconditionally when conditions are met.
+	if shouldEmitNoPolicyEngineFinding(snapshot) {
+		findings = append(findings, postureFinding(
+			"KUBE-ADMISSION-NO-POLICY-ENGINE-001",
+			models.SeverityMedium,
+			scoring.MinScoreForSeverity(models.SeverityMedium),
+			contentNoPolicyEngine(),
+			"no_policy_engine",
+		))
+	}
+
 	return findings, nil
+}
+
+// shouldEmitNoPolicyEngineFinding returns true when (a) the snapshot has at
+// least one namespace (gates out manifest-mode single-resource scans), (b) no
+// namespace carries a PSA enforce label at baseline or stricter, and (c) no
+// policy-engine resources were observed. All three must hold — any defense in
+// place suppresses the posture finding.
+func shouldEmitNoPolicyEngineFinding(snapshot models.Snapshot) bool {
+	if len(snapshot.Resources.Namespaces) == 0 {
+		return false
+	}
+	for _, ns := range snapshot.Resources.Namespaces {
+		if mitigation.PSAStateForLabels(ns.Labels).HasEnforce() {
+			return false
+		}
+	}
+	if len(snapshot.Resources.ValidatingAdmissionPolicies) > 0 ||
+		len(snapshot.Resources.KyvernoClusterPolicies) > 0 ||
+		len(snapshot.Resources.KyvernoPolicies) > 0 ||
+		len(snapshot.Resources.GatekeeperConstraintTemplates) > 0 {
+		return false
+	}
+	return true
+}
+
+// postureFinding materializes a cluster-wide finding with no Resource, Subject,
+// or Namespace. The deterministic ID is just the rule ID — there is only ever
+// one instance per cluster scan, so no per-instance disambiguation is needed.
+// Carries the module:admission tag (so the PSA stage's isPodSecurityFinding
+// check returns false and won't try to attenuate it) and a check tag for
+// downstream filtering.
+func postureFinding(ruleID string, severity models.Severity, score float64, content ruleContent, check string) models.Finding {
+	references := make([]string, 0, len(content.LearnMore))
+	for _, ref := range content.LearnMore {
+		references = append(references, ref.URL)
+	}
+	return models.Finding{
+		ID:               ruleID,
+		RuleID:           ruleID,
+		Severity:         severity,
+		Score:            scoring.Clamp(score),
+		Category:         models.CategoryInfrastructureModification,
+		Title:            content.Title,
+		Description:      content.Description,
+		Scope:            content.Scope,
+		Impact:           content.Impact,
+		AttackScenario:   content.AttackScenario,
+		Remediation:      content.Remediation,
+		RemediationSteps: content.RemediationSteps,
+		References:       references,
+		LearnMore:        content.LearnMore,
+		MitreTechniques:  content.MitreTechniques,
+		Tags:             []string{"module:admission", "check:" + check},
+	}
 }
 
 // analyzeMutating checks one mutating webhook entry for fail-open, bypassable selector, and sensitive-namespace exemption issues.

--- a/internal/analyzer/admission/analyzer_test.go
+++ b/internal/analyzer/admission/analyzer_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/0hardik1/kubesplaining/internal/models"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestAnalyzerFindsWebhookBypassRisks(t *testing.T) {
@@ -75,4 +77,160 @@ func assertRulePresent(t *testing.T, findings []models.Finding, ruleID string) {
 
 func sideEffectsPtr(value admissionregistrationv1.SideEffectClass) *admissionregistrationv1.SideEffectClass {
 	return &value
+}
+
+func TestShouldEmitNoPolicyEngineFinding(t *testing.T) {
+	t.Parallel()
+
+	withNamespaces := func(labelsByName map[string]map[string]string) models.Snapshot {
+		s := models.Snapshot{}
+		for name, labels := range labelsByName {
+			s.Resources.Namespaces = append(s.Resources.Namespaces, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+			})
+		}
+		return s
+	}
+
+	cases := []struct {
+		name     string
+		snapshot func() models.Snapshot
+		want     bool
+	}{
+		{
+			name:     "manifest mode (no namespaces) — never emit",
+			snapshot: func() models.Snapshot { return models.Snapshot{} },
+			want:     false,
+		},
+		{
+			name: "single namespace, no PSA, no engines — emit",
+			snapshot: func() models.Snapshot {
+				return withNamespaces(map[string]map[string]string{"default": nil})
+			},
+			want: true,
+		},
+		{
+			name: "PSA enforce restricted on any namespace — suppress",
+			snapshot: func() models.Snapshot {
+				return withNamespaces(map[string]map[string]string{
+					"default": nil,
+					"prod":    {"pod-security.kubernetes.io/enforce": "restricted"},
+				})
+			},
+			want: false,
+		},
+		{
+			name: "PSA enforce baseline on any namespace — suppress",
+			snapshot: func() models.Snapshot {
+				return withNamespaces(map[string]map[string]string{
+					"prod": {"pod-security.kubernetes.io/enforce": "baseline"},
+				})
+			},
+			want: false,
+		},
+		{
+			name: "PSA enforce privileged is not a defense — emit",
+			snapshot: func() models.Snapshot {
+				// HasEnforce() returns false for privileged level (it's the most permissive
+				// PSS level — blocks nothing), so the posture finding should still fire.
+				return withNamespaces(map[string]map[string]string{
+					"default": {"pod-security.kubernetes.io/enforce": "privileged"},
+				})
+			},
+			want: true,
+		},
+		{
+			name: "PSA audit-only — not a defense, emit",
+			snapshot: func() models.Snapshot {
+				// audit and warn modes log violations but don't reject creates/updates.
+				return withNamespaces(map[string]map[string]string{
+					"default": {"pod-security.kubernetes.io/audit": "restricted"},
+				})
+			},
+			want: true,
+		},
+		{
+			name: "VAP present — suppress",
+			snapshot: func() models.Snapshot {
+				s := withNamespaces(map[string]map[string]string{"default": nil})
+				s.Resources.ValidatingAdmissionPolicies = []admissionregistrationv1.ValidatingAdmissionPolicy{{}}
+				return s
+			},
+			want: false,
+		},
+		{
+			name: "Kyverno ClusterPolicy present — suppress",
+			snapshot: func() models.Snapshot {
+				s := withNamespaces(map[string]map[string]string{"default": nil})
+				s.Resources.KyvernoClusterPolicies = []unstructured.Unstructured{{}}
+				return s
+			},
+			want: false,
+		},
+		{
+			name: "Kyverno namespaced Policy present — suppress",
+			snapshot: func() models.Snapshot {
+				s := withNamespaces(map[string]map[string]string{"default": nil})
+				s.Resources.KyvernoPolicies = []unstructured.Unstructured{{}}
+				return s
+			},
+			want: false,
+		},
+		{
+			name: "Gatekeeper ConstraintTemplate present — suppress",
+			snapshot: func() models.Snapshot {
+				s := withNamespaces(map[string]map[string]string{"default": nil})
+				s.Resources.GatekeeperConstraintTemplates = []unstructured.Unstructured{{}}
+				return s
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldEmitNoPolicyEngineFinding(tc.snapshot()); got != tc.want {
+				t.Errorf("shouldEmitNoPolicyEngineFinding = %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAnalyzerEmitsNoPolicyEngineFinding(t *testing.T) {
+	t.Parallel()
+	snapshot := models.Snapshot{}
+	snapshot.Resources.Namespaces = []corev1.Namespace{{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	assertRulePresent(t, findings, "KUBE-ADMISSION-NO-POLICY-ENGINE-001")
+
+	// And confirm the finding has the expected shape: cluster-wide (no Resource),
+	// MEDIUM, with the right tags.
+	for _, f := range findings {
+		if f.RuleID != "KUBE-ADMISSION-NO-POLICY-ENGINE-001" {
+			continue
+		}
+		if f.Severity != models.SeverityMedium {
+			t.Errorf("expected MEDIUM, got %v", f.Severity)
+		}
+		if f.Resource != nil {
+			t.Errorf("posture finding should be cluster-wide (Resource=nil), got %+v", f.Resource)
+		}
+		var sawModule, sawCheck bool
+		for _, tag := range f.Tags {
+			if tag == "module:admission" {
+				sawModule = true
+			}
+			if tag == "check:no_policy_engine" {
+				sawCheck = true
+			}
+		}
+		if !sawModule || !sawCheck {
+			t.Errorf("expected module:admission and check:no_policy_engine tags, got %v", f.Tags)
+		}
+	}
 }

--- a/internal/analyzer/admission/content.go
+++ b/internal/analyzer/admission/content.go
@@ -39,6 +39,10 @@ var (
 	refK8sAdmissionFP = models.Reference{Title: "Kubernetes — failurePolicy semantics", URL: "https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy"}
 	refNSAHardening   = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
 	refOPABestPrac    = models.Reference{Title: "OPA Gatekeeper — Production best practices", URL: "https://open-policy-agent.github.io/gatekeeper/website/docs/operations"}
+	refK8sPSA         = models.Reference{Title: "Kubernetes — Pod Security Admission", URL: "https://kubernetes.io/docs/concepts/security/pod-security-admission/"}
+	refK8sPSS         = models.Reference{Title: "Kubernetes — Pod Security Standards", URL: "https://kubernetes.io/docs/concepts/security/pod-security-standards/"}
+	refK8sVAP         = models.Reference{Title: "Kubernetes — ValidatingAdmissionPolicy (CEL)", URL: "https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/"}
+	refKyvernoIntro   = models.Reference{Title: "Kyverno — Introduction", URL: "https://kyverno.io/docs/introduction/"}
 )
 
 // scopeForWebhook returns the scope label for an admission webhook configuration.
@@ -151,5 +155,48 @@ func contentAdmission003(configKind, configName, webhookName string) ruleContent
 			refOPABestPrac,
 		},
 		MitreTechniques: []models.MitreTechnique{mitreT1562, mitreT1611, mitreT1578},
+	}
+}
+
+// contentNoPolicyEngine is the cluster-wide posture finding emitted when a
+// snapshot has no PSA enforce labels in any namespace and no detected policy
+// engine (ValidatingAdmissionPolicy, Kyverno, or Gatekeeper). The remediation
+// names every option so operators can pick the one that fits their stack.
+func contentNoPolicyEngine() ruleContent {
+	return ruleContent{
+		Title: "Cluster has no Pod Security Admission labels and no detected policy engine",
+		Scope: models.Scope{
+			Level:  models.ScopeCluster,
+			Detail: "Applies cluster-wide. No namespace carries `pod-security.kubernetes.io/enforce=baseline|restricted` and no ValidatingAdmissionPolicy / Kyverno / Gatekeeper resources were observed in the snapshot.",
+		},
+		Description: "Kubesplaining inspected every namespace in this snapshot and found zero `pod-security.kubernetes.io/enforce` labels at the `baseline` or `restricted` level. It also found zero `ValidatingAdmissionPolicy` resources, zero Kyverno `(Cluster)Policy` resources, and zero Gatekeeper `ConstraintTemplate` resources. Together these are the four statically-detectable defenses against privileged or otherwise dangerous pod specs being admitted to the cluster.\n\n" +
+			"With none of them in place, an attacker (or a careless developer) who can `create pods` in any namespace can submit a manifest with `securityContext.privileged: true`, `hostPID: true`, `hostNetwork: true`, `hostPath: /`, or `runAsUser: 0` and the API server will admit it without challenge. There is no in-tree backstop: the legacy PodSecurityPolicy admission controller was removed in Kubernetes v1.25, and Pod Security Admission only enforces what each namespace's labels ask for. A namespace without an enforce label is a permissive namespace.\n\n" +
+			"This finding is *posture*, not workload-specific. The reason every other host-level finding in this report (KUBE-ESCAPE-*, KUBE-PODSEC-*, KUBE-HOSTPATH-*) is unmitigated by admission is that this cluster has no admission control to mitigate them. Fixing this one finding is the highest-leverage action: it does not patch any individual workload, but it prevents the next privileged pod from being admitted at all.\n\n" +
+			"There are three viable paths, in order of decreasing operational cost: (1) apply Pod Security Admission labels to every namespace (in-tree, no install required, but you have to label every namespace and decide on the right level per namespace); (2) install Kyverno or Gatekeeper for richer policy expression with audit + warn + enforce modes (an operator install plus per-rule authoring); (3) author one or more `ValidatingAdmissionPolicy` resources for K8s-native CEL-based policies (no install but requires v1.30+ and CEL fluency). Most teams pair (1) with one of (2)/(3) for defense in depth.",
+		Impact: "Any user with `create pods` in any namespace can admit a pod that mounts the host filesystem, runs as root, or shares the host's network/PID/IPC namespaces — all without admission-time intervention. From there the standard escape-to-host kill chain is available cluster-wide.",
+		AttackScenario: []string{
+			"Attacker compromises a workload, ServiceAccount token, or developer kubeconfig that has `create pods` permission in any namespace (most internal namespaces grant this by default).",
+			"They craft a pod manifest with `hostPID: true`, `hostNetwork: true`, `securityContext.privileged: true`, and `volumes: [{hostPath: {path: /}}]` mounted at `/host`.",
+			"They `kubectl apply` the manifest. The API server runs through built-in admission, finds no PSA enforce label and no policy-engine webhook, and admits the pod.",
+			"The pod schedules on a node, mounts the host root filesystem, and the attacker `chroot`s into `/host` — they now have root on a Kubernetes node with full visibility into every container, secret, and network connection on it.",
+			"From the node they read `/var/lib/kubelet/pki/*` and `/etc/kubernetes/*` (when present), enumerate other nodes via the kubelet API, and pivot to control-plane material for full cluster takeover.",
+		},
+		Remediation: "Apply Pod Security Admission labels to every namespace at the appropriate level (`baseline` minimum, `restricted` for tenant workloads), or install Kyverno / Gatekeeper, or author ValidatingAdmissionPolicy resources. Pair PSA with a policy engine for defense in depth.",
+		RemediationSteps: []string{
+			"Inventory namespaces: `kubectl get namespaces -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'`. Decide a default level per namespace — `restricted` for application workloads, `baseline` only where a workload genuinely needs it, `privileged` only for control-plane components that must run with host access.",
+			"Label namespaces: `kubectl label namespace <ns> pod-security.kubernetes.io/enforce=restricted pod-security.kubernetes.io/audit=restricted pod-security.kubernetes.io/warn=restricted`. PSA only checks creates and updates, so existing pods continue to run; you'll see `audit`/`warn` log entries for the survivors so you can roll them out gradually.",
+			"For richer policy expression, install Kyverno (`helm install kyverno kyverno/kyverno -n kyverno --create-namespace`) or Gatekeeper (`helm install gatekeeper gatekeeper/gatekeeper -n gatekeeper-system --create-namespace`) and adopt one of the published policy bundles (Kyverno's `pod-security` set, Gatekeeper's `gatekeeper-library`).",
+			"For K8s-native CEL policies on v1.30+, author `ValidatingAdmissionPolicy` resources for the rules you care about most (e.g. block `securityContext.privileged: true` cluster-wide). Bind them with `ValidatingAdmissionPolicyBinding` and use `audit` mode first to size the impact before flipping to `deny`.",
+			"Re-run kubesplaining: this posture finding will disappear, and individual workload findings will start being suppressed (default) or attenuated (`--admission-mode=attenuate`) when the admission controls would block them.",
+		},
+		LearnMore: []models.Reference{
+			refK8sPSA,
+			refK8sPSS,
+			refK8sVAP,
+			refKyvernoIntro,
+			refOPABestPrac,
+			refNSAHardening,
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1562, mitreT1611, mitreT1525},
 	}
 }

--- a/internal/analyzer/admission/mitigation/detection.go
+++ b/internal/analyzer/admission/mitigation/detection.go
@@ -1,0 +1,45 @@
+package mitigation
+
+import "sort"
+
+// Engine names for the admission:policy-engine-detected:* tag suffix and for
+// AdmissionSummary.PolicyEnginesDetected entries. Keep these stable — they
+// surface in JSON, CSV, and SARIF outputs.
+const (
+	EngineKyverno    = "kyverno"
+	EngineGatekeeper = "gatekeeper"
+	EngineVAP        = "vap"
+)
+
+// PolicyEngines records which admission policy engines have observed resources
+// in a snapshot. Phase 2 only checks presence; Phase 3 (CEL evaluation of VAP)
+// and Phase 4 (operator attestation for Kyverno/Gatekeeper) consume the same
+// snapshot fields more deeply.
+type PolicyEngines struct {
+	Kyverno    bool // any Kyverno (Cluster)Policy observed
+	Gatekeeper bool // any Gatekeeper ConstraintTemplate observed
+	VAP        bool // any ValidatingAdmissionPolicy observed
+}
+
+// Names returns the detected engines as a sorted, deduplicated slice
+// (e.g. ["gatekeeper", "kyverno", "vap"]). Suitable for tag emission and
+// AdmissionSummary.PolicyEnginesDetected.
+func (p PolicyEngines) Names() []string {
+	names := make([]string, 0, 3)
+	if p.Gatekeeper {
+		names = append(names, EngineGatekeeper)
+	}
+	if p.Kyverno {
+		names = append(names, EngineKyverno)
+	}
+	if p.VAP {
+		names = append(names, EngineVAP)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Any reports whether at least one engine was detected.
+func (p PolicyEngines) Any() bool {
+	return p.Kyverno || p.Gatekeeper || p.VAP
+}

--- a/internal/analyzer/admission/mitigation/detection_test.go
+++ b/internal/analyzer/admission/mitigation/detection_test.go
@@ -1,0 +1,58 @@
+package mitigation
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPolicyEnginesAny(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		engines PolicyEngines
+		want    bool
+	}{
+		{"empty", PolicyEngines{}, false},
+		{"kyverno only", PolicyEngines{Kyverno: true}, true},
+		{"gatekeeper only", PolicyEngines{Gatekeeper: true}, true},
+		{"vap only", PolicyEngines{VAP: true}, true},
+		{"all three", PolicyEngines{Kyverno: true, Gatekeeper: true, VAP: true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.engines.Any(); got != tc.want {
+				t.Errorf("Any() = %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPolicyEnginesNames(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		engines PolicyEngines
+		want    []string
+	}{
+		{"empty", PolicyEngines{}, []string{}},
+		{"kyverno only", PolicyEngines{Kyverno: true}, []string{"kyverno"}},
+		{"gatekeeper only", PolicyEngines{Gatekeeper: true}, []string{"gatekeeper"}},
+		{"vap only", PolicyEngines{VAP: true}, []string{"vap"}},
+		// Sort stability: regardless of struct field order, output is alphabetical so
+		// downstream JSON / SARIF consumers see a deterministic list.
+		{"kyverno+vap", PolicyEngines{Kyverno: true, VAP: true}, []string{"kyverno", "vap"}},
+		{"all three", PolicyEngines{Kyverno: true, Gatekeeper: true, VAP: true}, []string{"gatekeeper", "kyverno", "vap"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.engines.Names()
+			// Treat nil and empty slice as equal — the empty-input case wants []string{}.
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Names() = %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/analyzer/admission_policy_engine.go
+++ b/internal/analyzer/admission_policy_engine.go
@@ -1,0 +1,80 @@
+package analyzer
+
+import (
+	"github.com/0hardik1/kubesplaining/internal/analyzer/admission/mitigation"
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// ruleIDNoPolicyEngine is the cluster-wide posture finding emitted by the
+// admission analyzer when no namespace carries a PSA enforce label and no
+// policy-engine resources were observed. The engine stage strips this
+// finding when --admission-mode=off, since users who opt out of admission
+// reasoning don't want it surfaced.
+const ruleIDNoPolicyEngine = "KUBE-ADMISSION-NO-POLICY-ENGINE-001"
+
+// applyPolicyEnginePresenceTags is the second admission-aware engine stage,
+// running after applyAdmissionMitigations and before correlate/dedupe. It:
+//
+//  1. Derives the PolicyEngines state from snapshot CRD fields and writes the
+//     sorted engine list onto summary.PolicyEnginesDetected.
+//  2. Strips the KUBE-ADMISSION-NO-POLICY-ENGINE-001 posture finding when
+//     mode == off (the admission analyzer always emits it when conditions are
+//     met; the engine decides whether the user wants to see it).
+//  3. Tags every surviving pod-security finding with
+//     admission:policy-engine-detected:<engine> — one tag per detected engine.
+//     Score is unchanged: this is a presence signal, not a mitigation. We tag
+//     only survivors of suppression because PSA-suppressed findings are already
+//     gone from the slice (the previous stage dropped them) and re-walking the
+//     original slice to tag invisible findings adds no value.
+//  4. Bumps summary.PolicyEngineTagged once per tagged finding (not once per
+//     engine), so a finding that gets both kyverno and vap tags counts as one.
+func applyPolicyEnginePresenceTags(
+	findings []models.Finding,
+	snapshot models.Snapshot,
+	summary models.AdmissionSummary,
+	mode AdmissionMode,
+) ([]models.Finding, models.AdmissionSummary) {
+	engines := detectPolicyEngines(snapshot)
+	summary.PolicyEnginesDetected = engines.Names()
+
+	if mode == AdmissionModeOff {
+		out := findings[:0]
+		for _, f := range findings {
+			if f.RuleID == ruleIDNoPolicyEngine {
+				continue
+			}
+			out = append(out, f)
+		}
+		return out, summary
+	}
+
+	if !engines.Any() {
+		return findings, summary
+	}
+
+	names := engines.Names()
+	for i := range findings {
+		if !isPodSecurityFinding(findings[i]) {
+			continue
+		}
+		for _, name := range names {
+			findings[i].Tags = appendUnique(findings[i].Tags, "admission:policy-engine-detected:"+name)
+		}
+		summary.PolicyEngineTagged++
+	}
+	return findings, summary
+}
+
+// detectPolicyEngines reads the four snapshot fields populated by the collector's
+// Phase 2 list operations and reports which engines have at least one observed
+// resource. Both Kyverno fields (ClusterPolicies and namespaced Policies) count
+// as Kyverno presence; Gatekeeper presence is keyed off ConstraintTemplate
+// (the user-facing Constraints are dynamically-typed CRDs deferred to Phase 3/4).
+func detectPolicyEngines(snapshot models.Snapshot) mitigation.PolicyEngines {
+	return mitigation.PolicyEngines{
+		Kyverno: len(snapshot.Resources.KyvernoClusterPolicies) > 0 ||
+			len(snapshot.Resources.KyvernoPolicies) > 0,
+		Gatekeeper: len(snapshot.Resources.GatekeeperConstraintTemplates) > 0,
+		VAP:        len(snapshot.Resources.ValidatingAdmissionPolicies) > 0,
+	}
+}

--- a/internal/analyzer/admission_policy_engine_test.go
+++ b/internal/analyzer/admission_policy_engine_test.go
@@ -1,0 +1,240 @@
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// snapshotWithEngines stuffs minimal placeholder objects into the snapshot's
+// policy-engine fields so detectPolicyEngines() reports the requested engines.
+// Each boolean adds one no-name placeholder to the relevant slice — enough to
+// flip the len() > 0 check.
+func snapshotWithEngines(kyverno, gatekeeper, vap bool) models.Snapshot {
+	s := models.Snapshot{}
+	if kyverno {
+		s.Resources.KyvernoClusterPolicies = []unstructured.Unstructured{{}}
+	}
+	if gatekeeper {
+		s.Resources.GatekeeperConstraintTemplates = []unstructured.Unstructured{{}}
+	}
+	if vap {
+		s.Resources.ValidatingAdmissionPolicies = []admissionregistrationv1.ValidatingAdmissionPolicy{{}}
+	}
+	return s
+}
+
+func TestPolicyEngineDetectionPopulatesSummary(t *testing.T) {
+	t.Parallel()
+	mod := &stubModule{name: "podsec"}
+	snapshot := snapshotWithEngines(true, false, true)
+	// Add a namespace so the engine has something to look at.
+	snapshot.Resources.Namespaces = []corev1.Namespace{{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Labels: map[string]string{"pod-security.kubernetes.io/enforce": "restricted"}},
+	}}
+
+	result, err := engineWith(mod).Analyze(context.Background(), snapshot, Options{AdmissionMode: AdmissionModeSuppress})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	want := []string{"kyverno", "vap"}
+	if len(result.Admission.PolicyEnginesDetected) != len(want) {
+		t.Fatalf("PolicyEnginesDetected = %v want %v", result.Admission.PolicyEnginesDetected, want)
+	}
+	for i := range want {
+		if result.Admission.PolicyEnginesDetected[i] != want[i] {
+			t.Errorf("PolicyEnginesDetected[%d] = %q want %q", i, result.Admission.PolicyEnginesDetected[i], want[i])
+		}
+	}
+}
+
+func TestPolicyEngineTagAppliedPerEngine(t *testing.T) {
+	t.Parallel()
+	mod := &stubModule{
+		name: "podsec",
+		findings: []models.Finding{
+			podsecFinding("priv:dev", "KUBE-ESCAPE-001", "dev", "privileged", models.SeverityCritical, 9.9),
+		},
+	}
+	snapshot := snapshotWithEngines(true, true, true)
+	snapshot.Resources.Namespaces = []corev1.Namespace{{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev"},
+	}}
+
+	result, err := engineWith(mod).Analyze(context.Background(), snapshot, Options{AdmissionMode: AdmissionModeSuppress})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 surviving finding, got %d", len(result.Findings))
+	}
+	for _, want := range []string{
+		"admission:policy-engine-detected:gatekeeper",
+		"admission:policy-engine-detected:kyverno",
+		"admission:policy-engine-detected:vap",
+	} {
+		if !hasTag(result.Findings[0].Tags, want) {
+			t.Errorf("missing tag %q in %v", want, result.Findings[0].Tags)
+		}
+	}
+	// One finding tagged, three engines — counter increments once per finding.
+	if result.Admission.PolicyEngineTagged != 1 {
+		t.Errorf("PolicyEngineTagged = %d want 1", result.Admission.PolicyEngineTagged)
+	}
+	// Score must be unchanged: tag is informational, not a mitigation.
+	if result.Findings[0].Score != 9.9 {
+		t.Errorf("Score changed by tagging: got %v want 9.9", result.Findings[0].Score)
+	}
+}
+
+func TestPolicyEngineNoEnginesNoTag(t *testing.T) {
+	t.Parallel()
+	mod := &stubModule{
+		name: "podsec",
+		findings: []models.Finding{
+			podsecFinding("priv:dev", "KUBE-ESCAPE-001", "dev", "privileged", models.SeverityCritical, 9.9),
+		},
+	}
+	// No engines, but at least one namespace with PSA enforce so the posture
+	// finding doesn't fire and noise this test.
+	snapshot := snapshotWithLabeledNamespaces(map[string]string{"dev": "restricted"})
+
+	result, err := engineWith(mod).Analyze(context.Background(), snapshot, Options{AdmissionMode: AdmissionModeSuppress})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	for _, finding := range result.Findings {
+		for _, tag := range finding.Tags {
+			if len(tag) >= len("admission:policy-engine-detected:") &&
+				tag[:len("admission:policy-engine-detected:")] == "admission:policy-engine-detected:" {
+				t.Errorf("unexpected policy-engine-detected tag with no engines: %s", tag)
+			}
+		}
+	}
+	if result.Admission.PolicyEngineTagged != 0 {
+		t.Errorf("PolicyEngineTagged = %d want 0", result.Admission.PolicyEngineTagged)
+	}
+}
+
+func TestPolicyEngineSuppressedFindingNotTagged(t *testing.T) {
+	t.Parallel()
+	mod := &stubModule{
+		name: "podsec",
+		findings: []models.Finding{
+			podsecFinding("priv:prod", "KUBE-ESCAPE-001", "prod", "privileged", models.SeverityCritical, 9.9),
+			podsecFinding("priv:dev", "KUBE-ESCAPE-001", "dev", "privileged", models.SeverityCritical, 9.9),
+		},
+	}
+	snapshot := snapshotWithEngines(true, false, false) // Kyverno detected
+	// prod has restricted enforce so its priv finding is suppressed; dev has none.
+	snapshot.Resources.Namespaces = []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "prod", Labels: map[string]string{"pod-security.kubernetes.io/enforce": "restricted"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "dev"}},
+	}
+
+	result, err := engineWith(mod).Analyze(context.Background(), snapshot, Options{AdmissionMode: AdmissionModeSuppress})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	// Only the dev finding should survive, and it should carry the kyverno tag.
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 surviving finding (dev), got %d", len(result.Findings))
+	}
+	if result.Findings[0].Namespace != "dev" {
+		t.Errorf("expected dev finding to survive, got %q", result.Findings[0].Namespace)
+	}
+	if !hasTag(result.Findings[0].Tags, "admission:policy-engine-detected:kyverno") {
+		t.Errorf("expected dev finding to carry kyverno tag, got %v", result.Findings[0].Tags)
+	}
+	// Counter is once per surviving tagged finding (the suppressed one is gone).
+	if result.Admission.PolicyEngineTagged != 1 {
+		t.Errorf("PolicyEngineTagged = %d want 1 (suppressed finding shouldn't count)", result.Admission.PolicyEngineTagged)
+	}
+}
+
+func TestPolicyEngineModeOffStripsPostureFinding(t *testing.T) {
+	t.Parallel()
+	// Inject a fake posture finding via a stub module; the engine stage should drop
+	// it when mode == off because users opted out of admission reasoning.
+	mod := &stubModule{
+		name: "admission",
+		findings: []models.Finding{
+			{
+				ID:       "KUBE-ADMISSION-NO-POLICY-ENGINE-001",
+				RuleID:   "KUBE-ADMISSION-NO-POLICY-ENGINE-001",
+				Severity: models.SeverityMedium,
+				Score:    4.0,
+				Tags:     []string{"module:admission", "check:no_policy_engine"},
+			},
+			{
+				ID:       "KUBE-ADMISSION-001:foo",
+				RuleID:   "KUBE-ADMISSION-001",
+				Severity: models.SeverityHigh,
+				Score:    7.9,
+				Tags:     []string{"module:admission"},
+			},
+		},
+	}
+	snapshot := models.Snapshot{}
+
+	result, err := engineWith(mod).Analyze(context.Background(), snapshot, Options{AdmissionMode: AdmissionModeOff})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	for _, f := range result.Findings {
+		if f.RuleID == "KUBE-ADMISSION-NO-POLICY-ENGINE-001" {
+			t.Errorf("posture finding should be stripped when mode=off, got %+v", f)
+		}
+	}
+	// The unrelated KUBE-ADMISSION-001 finding must still be present.
+	var sawAdm001 bool
+	for _, f := range result.Findings {
+		if f.RuleID == "KUBE-ADMISSION-001" {
+			sawAdm001 = true
+		}
+	}
+	if !sawAdm001 {
+		t.Errorf("non-posture admission finding was lost: %+v", result.Findings)
+	}
+}
+
+func TestPolicyEnginePostureFindingNotAttenuated(t *testing.T) {
+	t.Parallel()
+	// Regression guard: the KUBE-ADMISSION-NO-POLICY-ENGINE-001 finding carries
+	// module:admission (not module:pod_security), so the PSA mitigation stage's
+	// isPodSecurityFinding check must return false and leave it untouched even
+	// when mode == attenuate and a namespace has enforce labels.
+	mod := &stubModule{
+		name: "admission",
+		findings: []models.Finding{
+			{
+				ID:        "KUBE-ADMISSION-NO-POLICY-ENGINE-001",
+				RuleID:    "KUBE-ADMISSION-NO-POLICY-ENGINE-001",
+				Severity:  models.SeverityMedium,
+				Score:     4.0,
+				Namespace: "", // cluster-wide
+				Tags:      []string{"module:admission", "check:no_policy_engine"},
+			},
+		},
+	}
+	snapshot := snapshotWithLabeledNamespaces(map[string]string{"prod": "restricted"})
+
+	result, err := engineWith(mod).Analyze(context.Background(), snapshot, Options{AdmissionMode: AdmissionModeAttenuate})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected posture finding to survive attenuation, got %d", len(result.Findings))
+	}
+	if result.Findings[0].Severity != models.SeverityMedium || result.Findings[0].Score != 4.0 {
+		t.Errorf("posture finding was attenuated: severity=%v score=%v", result.Findings[0].Severity, result.Findings[0].Score)
+	}
+	if hasTag(result.Findings[0].Tags, "admission:mitigated-psa-restricted") {
+		t.Errorf("posture finding should not carry mitigated-psa tag, got %v", result.Findings[0].Tags)
+	}
+}

--- a/internal/analyzer/engine.go
+++ b/internal/analyzer/engine.go
@@ -122,6 +122,7 @@ func (e *Engine) Analyze(ctx context.Context, snapshot models.Snapshot, opts Opt
 	wg.Wait()
 
 	findings, admissionSummary := applyAdmissionMitigations(findings, snapshot, mode)
+	findings, admissionSummary = applyPolicyEnginePresenceTags(findings, snapshot, admissionSummary, mode)
 	findings = correlate(findings)
 	findings = dedupe(findings)
 

--- a/internal/cli/download.go
+++ b/internal/cli/download.go
@@ -77,7 +77,12 @@ func NewDownloadCmd(build BuildInfo) *cobra.Command {
 				return err
 			}
 
-			c := collector.New(clientset, config, collector.Options{
+			dyn, err := connection.NewDynamicClient(config)
+			if err != nil {
+				return err
+			}
+
+			c := collector.New(clientset, dyn, config, collector.Options{
 				Namespaces:           namespaces,
 				ExcludeNamespaces:    excludeNamespaces,
 				IncludeManagedFields: includeManagedFields,

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -144,7 +144,12 @@ func loadOrCollectSnapshot(
 		return models.Snapshot{}, err
 	}
 
-	c := collector.New(clientset, config, collector.Options{
+	dyn, err := connection.NewDynamicClient(config)
+	if err != nil {
+		return models.Snapshot{}, err
+	}
+
+	c := collector.New(clientset, dyn, config, collector.Options{
 		Namespaces:           namespaces,
 		ExcludeNamespaces:    excludeNamespaces,
 		IncludeManagedFields: includeManagedFields,

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -19,7 +19,11 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -35,21 +39,25 @@ type Options struct {
 
 // Collector lists cluster resources and produces a models.Snapshot.
 type Collector struct {
-	client kubernetes.Interface
-	config *rest.Config
-	opts   Options
+	client  kubernetes.Interface
+	dynamic dynamic.Interface
+	config  *rest.Config
+	opts    Options
 }
 
 // New constructs a Collector with defaulted options (parallelism defaults to 10 when unset or non-positive).
-func New(client kubernetes.Interface, config *rest.Config, opts Options) *Collector {
+// dyn may be nil; when nil, dynamic-client list operations (Kyverno/Gatekeeper CRDs) are skipped
+// and recorded as warnings rather than failing.
+func New(client kubernetes.Interface, dyn dynamic.Interface, config *rest.Config, opts Options) *Collector {
 	if opts.Parallelism <= 0 {
 		opts.Parallelism = 10
 	}
 
 	return &Collector{
-		client: client,
-		config: config,
-		opts:   opts,
+		client:  client,
+		dynamic: dyn,
+		config:  config,
+		opts:    opts,
 	}
 }
 
@@ -94,6 +102,13 @@ func (c *Collector) Collect(ctx context.Context) (models.Snapshot, error) {
 				switch {
 				case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
 					recordMissing(resource, err)
+				case meta.IsNoMatchError(err), apierrors.IsNotFound(err):
+					// CRD isn't installed (Kyverno/Gatekeeper not deployed, or the API
+					// server doesn't serve VAP). Not a failure, not a permissions issue —
+					// just an absent resource. Record as a warning so operators see what
+					// we tried, but don't add to PermissionsMissing (which implies "you
+					// should grant access").
+					recordWarning(fmt.Sprintf("%s: %v", resource, err))
 				default:
 					recordWarning(fmt.Sprintf("%s: %v", resource, err))
 					mu.Lock()
@@ -483,6 +498,110 @@ func (c *Collector) Collect(ctx context.Context) (models.Snapshot, error) {
 		return nil
 	})
 
+	// VAP graduated to GA in Kubernetes v1.30. On older clusters the typed list
+	// returns NotFound; the runTask switch downgrades that to a warning.
+	runTask("validatingadmissionpolicies", func() error {
+		list, err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		items := make([]admissionregistrationv1.ValidatingAdmissionPolicy, 0, len(list.Items))
+		for _, item := range list.Items {
+			items = append(items, sanitizeValidatingAdmissionPolicy(item, c.opts.IncludeManagedFields))
+		}
+
+		mu.Lock()
+		snapshot.Resources.ValidatingAdmissionPolicies = items
+		mu.Unlock()
+		return nil
+	})
+
+	runTask("validatingadmissionpolicybindings", func() error {
+		list, err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		items := make([]admissionregistrationv1.ValidatingAdmissionPolicyBinding, 0, len(list.Items))
+		for _, item := range list.Items {
+			items = append(items, sanitizeValidatingAdmissionPolicyBinding(item, c.opts.IncludeManagedFields))
+		}
+
+		mu.Lock()
+		snapshot.Resources.ValidatingAdmissionPolicyBindings = items
+		mu.Unlock()
+		return nil
+	})
+
+	// Kyverno and Gatekeeper are CRDs — use the dynamic client (when available)
+	// and pre-flight on Discovery().ServerGroups() so we skip the list entirely
+	// when the API group isn't served. Avoids a per-engine NoMatchError round-trip
+	// on clusters where the engine isn't installed.
+	if c.dynamic != nil {
+		apiGroups := map[string]bool{}
+		groupsList, groupsErr := c.client.Discovery().ServerGroups()
+		if groupsErr == nil {
+			for _, g := range groupsList.Groups {
+				apiGroups[g.Name] = true
+			}
+		}
+		hasGroup := func(name string) bool {
+			if groupsErr != nil {
+				// Discovery failed — fall through to dynamic list, which will return
+				// NoMatchError if the group is absent (handled by runTask switch).
+				return true
+			}
+			return apiGroups[name]
+		}
+
+		if hasGroup("kyverno.io") {
+			runTask("kyverno.clusterpolicies", func() error {
+				gvr := schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "clusterpolicies"}
+				list, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				mu.Lock()
+				snapshot.Resources.KyvernoClusterPolicies = list.Items
+				mu.Unlock()
+				return nil
+			})
+
+			runTask("kyverno.policies", func() error {
+				gvr := schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "policies"}
+				list, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				items := make([]unstructured.Unstructured, 0, len(list.Items))
+				for _, item := range list.Items {
+					if c.includeNamespace(item.GetNamespace()) {
+						items = append(items, item)
+					}
+				}
+				mu.Lock()
+				snapshot.Resources.KyvernoPolicies = items
+				mu.Unlock()
+				return nil
+			})
+		}
+
+		if hasGroup("templates.gatekeeper.sh") {
+			runTask("gatekeeper.constrainttemplates", func() error {
+				gvr := schema.GroupVersionResource{Group: "templates.gatekeeper.sh", Version: "v1", Resource: "constrainttemplates"}
+				list, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				mu.Lock()
+				snapshot.Resources.GatekeeperConstraintTemplates = list.Items
+				mu.Unlock()
+				return nil
+			})
+		}
+	}
+
 	wg.Wait()
 
 	snapshot.Metadata.CollectionWarnings = dedupeStrings(warnings)
@@ -644,6 +763,16 @@ func sanitizeValidatingWebhookConfiguration(obj admissionregistrationv1.Validati
 }
 
 func sanitizeMutatingWebhookConfiguration(obj admissionregistrationv1.MutatingWebhookConfiguration, includeManagedFields bool) admissionregistrationv1.MutatingWebhookConfiguration {
+	obj.ManagedFields = maybeManagedFields(nil, includeManagedFields, obj.ManagedFields)
+	return obj
+}
+
+func sanitizeValidatingAdmissionPolicy(obj admissionregistrationv1.ValidatingAdmissionPolicy, includeManagedFields bool) admissionregistrationv1.ValidatingAdmissionPolicy {
+	obj.ManagedFields = maybeManagedFields(nil, includeManagedFields, obj.ManagedFields)
+	return obj
+}
+
+func sanitizeValidatingAdmissionPolicyBinding(obj admissionregistrationv1.ValidatingAdmissionPolicyBinding, includeManagedFields bool) admissionregistrationv1.ValidatingAdmissionPolicyBinding {
 	obj.ManagedFields = maybeManagedFields(nil, includeManagedFields, obj.ManagedFields)
 	return obj
 }

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,6 +58,18 @@ func NewClientset(opts Options) (*kubernetes.Clientset, *rest.Config, error) {
 	}
 
 	return clientset, cfg, nil
+}
+
+// NewDynamicClient builds a dynamic client for listing CRD-backed resources
+// (Kyverno policies, Gatekeeper constraint templates) that aren't part of the
+// typed kubernetes.Interface. Shares the rest.Config built by BuildConfig so
+// auth and timeout knobs flow through unchanged.
+func NewDynamicClient(cfg *rest.Config) (dynamic.Interface, error) {
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create dynamic client: %w", err)
+	}
+	return dyn, nil
 }
 
 // buildKubeconfig loads a rest.Config from the user's kubeconfig, honoring an explicit path and context override.

--- a/internal/models/admission.go
+++ b/internal/models/admission.go
@@ -23,4 +23,12 @@ type AdmissionSummary struct {
 	// SuppressedByNamespace breaks down Suppressed by namespace then RuleID for
 	// per-namespace tooltips in the HTML report.
 	SuppressedByNamespace map[string]map[string]int `json:"suppressed_by_namespace,omitempty"`
+	// PolicyEnginesDetected lists policy engines whose resources were observed in
+	// the snapshot, sorted alphabetically (e.g. ["gatekeeper", "kyverno", "vap"]).
+	// Empty when none. Populated by the engine's policy-engine-presence stage.
+	PolicyEnginesDetected []string `json:"policy_engines_detected,omitempty"`
+	// PolicyEngineTagged counts findings that received an admission:policy-engine-detected:*
+	// tag. A single finding may carry tags for multiple engines, but it bumps this
+	// counter once per finding (not once per engine).
+	PolicyEngineTagged int `json:"policy_engine_tagged,omitempty"`
 }

--- a/internal/models/snapshot.go
+++ b/internal/models/snapshot.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Snapshot is the in-memory representation of everything the collector pulled from a cluster;
@@ -55,6 +56,20 @@ type SnapshotResources struct {
 	NetworkPolicies          []networkingv1.NetworkPolicy                             `json:"network_policies,omitempty"`
 	ValidatingWebhookConfigs []admissionregistrationv1.ValidatingWebhookConfiguration `json:"validating_webhook_configs,omitempty"`
 	MutatingWebhookConfigs   []admissionregistrationv1.MutatingWebhookConfiguration   `json:"mutating_webhook_configs,omitempty"`
+	// ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings are the in-tree
+	// CEL-based admission policies (GA in Kubernetes v1.30). Phase 2 collects them for
+	// presence detection; Phase 3 will evaluate the CEL expressions offline.
+	ValidatingAdmissionPolicies       []admissionregistrationv1.ValidatingAdmissionPolicy        `json:"validating_admission_policies,omitempty"`
+	ValidatingAdmissionPolicyBindings []admissionregistrationv1.ValidatingAdmissionPolicyBinding `json:"validating_admission_policy_bindings,omitempty"`
+	// KyvernoClusterPolicies and KyvernoPolicies hold Kyverno (Cluster)Policies as
+	// unstructured.Unstructured so we don't take a typed dependency on Kyverno's CRDs.
+	// Split mirrors the (Cluster)Role precedent so consumers preserve scope.
+	KyvernoClusterPolicies []unstructured.Unstructured `json:"kyverno_cluster_policies,omitempty"`
+	KyvernoPolicies        []unstructured.Unstructured `json:"kyverno_policies,omitempty"`
+	// GatekeeperConstraintTemplates are the cluster's OPA Gatekeeper templates. Phase 2
+	// uses presence as a "Gatekeeper installed" signal; per-constraint instances are
+	// dynamically-typed CRDs and are deferred to Phase 3/4.
+	GatekeeperConstraintTemplates []unstructured.Unstructured `json:"gatekeeper_constraint_templates,omitempty"`
 }
 
 // SecretMetadata stores Secret identifying info and labels/annotations only; raw data is intentionally never collected.

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -166,6 +166,18 @@ if rg -q "\"id\":\s*\"${NS_FP_ID_PREFIX}" "${ROOT_DIR}/.tmp/e2e-report/findings.
 fi
 ok "no cluster-admin false positive for namespace-scoped RoleBinding"
 
+# Phase 2 posture finding: KUBE-ADMISSION-NO-POLICY-ENGINE-001 must NOT fire in
+# this fixture because the psa-suppressed namespace carries
+# pod-security.kubernetes.io/enforce=restricted (set above), and PSAState.HasEnforce()
+# returns true for any baseline-or-stricter level. Asserting the absence is more
+# valuable than asserting presence: it locks in that the posture finding correctly
+# suppresses itself when *any* admission control is in place.
+if rg -q "\"rule_id\":\s*\"KUBE-ADMISSION-NO-POLICY-ENGINE-001\"" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+  echo "regression: KUBE-ADMISSION-NO-POLICY-ENGINE-001 fired despite psa-suppressed namespace having enforce=restricted" >&2
+  exit 1
+fi
+ok "no policy-engine posture finding (correctly suppressed by psa-suppressed enforce label)"
+
 # The same fixture must instead produce KUBE-PRIVESC-PATH-NAMESPACE-ADMIN, naming
 # the namespace it can take over. The finding ID encodes the target namespace as
 # the last segment after a fourth `:`.


### PR DESCRIPTION
## Summary

Phase 2 of the admission-aware findings effort (Phase 1 shipped in #50). Makes the analyzer reason about Kyverno, Gatekeeper, and ValidatingAdmissionPolicy in addition to PSA labels, with two new statically-derived signals:

- **`KUBE-ADMISSION-NO-POLICY-ENGINE-001`** (MEDIUM, cluster-wide) — fires when no namespace carries a PSA enforce label *and* zero policy-engine resources were observed. Tells the operator "this cluster is one mistake away from accepting a privileged pod" so they prioritize the cheapest leverage move (apply PSA labels or install a policy engine) before chasing per-workload findings.
- **`admission:policy-engine-detected:<engine>` tag** — appended to surviving pod-security findings when an engine *is* present but kubesplaining didn't evaluate its rules. One tag per detected engine (`kyverno`, `gatekeeper`, `vap`); score unchanged. Sets up Phase 3 (CEL evaluation of VAP via `cel-go`).

The collector grows a `dynamic.Interface` for the Kyverno/Gatekeeper CRDs (VAP is in the typed clientset). A `Discovery().ServerGroups()` pre-flight skips absent CRD groups cleanly, and a new `meta.IsNoMatchError` / `apierrors.IsNotFound` branch in the `runTask` switch downgrades absent-CRD errors to warnings (not `PermissionsMissing` — the latter implies "you should grant access," wrong here).

The new engine stage `applyPolicyEnginePresenceTags` runs after `applyAdmissionMitigations` (so PSA-suppressed findings are already gone) and before `correlate`/`dedupe`. Strips the posture finding when `--admission-mode=off` so users opting out of admission reasoning don't see it.

### Design decisions worth surfacing

- **Collect actual CRD instances, not just discovery-API presence booleans.** A `ServerGroups()` check would tell us "Kyverno installed" but not "0 policies exist" — a real distinct state. Phase 3/4 also need the resource bodies, so we pay the cost once.
- **One tag per engine, not a comma-joined list.** Existing `module:foo` / `check:bar` / `admission:audit-psa-restricted` tags are all single-value; a finding gets both `admission:policy-engine-detected:kyverno` and `admission:policy-engine-detected:vap` if both engines are present.
- **Tag only survivors of suppression.** PSA-suppressed findings are already dropped before this stage runs. Re-walking the original slice to tag invisible findings would add no value.
- **Posture finding emitted by the analyzer; mode-off stripping done by the engine.** Keeps the analyzer admission-unaware (mirrors how Phase 1 keeps PSA reasoning out of analyzers). The posture finding carries `module:admission` (not `module:pod_security`), so the PSA stage's `isPodSecurityFinding` check returns false and won't try to attenuate it — locked in by a regression test.
- **Defer e2e Kyverno install** to a separate manual script; unit tests cover the logic and the existing `make e2e` stays at its current runtime.

## Test plan

- [x] `make test` passes (cached): all packages including new `mitigation/detection_test.go`, `admission_policy_engine_test.go`, and the extended `admission/analyzer_test.go` truth table for `shouldEmitNoPolicyEngineFinding`.
- [x] `make lint` passes (gofmt + go vet).
- [x] `make e2e` passes against a kind cluster: 43 expected rule IDs present, plus the new negative assertion `KUBE-ADMISSION-NO-POLICY-ENGINE-001 must NOT fire` (because the existing `psa-suppressed` namespace's `enforce=restricted` label suppresses it). All previously-shipped PSA suppression/attenuation flows still work.
- [x] Manual sanity on a real cluster with Kyverno installed — confirm `kyverno_cluster_policies` populated in snapshot JSON and pod-security findings carry `admission:policy-engine-detected:kyverno`.
- [ ] Manual sanity on a clean cluster with no engines and no PSA labels — confirm `KUBE-ADMISSION-NO-POLICY-ENGINE-001` appears.
- [x] Snapshot back-compat: load a Phase 1 snapshot via `--input-file` — should parse cleanly, new fields default to empty, posture finding fires (correct: the snapshot literally has no engine data).

## Out of scope

- **Phase 3** (`cel-go` evaluation of VAP CEL expressions) — separate PR.
- **Phase 4** (operator attestation for Kyverno/Gatekeeper effects) — separate PR + new `attest-admission` subcommand.
- **e2e Kyverno install** — deferred to a future `scripts/kind-e2e-policy-engines.sh`.
- **Per-Gatekeeper-constraint collection** — Phase 2 only collects `ConstraintTemplate` (presence indicator); the dynamically-typed constraint instances themselves are deferred to Phase 3/4.
- **Report template changes** beyond what flows naturally — the new posture finding renders through the standard pipeline; the new tag is in JSON/CSV but not HTML (consistent with how all tags render today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)