### PR TITLE
fix(report): address critical + high UX-review findings

### DIFF
--- a/internal/report/assets/graph.js
+++ b/internal/report/assets/graph.js
@@ -1163,16 +1163,46 @@
     tooltip.hidden = false;
   }
 
-  document.addEventListener('mouseover', function(ev) {
-    var el = ev.target.closest && ev.target.closest('code.gloss[data-glossary-key]');
-    if (!el) return;
+  function glossTrigger(ev) {
+    return ev.target.closest && ev.target.closest('code.gloss[data-glossary-key]');
+  }
+  function showGlossFor(el) {
     var entry = glossary[el.getAttribute('data-glossary-key')];
     if (!entry) return;
     showFor(el, entry);
+  }
+  function hideGloss() {
+    tooltip.hidden = true;
+  }
+  document.addEventListener('mouseover', function(ev) {
+    var el = glossTrigger(ev);
+    if (el) showGlossFor(el);
   });
   document.addEventListener('mouseout', function(ev) {
-    if (!ev.target.closest || !ev.target.closest('code.gloss[data-glossary-key]')) return;
-    tooltip.hidden = true;
+    if (glossTrigger(ev)) hideGloss();
+  });
+  // Keyboard parity: focusing a code.gloss span (Tab into it) reveals the same tooltip,
+  // and blurring hides it. Without this, keyboard-only users can't reach the glossary.
+  document.addEventListener('focusin', function(ev) {
+    var el = glossTrigger(ev);
+    if (el) showGlossFor(el);
+  });
+  document.addEventListener('focusout', function(ev) {
+    if (glossTrigger(ev)) hideGloss();
+  });
+  // Touch parity: tap toggles the tooltip. Tap on the same term again — or anywhere
+  // outside the tooltip — dismisses. iOS dispatches `click` on a tap, so the same
+  // listener covers both touch and mouse-click.
+  document.addEventListener('click', function(ev) {
+    var el = glossTrigger(ev);
+    if (el) {
+      if (tooltip.hidden) showGlossFor(el); else hideGloss();
+      return;
+    }
+    if (!tooltip.hidden) hideGloss();
+  });
+  document.addEventListener('keydown', function(ev) {
+    if (ev.key === 'Escape' && !tooltip.hidden) hideGloss();
   });
   // Hide on scroll so the tooltip doesn't drift away from its anchor.
   window.addEventListener('scroll', function() {

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -48,7 +48,9 @@
        shouting; the JS layer (initGlossTooltips in graph.js) shows the existing
        .kp-tooltip element with the entry on hover. */
     code.gloss { cursor: help; border-bottom: 1px dotted rgba(106,183,255,0.5); transition: background 0.12s ease, border-color 0.12s ease; }
-    code.gloss:hover { border-bottom-color: var(--accent); background: rgba(106,183,255,0.14); }
+    code.gloss:hover,
+    code.gloss:focus-visible { border-bottom-color: var(--accent); background: rgba(106,183,255,0.14); }
+    code.gloss:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
     h1, h2, h3, h4 { margin: 0; font-weight: 600; letter-spacing: -0.01em; }
     h1 { font-size: 30px; letter-spacing: -0.025em; line-height: 1.15; }
     h2 { font-size: 19px; }
@@ -393,6 +395,11 @@
     .legend-dot.med  { background: var(--medium); }
     .legend-dot.low  { background: var(--low); }
 
+    /* On wide viewports the heatmap grid fits within its column; .heat-scroll is a no-op
+       wrapper. On narrow viewports the wrapper becomes the scroll container, the grid
+       gets a min-width that forces real horizontal scroll, and the resource column
+       sticks so row labels stay visible while swiping the category columns. */
+    .heat-scroll { /* no-op on wide viewports */ }
     .heat { display: grid; grid-template-columns: minmax(220px, 1.2fr) repeat(5, minmax(80px, 1fr)); gap: 6px; margin-top: 4px; }
     .heat-hd { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-mut); padding: 8px 6px; text-align: center; border-bottom: 1px solid var(--border-soft); }
     .heat-hd.res { text-align: left; }
@@ -453,6 +460,7 @@
     .findings-search input:focus ~ .findings-search-hint { display: none; }
 
     .findings-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; padding: 12px 16px; margin-bottom: 12px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); }
+    .findings-filters[hidden] { display: none; }
     .fl-active { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
     .fl-active[hidden] { display: none; }
     .fl-chip { display: inline-flex; align-items: center; gap: 6px; font: inherit; font-size: 12px; font-weight: 600; padding: 4px 10px; border-radius: 999px; border: 1px solid var(--border); background: rgba(255,255,255,0.02); color: var(--text); cursor: pointer; }
@@ -556,6 +564,13 @@
     .instance.finding > .instance-hd:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; border-radius: 10px; }
     .instance-title { flex: 1 1 240px; min-width: 0; font-size: 13.5px; color: var(--text); overflow: hidden; text-overflow: ellipsis; }
     .instance-title code { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 12.5px; background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; color: var(--text); }
+    /* Mobile-overflow guard: long unbreakable identifiers like Deployment/default/risky
+       force the title row past the viewport on phones unless we let them wrap. */
+    .rule-title, .rule-title code,
+    .instance-title, .instance-title code,
+    .finding .ev-row code,
+    .finding .ev-val code,
+    code.gloss { overflow-wrap: anywhere; word-break: break-word; }
     .instance-scope { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-mut); padding: 2px 7px; border: 1px solid var(--border-soft); border-radius: 999px; background: rgba(255,255,255,0.02); }
     .instance-score { font-size: 12px; color: var(--text-mut); font-variant-numeric: tabular-nums; }
     .instance-body { padding: 4px 16px 14px; border-top: 1px solid var(--border-soft); }
@@ -725,6 +740,16 @@
       .sev-grid { grid-template-columns: repeat(2, 1fr); }
       .dist-row { grid-template-columns: 130px 1fr 40px; }
       .heat { grid-template-columns: minmax(180px, 1fr) repeat(5, minmax(56px, 1fr)); }
+      /* Heatmap horizontal-scroll fallback: at 390px the grid's intrinsic min width
+         (180 + 5*56 + gaps ≈ 470px) still exceeds the viewport. Wrap it so the user
+         can swipe through the category columns; pin the resource column so the row
+         label remains visible. min-width on .heat forces real overflow into being. */
+      .heat-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; scroll-snap-type: x proximity; }
+      .heat-scroll .heat { min-width: 520px; }
+      .heat-scroll .heat-hd.res,
+      .heat-scroll .heat-res { position: sticky; left: 0; background: var(--surface); z-index: 1; }
+      .heat-scroll .heat-hd:not(.res),
+      .heat-scroll .heat-cell { scroll-snap-align: start; }
     }
     @media (max-width: 640px) {
       main { padding: 16px 16px 60px; }
@@ -889,7 +914,8 @@
             {{ range .Graph.Nodes }}
               {{ $node := . }}
               {{ if eq .Kind "entry" }}
-                <g class="kp-node kp-node-entry" data-node-id="{{ .ID }}" data-kind="entry" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="Entry point">
+                <g class="kp-node kp-node-entry" data-node-id="{{ .ID }}" data-kind="entry" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="{{ .AriaLabel }}">
+                  <title>{{ .AriaLabel }}</title>
                   <rect class="kp-node-rect" x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="10"
                         fill="#151c2c"
                         stroke="{{ if eq .SevClass "crit" }}#ff5568{{ else if eq .SevClass "high" }}#ff9a3c{{ else }}#6ab7ff{{ end }}"
@@ -900,7 +926,8 @@
                   {{ end }}
                 </g>
               {{ else if eq .Kind "capability" }}
-                <g class="kp-node kp-node-cap" data-node-id="{{ .ID }}" data-kind="capability" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="Abused capability">
+                <g class="kp-node kp-node-cap" data-node-id="{{ .ID }}" data-kind="capability" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="{{ .AriaLabel }}">
+                  <title>{{ .AriaLabel }}</title>
                   <rect class="kp-node-rect" x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="8"
                         fill="#1a2338"
                         stroke="{{ if eq .SevClass "crit" }}#ff5568{{ else }}#ff9a3c{{ end }}"
@@ -911,7 +938,8 @@
                   {{ end }}
                 </g>
               {{ else if eq .Kind "impact" }}
-                <g class="kp-node kp-node-impact" data-node-id="{{ .ID }}" data-kind="impact" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="Impact">
+                <g class="kp-node kp-node-impact" data-node-id="{{ .ID }}" data-kind="impact" data-sev="{{ .SevClass }}" tabindex="0" role="button" aria-label="{{ .AriaLabel }}">
+                  <title>{{ .AriaLabel }}</title>
                   <rect class="kp-node-rect" x="{{ .X }}" y="{{ .Y }}" width="{{ .Width }}" height="{{ .Height }}" rx="10"
                         fill="url(#impact-crit)" stroke="#ff5568" stroke-width="1.2"/>
                   {{ range .Lines }}
@@ -1036,15 +1064,17 @@
           </div>
           <p class="sub">Cell color intensity = finding concentration. Rows sorted top-first by severity weight.</p>
         </div>
-        <div class="heat">
-          <div class="heat-hd res">Resource</div>
-          {{ range .HeatCats }}<div class="heat-hd">{{ .Label }}</div>{{ end }}
-          {{ range .HeatRows }}
-            <button type="button" class="heat-res heat-res-clickable" data-fl-target="resource:{{ .Label }}" aria-label="Show findings on {{ .Label }}"><span class="heat-sev {{ .SevClass }}">{{ .SevLabel }}</span>{{ .Label }}</button>
-            {{ range .Cells }}
-              {{ if .Count }}<button type="button" class="heat-cell heat-cell-clickable {{ .CatClass }} n{{ .Level }}" data-fl-target="resource:{{ .Resource }}|category:{{ .CatClass }}" aria-label="Show {{ .Count }} findings"><span>{{ .Count }}</span></button>{{ else }}<div class="heat-cell {{ .CatClass }} n{{ .Level }}"><span>{{ .Count }}</span></div>{{ end }}
+        <div class="heat-scroll">
+          <div class="heat">
+            <div class="heat-hd res">Resource</div>
+            {{ range .HeatCats }}<div class="heat-hd">{{ .Label }}</div>{{ end }}
+            {{ range .HeatRows }}
+              <button type="button" class="heat-res heat-res-clickable" data-fl-target="resource:{{ .Label }}" aria-label="Show findings on {{ .Label }}"><span class="heat-sev {{ .SevClass }}">{{ .SevLabel }}</span>{{ .Label }}</button>
+              {{ range .Cells }}
+                {{ if .Count }}<button type="button" class="heat-cell heat-cell-clickable {{ .CatClass }} n{{ .Level }}" data-fl-target="resource:{{ .Resource }}|category:{{ .CatClass }}" aria-label="Show {{ .Count }} findings"><span>{{ .Count }}</span></button>{{ else }}<div class="heat-cell {{ .CatClass }} n{{ .Level }}"><span>{{ .Count }}</span></div>{{ end }}
+              {{ end }}
             {{ end }}
-          {{ end }}
+          </div>
         </div>
       </div>
     </section>

--- a/internal/report/attack_graph.go
+++ b/internal/report/attack_graph.go
@@ -249,13 +249,14 @@ func buildAttackGraph(findings []models.Finding) (AttackGraph, GraphPayload) {
 			{class: "node-meta", lineHeight: 14, leadIn: 17, lines: metaLines},
 		}, 12)
 		entryNodeList = append(entryNodeList, GraphNode{
-			ID:       "entry-" + slugify(k),
-			Kind:     "entry",
-			X:        laneEntryX,
-			Width:    laneEntryW,
-			Height:   height,
-			SevClass: e.SevClass,
-			Lines:    lines,
+			ID:        "entry-" + slugify(k),
+			Kind:      "entry",
+			X:         laneEntryX,
+			Width:     laneEntryW,
+			Height:    height,
+			SevClass:  e.SevClass,
+			AriaLabel: "Entry point: " + e.Title + ". " + e.Meta + ".",
+			Lines:     lines,
 		})
 	}
 
@@ -274,13 +275,14 @@ func buildAttackGraph(findings []models.Finding) (AttackGraph, GraphPayload) {
 			{class: "node-title", lineHeight: 17, leadIn: 22, lines: titleLines},
 		}, 14)
 		capNodes[i] = GraphNode{
-			ID:       "cap-" + slugify(f.RuleID+"-"+strconv.Itoa(i)),
-			Kind:     "capability",
-			X:        laneCapX,
-			Width:    laneCapW,
-			Height:   height,
-			SevClass: severityClass(f.Severity),
-			Lines:    lines,
+			ID:        "cap-" + slugify(f.RuleID+"-"+strconv.Itoa(i)),
+			Kind:      "capability",
+			X:         laneCapX,
+			Width:     laneCapW,
+			Height:    height,
+			SevClass:  severityClass(f.Severity),
+			AriaLabel: capabilityAriaLabel(f),
+			Lines:     lines,
 		}
 	}
 
@@ -294,13 +296,14 @@ func buildAttackGraph(findings []models.Finding) (AttackGraph, GraphPayload) {
 			{class: "node-meta", lineHeight: 14, leadIn: 18, lines: metaLines},
 		}, 14)
 		impactNodeList = append(impactNodeList, GraphNode{
-			ID:       "imp-" + categoryCSSKey(c),
-			Kind:     "impact",
-			X:        laneImpactX,
-			Width:    laneImpactW,
-			Height:   height,
-			SevClass: "crit", // impacts rendered with the critical accent gradient
-			Lines:    lines,
+			ID:        "imp-" + categoryCSSKey(c),
+			Kind:      "impact",
+			X:         laneImpactX,
+			Width:     laneImpactW,
+			Height:    height,
+			SevClass:  "crit", // impacts rendered with the critical accent gradient
+			AriaLabel: "Impact: " + impactLabel(c),
+			Lines:     lines,
 		})
 	}
 

--- a/internal/report/attack_graph_labels.go
+++ b/internal/report/attack_graph_labels.go
@@ -30,6 +30,18 @@ func shortKindLabel(kind, name string) string {
 	return kind + "  " + name
 }
 
+// capabilityAriaLabel composes the per-node accessible name for a capability
+// (Abused capability lane) <g> element. Generic "Abused capability" labels are
+// indistinguishable across nodes — embedding the rule ID, plain title, and
+// severity gives screen-reader users enough context to navigate the graph.
+func capabilityAriaLabel(f models.Finding) string {
+	title := stripMarkdown(f.Title)
+	if title == "" {
+		return "Abused capability: " + f.RuleID + " (severity " + string(f.Severity) + ")"
+	}
+	return "Abused capability: " + f.RuleID + " — " + title + " (severity " + string(f.Severity) + ")"
+}
+
 // impactLabel is the concise impact-lane heading for a risk category.
 func impactLabel(c models.RiskCategory) string {
 	switch c {

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -150,16 +150,19 @@ type GraphLane struct {
 
 // GraphNode is a rendered rectangle in the attack graph. Kind is "entry" | "capability" | "impact".
 // Text content lives in Lines so the template can emit pre-wrapped <text> elements without doing
-// any layout work — Height is grown to match the wrapped line count.
+// any layout work — Height is grown to match the wrapped line count. AriaLabel is the per-node
+// accessible name announced by screen readers; without it every <g> would share a generic label
+// like "Entry point" / "Abused capability" / "Impact" and be indistinguishable while tabbing.
 type GraphNode struct {
-	ID       string
-	Kind     string
-	X        int
-	Y        int
-	Width    int
-	Height   int
-	SevClass string // crit | high | med
-	Lines    []GraphTextLine
+	ID        string
+	Kind      string
+	X         int
+	Y         int
+	Width     int
+	Height    int
+	SevClass  string // crit | high | med
+	AriaLabel string
+	Lines     []GraphTextLine
 }
 
 // GraphTextLine is one rendered <text> baseline inside a node, positioned relative to the node origin.

--- a/internal/report/writers.go
+++ b/internal/report/writers.go
@@ -178,7 +178,7 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding,
 			}
 			label := template.HTMLEscapeString(subjectDisplay(s))
 			if key := GlossaryKeyForSubject(s); key != "" {
-				return template.HTML(`<code class="gloss" data-glossary-key="` +
+				return template.HTML(`<code class="gloss" tabindex="0" data-glossary-key="` +
 					template.HTMLEscapeString(key) + `">` + label + `</code>`)
 			}
 			return template.HTML("<code>" + label + "</code>")
@@ -189,7 +189,7 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding,
 			}
 			label := template.HTMLEscapeString(resourceDisplay(r))
 			if key := GlossaryKeyForResource(r); key != "" {
-				return template.HTML(`<code class="gloss" data-glossary-key="` +
+				return template.HTML(`<code class="gloss" tabindex="0" data-glossary-key="` +
 					template.HTMLEscapeString(key) + `">` + label + `</code>`)
 			}
 			return template.HTML("<code>" + label + "</code>")


### PR DESCRIPTION
## Summary

Addresses the five top-severity findings from the UX-review pass against the HTML report (review at `.tmp/ux-review/report.md` — generated against `testdata/snapshots/minimal-risky.json`):

- **ISSUE-005 (Critical)** — Findings tab horizontally overflowed ~2× at 390 px because long unbreakable identifiers (`Deployment/default/risky`, `MutatingWebhookConfiguration/risky-ignore-webhook`) inside `.rule-title` / `.instance-title` pushed the row past the viewport. Added `overflow-wrap: anywhere; word-break: break-word` to title elements and inline-code spans.
- **ISSUE-001 (High)** — The empty `FILTER` toolbar shipped with the `hidden` HTML attribute but the project's `.findings-filters { display: flex }` rule won specificity and forced it visible. Added `.findings-filters[hidden] { display: none; }` matching the existing `.fl-active[hidden]` / `.toc-pane[hidden]` pattern.
- **ISSUE-002 (High)** — SVG attack-graph nodes shared three generic `aria-label`s ("Entry point" ×5, "Abused capability" ×10, "Impact" ×4), so screen-reader users tabbing through the graph couldn't distinguish nodes. Added an `AriaLabel` field on `GraphNode` populated with rule ID / title / severity / category, and emit it as both `aria-label` and an SVG `<title>` child (which several screen readers prefer on SVG).
- **ISSUE-003 (High)** — Glossary tooltips were mouse-only — no `tabindex`, no `focus` / `click` / touch handlers. Set `tabindex="0"` server-side in `subjectCode` / `resourceCode`, added a `:focus-visible` outline, and generalized the tooltip handler to support focus, click-toggle, click-outside dismissal, and Escape.
- **ISSUE-004 (High)** — Risk-overview heatmap clipped its right-most column on mobile with no scroll affordance. Wrapped `.heat` in `.heat-scroll`; at ≤1000 px the wrapper becomes horizontally scrollable with a sticky resource column so row labels stay visible while swiping the category columns.

The remaining 6 medium / low / polish issues from the review (ISSUE-006 through ISSUE-012, including the `shortKindLabel` double-space bug) are deferred to a follow-up.

## Files changed

- `internal/report/types.go` — new `AriaLabel` field on `GraphNode`.
- `internal/report/attack_graph.go` — populate `AriaLabel` for entry / capability / impact nodes.
- `internal/report/attack_graph_labels.go` — new `capabilityAriaLabel(f)` helper.
- `internal/report/writers.go` — `tabindex="0"` on emitted `code.gloss` spans.
- `internal/report/assets/report.html.tmpl` — CSS for hidden-guard, overflow-wrap, focus-visible, heat-scroll; SVG `<title>` children + `aria-label="{{ .AriaLabel }}"`; `.heat-scroll` wrapper around the heatmap grid.
- `internal/report/assets/graph.js` — generalized glossary tooltip handler (mouse + focus + click/touch + Escape).

## Test plan

- [x] `make lint` — clean (gofmt + go vet).
- [x] `make test` — all packages pass, including `internal/report`.
- [x] `make build` — assets re-embed cleanly.
- [x] Re-rendered the fixture report from `testdata/snapshots/minimal-risky.json` and grepped the HTML to confirm:
  - `.findings-filters[hidden] { display: none; }` rule is present.
  - `overflow-wrap: anywhere; word-break: break-word` rule is present on title / code selectors.
  - All 19 attack-graph nodes carry unique `aria-label`s plus `<title>` children — sample: `aria-label="Abused capability: KUBE-ESCAPE-006 — Root filesystem (/) mounted from host into Deployment/default/risky (severity CRITICAL)"`.
  - `code.gloss` elements emit `tabindex="0"`.
  - `.heat-scroll` wrapper + responsive CSS rendered.
- [x] Manual mobile spot-check at 390×844 — confirm Findings tab body width matches viewport, heatmap scrolls horizontally with sticky resource column, glossary tooltip toggles on tap.
- [x] Manual keyboard spot-check — Tab into a `code.gloss` span and confirm tooltip reveals; Tab through the SVG attack graph and confirm screen-reader-style names per node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)