### PR TITLE
fix(report): responsive HTML report for iPhone-class viewports

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -18,7 +18,7 @@
       --low: #52e3a4; --low-soft: rgba(82,227,164,0.11); --low-edge: rgba(82,227,164,0.38);
     }
     * { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; }
+    html, body { margin: 0; padding: 0; overflow-x: clip; }
     body {
       background:
         radial-gradient(1100px 520px at 6% -8%, rgba(106,183,255,0.08) 0%, transparent 55%),
@@ -65,7 +65,8 @@
       letter-spacing: -0.03em; box-shadow: 0 0 24px rgba(106,183,255,0.35); }
     .brand-title { font-weight: 600; letter-spacing: -0.01em; font-size: 15px; }
     .brand-title span { color: var(--text-mut); font-weight: 400; margin-left: 6px; }
-    .topbar-meta { display: flex; gap: 6px 14px; color: var(--text-mut); font-size: 13px; margin-left: auto; flex-wrap: wrap; align-items: center; }
+    .topbar-meta { display: flex; gap: 6px 14px; color: var(--text-mut); font-size: 13px; margin-left: auto; flex-wrap: wrap; align-items: center; min-width: 0; }
+    .topbar-meta > span { min-width: 0; max-width: 100%; }
     .topbar-meta strong { color: var(--text); font-weight: 500; }
     .topbar-meta .sep { width: 4px; height: 4px; border-radius: 999px; background: var(--text-dim); display: inline-block; margin: 0 4px; }
 
@@ -565,12 +566,32 @@
     .instance-title { flex: 1 1 240px; min-width: 0; font-size: 13.5px; color: var(--text); overflow: hidden; text-overflow: ellipsis; }
     .instance-title code { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 12.5px; background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; color: var(--text); }
     /* Mobile-overflow guard: long unbreakable identifiers like Deployment/default/risky
-       force the title row past the viewport on phones unless we let them wrap. */
+       force the title row past the viewport on phones unless we let them wrap. The
+       sweep is intentionally broad — any prose/code descendant of a finding body or
+       the Attack Paths side panel can carry resource paths or API URLs; if any one
+       of them stays unbreakable, the document gains horizontal overflow and the
+       sticky topbar visibly left-aligns when the user pinch-zooms out. min-width: 0
+       on flex/grid descendants is what actually allows them to shrink — without it
+       the intrinsic min width is the longest unbreakable child word. */
     .rule-title, .rule-title code,
     .instance-title, .instance-title code,
-    .finding .ev-row code,
-    .finding .ev-val code,
-    code.gloss { overflow-wrap: anywhere; word-break: break-word; }
+    .instance-body code,
+    .finding .desc, .finding .desc code,
+    .finding .scope-detail, .finding .scope-detail code,
+    .finding .impact .v, .finding .impact .v code,
+    .finding .scenario, .finding .scenario code,
+    .finding .scenario .step-explainer code,
+    .finding .scenario .step-edge code,
+    .finding .scenario .step-meta code,
+    .finding .scenario ol.attack-chain li.attack-step,
+    .finding .education .edu-body, .finding .education .edu-body code,
+    .finding .ev-row code, .finding .ev-val, .finding .ev-val code,
+    .finding .ev-sentence, .finding .ev-sentence code,
+    .finding .meta code, .finding .rem, .finding .rem code,
+    .kp-detail .kp-prose, .kp-detail .kp-prose code,
+    .kp-detail .kp-panel-sub, .kp-detail .kp-walk-id,
+    .topbar-meta code,
+    code.gloss { overflow-wrap: anywhere; word-break: break-word; min-width: 0; }
     .instance-scope { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-mut); padding: 2px 7px; border: 1px solid var(--border-soft); border-radius: 999px; background: rgba(255,255,255,0.02); }
     .instance-score { font-size: 12px; color: var(--text-mut); font-variant-numeric: tabular-nums; }
     .instance-body { padding: 4px 16px 14px; border-top: 1px solid var(--border-soft); }
@@ -728,6 +749,12 @@
       .finding .ev-row { grid-template-columns: 1fr; }
       .finding .ev-hints { grid-column: 1; }
     }
+    /* At iPhone widths the 90px IMPACT label column eats too much of the row;
+       stack label-above-value to mirror what .ev-row does at 720px. */
+    @media (max-width: 480px) {
+      .finding .impact { grid-template-columns: 1fr; gap: 4px; }
+      .finding .impact .k { padding-top: 0; }
+    }
 
     .notes { display: grid; gap: 8px; font-size: 13px; color: var(--text-mut); }
     .notes li { padding: 8px 10px; background: rgba(255,154,60,0.07); border: 1px solid rgba(255,154,60,0.22); border-radius: 8px; list-style: none; }
@@ -751,10 +778,31 @@
       .heat-scroll .heat-hd:not(.res),
       .heat-scroll .heat-cell { scroll-snap-align: start; }
     }
+    /* Phone-band layout: the desktop pile-up of three sticky bars (topbar / tabs /
+       modules-nav) eats half the viewport on a phone, which is what produced the
+       "header bubble dominating the page" look users reported. We keep .topbar
+       sticky so the tabs stay reachable, but un-stick .modules-nav so the filter
+       chips scroll with content and reclaim that vertical space. .tabs gets a
+       horizontal-overflow-scroll fallback in case tab labels grow. */
     @media (max-width: 640px) {
       main { padding: 16px 16px 60px; }
-      .topbar-inner { padding: 12px 16px; }
-      .modules-nav { top: 96px; }
+      .topbar-inner { padding: 12px 16px; gap: 10px; }
+      .topbar-meta { font-size: 12px; gap: 4px 10px; }
+      .tabs { padding: 0 16px; gap: 2px; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+      .tabs::-webkit-scrollbar { display: none; }
+      .tab { padding: 10px 10px 12px; font-size: 12.5px; }
+      .modules-nav { position: static; top: auto; padding: 10px 12px; }
+      .modules-nav .mn-title { display: none; }
+      .module-link { font-size: 12px; padding: 5px 10px; }
+    }
+    /* iPhone-band: at ~430px the brand title + meta still feel cramped. Stack the
+       "Security Report" subtitle below the brand and drop the meta dot separators
+       so wrapped meta items read cleanly. */
+    @media (max-width: 460px) {
+      .brand-title { font-size: 14px; }
+      .brand-title span { display: block; margin-left: 0; font-size: 12px; }
+      .topbar-meta .sep { display: none; }
+      h1 { font-size: 24px; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary

CSS-only fix to `internal/report/assets/report.html.tmpl` that addresses two visible bugs on iPhone 17 Pro Max (Chrome) when viewing the HTML report's Findings tab:

- **Sticky-bar pile-up.** Topbar + tab nav + module-filter chips all stuck at the top consumed ~half the viewport on phones, overlapping the finding-body content.
- **Page wider than viewport.** Long unbreakable tokens (`ServiceAccount/rbac-fixtures/sa-bind-escalate`, the API URL chip, etc.) forced the document body wider than the viewport. On pinch-zoom-out the topbar visibly left-aligned with empty space to its right — the visual signature of horizontal page overflow.

Both share a root cause: content widths in finding bodies weren't constrained on narrow viewports.

## Changes (all in the embedded `<style>` block)

- `html, body { overflow-x: clip }` — backstop preventing page-level horizontal scroll.
- Broaden the existing long-token wrap rule from 5 selectors to ~25, covering `<code>` and prose inside `.finding`, `.instance-body`, `.kp-detail`, `.education`, `.scenario`, and `.topbar-meta`. Add `min-width: 0` so flex/grid descendants can actually shrink.
- `.topbar-meta` gets `min-width: 0`; new `.topbar-meta > span { min-width: 0; max-width: 100% }` lets the API URL chip wrap.
- New `@media (max-width: 480px)` collapses `.finding .impact` from `90px 1fr` to single column (mirrors how `.ev-row` collapses at 720px).
- Expanded `@media (max-width: 640px)`: `.modules-nav` becomes `position: static` (third sticky bar gone), `.tabs` get an overflow-x scroll fallback, "Jump to module" label hides.
- New `@media (max-width: 460px)` for iPhone 17 Pro Max: stacks the "Security Report" brand subtitle below the brand mark, hides the topbar dot separators, shrinks h1.

No HTML or template changes; no Go changes; no JS changes. Class names unchanged — desktop behavior is identical.

## Test plan

- [x] `make build` passes
- [x] `make lint` passes
- [x] Generated report against `testdata/snapshots/minimal-risky.json` and verified all six edits land in the rendered HTML
- [x] Open `kubesplaining-report/report.html` in Chrome DevTools → device toolbar → iPhone 17 Pro Max (430 × 932). On Findings tab: no horizontal scrollbar, long resource paths wrap inside cards, only `.topbar` is sticky, module-filter chips scroll with content
- [x] Pinch-zoom out: topbar background spans full visual viewport (no left-aligned bubble)
- [x] Click an "Affected subjects" disclosure on a privesc finding — content opens cleanly without clipping
- [x] Regression: Attack Paths tab side panel still bottom-sheets correctly at <=720px

🤖 Generated with [Claude Code](https://claude.com/claude-code)