### PR TITLE
fix(report): compact affected-subjects cards on phone viewports

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -764,6 +764,16 @@
     @media (max-width: 480px) {
       .finding .impact { grid-template-columns: 1fr; gap: 4px; }
       .finding .impact .k { padding-top: 0; }
+      /* Affected-subjects cards: at iPhone widths the 240px flex-basis on
+         .instance-title pushed the identifier off row 1, then wrapping bumped
+         the score to row 3. Force the identifier to its own row (order: 99
+         flows it last) and pin the score to the right edge of row 1, so each
+         card is 2 rows: chrome (▸ + sev + scope + score) over identifier. */
+      .instance.finding { margin-bottom: 4px; }
+      .instance.finding > .instance-hd { padding: 8px 12px; gap: 6px 8px; }
+      .instance.finding > .instance-hd .instance-title { flex: 1 1 100%; order: 99; font-size: 13px; }
+      .instance.finding > .instance-hd .instance-score { margin-left: auto; }
+      .instance-scope { padding: 1px 6px; font-size: 10px; letter-spacing: 0.06em; }
     }
 
     .notes { display: grid; gap: 8px; font-size: 13px; color: var(--text-mut); }


### PR DESCRIPTION
## Summary
- At iPhone widths each affected-subjects card was 3 visual rows (severity alone, wrapped identifier + scope, score alone) because `.instance-title`'s 240px flex-basis couldn't share row 1 with the severity badge — flex-wrap then pushed the score onto a third row.
- Inside the existing `@media (max-width: 480px)` block in `report.html.tmpl`, force `.instance-title` onto its own row (`flex: 1 1 100%; order: 99`) and pin `.instance-score` flush right (`margin-left: auto`). Tighten card padding/gap and shrink the scope chip.
- Result: chrome row (▸ + sev + scope + score) over identifier row — roughly half the previous vertical footprint per card on phones. Tablet/desktop (>480px) layout is unchanged.

## Test plan
- [x] `make test` (already passes locally for `internal/report/...`).
- [x] `./bin/kubesplaining scan --input-file testdata/snapshots/minimal-risky.json --output-dir tmp-report-minimal` and open `tmp-report-minimal/report.html`.
- [x] In Chrome/Safari DevTools device toolbar, set width to **390px** and verify each card on the Findings tab is 2 rows: chrome (severity + scope + score) on top, identifier below; score sits flush right.
- [x] Re-check at **360px** (small Android) and **460px** (iPhone Plus) — same 2-row structure.
- [ ] Toggle to **481px** — desktop look should return identical to before this PR (no regression for tablet).
- [x] Spot-check at **1280px** desktop — affected-subjects cards should be byte-identical to current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)