### PR TITLE
feat(report): cluster reconnaissance panel at top of HTML report

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -114,6 +114,99 @@
     .admission-banner ul { margin: 6px 0 0; padding-left: 18px; }
     .admission-banner li { margin: 2px 0; }
 
+    /* Cluster reconnaissance — collapsible top-of-report panel surfacing
+       pentester-relevant snapshot facts. Sits as the first card inside <main>
+       (above the executive-summary hero) so the recon view is the first thing
+       the reader sees, and stays out of the sticky topbar to avoid the
+       sticky-grow-on-expand layout footgun. */
+    .recon-card { background: linear-gradient(180deg, rgba(21,28,44,0.85) 0%, rgba(18,24,38,0.85) 100%);
+      border: 1px solid var(--border); border-radius: 14px; margin-bottom: 16px; overflow: hidden; }
+    .recon-card[open] { border-color: var(--border-strong); }
+    .recon-card > summary { cursor: pointer; list-style: none; padding: 14px 18px;
+      display: flex; flex-wrap: wrap; gap: 10px 14px; align-items: center; }
+    .recon-card > summary::-webkit-details-marker { display: none; }
+    /* Big, clearly-affordant disclosure triangle. The default <details> marker is
+       too easy to miss on a dark surface, and on phones a 13px ▸ next to wide
+       letter-spacing turned into "is this clickable?" guesswork. Use a chunky
+       BLACK RIGHT-POINTING TRIANGLE inside an outlined chip so the affordance
+       reads as a button. */
+    .recon-card > summary::before {
+      content: '▶'; color: var(--accent); font-size: 11px; font-weight: 700;
+      width: 22px; height: 22px; flex: 0 0 22px; line-height: 22px; text-align: center;
+      border: 1px solid rgba(106,183,255,0.4); border-radius: 6px;
+      background: rgba(106,183,255,0.08);
+      transition: transform 0.18s ease, background 0.18s ease;
+      display: inline-block; }
+    .recon-card[open] > summary::before { transform: rotate(90deg); background: rgba(106,183,255,0.18); }
+    .recon-card > summary:hover::before { background: rgba(106,183,255,0.18); }
+    .recon-title { font-size: 12px; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.14em; color: var(--text); }
+    .recon-teaser { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; min-width: 0; }
+    .recon-chip { display: inline-flex; align-items: baseline; gap: 5px; font-size: 12px;
+      font-weight: 500; padding: 4px 10px; border-radius: 999px;
+      border: 1px solid var(--border); background: rgba(255,255,255,0.02); color: var(--text-mut); }
+    .recon-chip strong { color: var(--text); font-weight: 700; font-variant-numeric: tabular-nums; }
+    .recon-chip-ok { border-color: rgba(82,227,164,0.32); background: rgba(82,227,164,0.06); }
+    .recon-chip-warn { border-color: rgba(255,154,60,0.36); background: rgba(255,154,60,0.07); }
+    .recon-chip-warn strong { color: #ffc89a; }
+    .recon-chip-danger { border-color: rgba(255,85,104,0.4); background: rgba(255,85,104,0.08); }
+    .recon-chip-danger strong { color: #ffb4be; }
+    .recon-hint { margin-left: auto; font-size: 11.5px; color: var(--text-dim); font-style: italic; }
+    .recon-card[open] .recon-hint { display: none; }
+    .recon-body { padding: 4px 18px 18px; display: grid; gap: 16px;
+      grid-template-columns: 1fr 1fr; border-top: 1px solid var(--border-soft); }
+    @media (max-width: 900px) { .recon-body { grid-template-columns: 1fr; } }
+    .recon-section { padding: 12px 0 0; min-width: 0; }
+    .recon-section .kicker { margin-bottom: 8px; }
+    .recon-grid { display: grid; grid-template-columns: max-content 1fr;
+      column-gap: 14px; row-gap: 0; font-size: 13px; line-height: 1.5; color: var(--text); }
+    .recon-row { display: grid; grid-template-columns: subgrid; grid-column: 1 / -1;
+      align-items: baseline; padding: 5px 0; border-top: 1px solid rgba(255,255,255,0.04); }
+    .recon-row:first-child { border-top: 0; padding-top: 0; }
+    .recon-key { color: var(--text-dim); font-size: 10.5px; text-transform: uppercase;
+      letter-spacing: 0.08em; font-weight: 600; white-space: nowrap; }
+    .recon-val { display: flex; flex-wrap: wrap; gap: 4px 8px; align-items: baseline;
+      min-width: 0; word-break: break-word; }
+    .recon-val code, .recon-val .recon-tag {
+      padding: 1px 6px; border-radius: 4px;
+      font-family: "JetBrains Mono", "SF Mono", Menlo, monospace;
+      font-size: 11.5px; color: var(--text);
+      background: rgba(255,255,255,0.10); border: 1px solid rgba(255,255,255,0.06);
+      max-width: 100%; overflow-wrap: anywhere; word-break: break-word; }
+    .recon-tag { display: inline-flex; align-items: center; gap: 4px; }
+    .recon-tag.tag-ok { color: #a6f2cf; border-color: rgba(82,227,164,0.32); background: rgba(82,227,164,0.10); }
+    .recon-tag.tag-warn { color: #ffc89a; border-color: rgba(255,154,60,0.36); background: rgba(255,154,60,0.10); }
+    .recon-tag.tag-danger { color: #ffb4be; border-color: rgba(255,85,104,0.4); background: rgba(255,85,104,0.12); }
+    .recon-tag.tag-mut { color: var(--text-mut); }
+    a.recon-tag { text-decoration: none; }
+    a.recon-tag:hover { background: rgba(255,255,255,0.06); border-color: var(--border-strong); }
+    .recon-more { font-size: 11.5px; color: var(--text-mut); }
+    .recon-more a { color: var(--accent); }
+    .recon-empty { color: var(--text-dim); font-style: italic; font-size: 12px; }
+    .recon-prov { grid-column: 1 / -1; margin-top: 4px; padding-top: 12px;
+      border-top: 1px solid var(--border-soft); }
+    .recon-prov > summary { cursor: pointer; list-style: none; font-size: 11px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-mut); padding: 4px 0; }
+    .recon-prov > summary::-webkit-details-marker { display: none; }
+    .recon-prov > summary::before { content: '▸ '; color: var(--accent); }
+    .recon-prov[open] > summary::before { content: '▾ '; }
+    .recon-prov-inner { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding-top: 10px; }
+    @media (max-width: 720px) { .recon-prov-inner { grid-template-columns: 1fr; } }
+    .recon-prov ul { margin: 4px 0; padding: 0; list-style: none;
+      font-family: "JetBrains Mono", monospace; font-size: 11.5px; color: var(--text-mut);
+      max-height: 180px; overflow-y: auto; }
+    .recon-prov li { padding: 1px 0; word-break: break-all; }
+    .recon-prov details summary { cursor: pointer; }
+    @media (max-width: 640px) {
+      .recon-card > summary { padding: 12px 14px; gap: 8px 10px; }
+      .recon-title { font-size: 11px; letter-spacing: 0.10em; }
+      .recon-chip { font-size: 11px; padding: 3px 8px; }
+      .recon-hint { display: none; }
+      .recon-body { padding: 4px 14px 14px; gap: 12px; }
+      .recon-row { grid-template-columns: 1fr; padding: 4px 0; row-gap: 2px; }
+      .recon-key { padding-top: 2px; }
+    }
+
     .sev-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-top: 16px; }
     .sev-tile { border: 1px solid var(--border); border-radius: 12px; padding: 12px 14px 12px 22px;
       background: rgba(10,13,22,0.35); position: relative; overflow: hidden; }
@@ -848,6 +941,134 @@
   </header>
 
   <main>
+    <details class="recon-card">
+      <summary>
+        <span class="recon-title">Cluster reconnaissance</span>
+        <span class="recon-teaser">{{ range .Recon.HeadlineChips }}<span class="recon-chip recon-chip-{{ .Tone }}"><strong>{{ .Value }}</strong> {{ .Label }}</span>{{ end }}</span>
+        <span class="recon-hint">Click to expand</span>
+      </summary>
+      <div class="recon-body">
+
+        <section class="recon-section">
+          <div class="kicker">Cluster shape</div>
+          <div class="recon-grid">
+            {{ if .Recon.Shape.Distribution }}<div class="recon-row"><span class="recon-key">Distribution</span><span class="recon-val"><strong>{{ .Recon.Shape.Distribution }}</strong></span></div>{{ end }}
+            {{ if .Recon.Shape.CloudLabel }}<div class="recon-row"><span class="recon-key">Cloud</span><span class="recon-val">{{ .Recon.Shape.CloudLabel }}</span></div>{{ end }}
+            <div class="recon-row">
+              <span class="recon-key">API server</span>
+              <span class="recon-val">
+                {{ if .Recon.Shape.APIHost }}<code>{{ .Recon.Shape.APIHost }}</code>{{ end }}
+                <span class="recon-tag tag-{{ if eq .Recon.Shape.APIReachability "public" }}danger{{ else if eq .Recon.Shape.APIReachability "private" }}ok{{ else if eq .Recon.Shape.APIReachability "loopback" }}mut{{ else }}mut{{ end }}">{{ .Recon.Shape.APIReachability }}</span>
+              </span>
+            </div>
+            <div class="recon-row">
+              <span class="recon-key">Nodes</span>
+              <span class="recon-val">
+                <strong>{{ .Recon.Shape.NodeCount }}</strong>
+                {{ if .Recon.Shape.ArchBreakdown }}<span class="recon-more">{{ .Recon.Shape.ArchBreakdown }}</span>{{ end }}
+                {{ if .Recon.Shape.OSImage }}<span class="recon-more">· {{ .Recon.Shape.OSImage }}</span>{{ end }}
+              </span>
+            </div>
+            {{ if .Recon.Shape.KubeletVersions }}<div class="recon-row"><span class="recon-key">Kubelet</span><span class="recon-val">{{ range .Recon.Shape.KubeletVersions }}<code>{{ . }}</code>{{ end }}</span></div>{{ end }}
+            {{ if .Recon.Shape.RuntimeVersions }}<div class="recon-row"><span class="recon-key">Runtime</span><span class="recon-val">{{ range .Recon.Shape.RuntimeVersions }}<code>{{ . }}</code>{{ end }}</span></div>{{ end }}
+            <div class="recon-row">
+              <span class="recon-key">Inventory</span>
+              <span class="recon-val">
+                <strong>{{ .Recon.Shape.NamespaceCount }}</strong> {{ pluralize .Recon.Shape.NamespaceCount "namespace" "namespaces" }} ·
+                <strong>{{ .Recon.Shape.PodCount }}</strong> {{ pluralize .Recon.Shape.PodCount "pod" "pods" }} ·
+                <strong>{{ .Recon.Shape.SACount }}</strong> {{ pluralize .Recon.Shape.SACount "service account" "service accounts" }}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section class="recon-section">
+          <div class="kicker">Who already owns this cluster</div>
+          <div class="recon-grid">
+            <div class="recon-row"><span class="recon-key">cluster-admin</span><span class="recon-val">{{ template "reconSubjectList" .Recon.Ownership.ClusterAdmins }}</span></div>
+            <div class="recon-row"><span class="recon-key">Wildcard verbs</span><span class="recon-val">{{ template "reconSubjectList" .Recon.Ownership.WildcardVerbSubjects }}</span></div>
+            <div class="recon-row"><span class="recon-key">Reads secrets</span><span class="recon-val">{{ template "reconSubjectList" .Recon.Ownership.SecretReaders }}</span></div>
+            <div class="recon-row">
+              <span class="recon-key">Privesc paths</span>
+              <span class="recon-val">
+                {{ if gt .Recon.Ownership.PrivescToAdminCount 0 }}<a href="#{{ .Recon.Ownership.PrivescToAdminAnchor }}" class="recon-tag tag-danger">{{ .Recon.Ownership.PrivescToAdminCount }} → cluster-admin</a>{{ end }}
+                {{ if gt .Recon.Ownership.NodeEscapeCount 0 }}<a href="#{{ .Recon.Ownership.NodeEscapeAnchor }}" class="recon-tag tag-danger">{{ .Recon.Ownership.NodeEscapeCount }} → node escape</a>{{ end }}
+                {{ if and (eq .Recon.Ownership.PrivescToAdminCount 0) (eq .Recon.Ownership.NodeEscapeCount 0) }}<span class="recon-empty">none detected</span>{{ end }}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section class="recon-section">
+          <div class="kicker">Exposed surface</div>
+          <div class="recon-grid">
+            <div class="recon-row"><span class="recon-key">LoadBalancers</span><span class="recon-val">{{ template "reconResourceList" .Recon.Surface.LoadBalancers }}</span></div>
+            <div class="recon-row"><span class="recon-key">NodePort / extIP</span><span class="recon-val"><strong>{{ .Recon.Surface.NodePorts }}</strong> NodePort · <strong>{{ .Recon.Surface.ExternalIPs }}</strong> externalIP</span></div>
+            <div class="recon-row"><span class="recon-key">HostNetwork pods</span><span class="recon-val">{{ template "reconResourceList" .Recon.Surface.HostNetworkPods }}</span></div>
+            <div class="recon-row"><span class="recon-key">Privileged pods</span><span class="recon-val">{{ template "reconResourceList" .Recon.Surface.PrivilegedPods }}</span></div>
+            <div class="recon-row">
+              <span class="recon-key">Mutating webhooks</span>
+              <span class="recon-val">
+                <strong>{{ .Recon.Surface.MutatingWebhooks }}</strong>
+                {{ if gt .Recon.Surface.OutOfClusterWebhooks 0 }}<span class="recon-tag tag-warn">{{ .Recon.Surface.OutOfClusterWebhooks }} out-of-cluster</span>{{ end }}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section class="recon-section">
+          <div class="kicker">Guardrails</div>
+          <div class="recon-grid">
+            <div class="recon-row">
+              <span class="recon-key">NetworkPolicies</span>
+              <span class="recon-val">
+                <strong>{{ .Recon.Guardrails.NetworkPolicies }}</strong>
+                <span class="recon-more">across {{ .Recon.Guardrails.NamespacesProtected }} {{ pluralize .Recon.Guardrails.NamespacesProtected "namespace" "namespaces" }}</span>
+                {{ if gt .Recon.Guardrails.NamespacesUnprotected 0 }}<span class="recon-tag tag-danger">{{ .Recon.Guardrails.NamespacesUnprotected }} unprotected</span>{{ end }}
+              </span>
+            </div>
+            <div class="recon-row">
+              <span class="recon-key">Pod Security</span>
+              <span class="recon-val">
+                {{ if .Recon.Guardrails.PSAEnforce }}{{ range $mode, $count := .Recon.Guardrails.PSAEnforce }}<span class="recon-tag {{ if eq $mode "restricted" }}tag-ok{{ else if eq $mode "baseline" }}tag-warn{{ else }}tag-danger{{ end }}">enforce={{ $mode }} ×{{ $count }}</span>{{ end }}{{ else }}<span class="recon-empty">no PSA labels</span>{{ end }}
+              </span>
+            </div>
+            <div class="recon-row">
+              <span class="recon-key">Policy engines</span>
+              <span class="recon-val">
+                {{ if .Recon.Guardrails.Engines }}{{ range .Recon.Guardrails.Engines }}<span class="recon-tag tag-ok">{{ . }}</span>{{ end }}{{ else }}<span class="recon-empty">none</span>{{ end }}
+              </span>
+            </div>
+            <div class="recon-row">
+              <span class="recon-key">Default-SA pods</span>
+              <span class="recon-val">
+                <strong>{{ .Recon.Guardrails.DefaultSATokenMounts }}</strong>
+                <span class="recon-more">with token automount</span>
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <details class="recon-prov">
+          <summary>Collection provenance</summary>
+          <div class="recon-prov-inner">
+            <div class="recon-grid">
+              {{ if .Recon.Provenance.CollectorIdentity }}<div class="recon-row"><span class="recon-key">Collector</span><span class="recon-val"><code>{{ .Recon.Provenance.CollectorIdentity }}</code></span></div>{{ end }}
+              <div class="recon-row"><span class="recon-key">Permissions seen</span><span class="recon-val"><strong>{{ len .Recon.Provenance.PermissionsAvailable }}</strong> · missing <strong>{{ len .Recon.Provenance.PermissionsMissing }}</strong></span></div>
+              <div class="recon-row"><span class="recon-key">Warnings</span><span class="recon-val"><strong>{{ len .Recon.Provenance.CollectionWarnings }}</strong></span></div>
+              <div class="recon-row"><span class="recon-key">Namespaces scanned</span><span class="recon-val"><strong>{{ len .Recon.Provenance.NamespacesScanned }}</strong></span></div>
+              {{ if .Recon.Provenance.CollectionDurationSec }}<div class="recon-row"><span class="recon-key">Duration</span><span class="recon-val">{{ printf "%.1fs" .Recon.Provenance.CollectionDurationSec }}</span></div>{{ end }}
+            </div>
+            <div>
+              {{ if .Recon.Provenance.PermissionsMissing }}<details><summary class="recon-key">Missing permissions ({{ len .Recon.Provenance.PermissionsMissing }})</summary><ul>{{ range .Recon.Provenance.PermissionsMissing }}<li>{{ . }}</li>{{ end }}</ul></details>{{ end }}
+              {{ if .Recon.Provenance.CollectionWarnings }}<details><summary class="recon-key">Warnings ({{ len .Recon.Provenance.CollectionWarnings }})</summary><ul>{{ range .Recon.Provenance.CollectionWarnings }}<li>{{ . }}</li>{{ end }}</ul></details>{{ end }}
+            </div>
+          </div>
+        </details>
+
+      </div>
+    </details>
+
     <section class="hero" data-tab="overview">
       <div class="card soft">
         <div class="kicker">Executive summary</div>
@@ -1363,4 +1584,12 @@
   </script>
   <script>{{ .GraphScript }}</script>
 </body>
+
+{{- define "reconSubjectList" -}}
+{{ if eq .Total 0 }}<span class="recon-empty">none</span>{{ else }}<strong>{{ .Total }}</strong>{{ range .Sample }} <code>{{ . }}</code>{{ end }}{{ if gt .MoreCount 0 }} <span class="recon-more">{{ if .Anchor }}<a href="#{{ .Anchor }}">+{{ .MoreCount }} more</a>{{ else }}+{{ .MoreCount }} more{{ end }}</span>{{ end }}{{ end }}
+{{- end -}}
+
+{{- define "reconResourceList" -}}
+{{ if eq .Total 0 }}<span class="recon-empty">none</span>{{ else }}<strong>{{ .Total }}</strong>{{ range .Sample }} <code>{{ . }}</code>{{ end }}{{ if gt .MoreCount 0 }} <span class="recon-more">+{{ .MoreCount }} more</span>{{ end }}{{ end }}
+{{- end -}}
 </html>

--- a/internal/report/recon.go
+++ b/internal/report/recon.go
@@ -428,10 +428,10 @@ func collectSecretReaders(subjects map[string]*permissions.EffectivePermissions)
 
 func grantsSecretRead(rules []permissions.EffectiveRule) bool {
 	for _, r := range rules {
-		if !(sliceContains(r.Resources, "secrets") || sliceContains(r.Resources, "*")) {
+		if !sliceContains(r.Resources, "secrets") && !sliceContains(r.Resources, "*") {
 			continue
 		}
-		if !(sliceContains(r.APIGroups, "") || sliceContains(r.APIGroups, "*")) {
+		if !sliceContains(r.APIGroups, "") && !sliceContains(r.APIGroups, "*") {
 			continue
 		}
 		if sliceContains(r.Verbs, "*") || sliceContains(r.Verbs, "get") || sliceContains(r.Verbs, "list") || sliceContains(r.Verbs, "watch") {

--- a/internal/report/recon.go
+++ b/internal/report/recon.go
@@ -1,0 +1,659 @@
+// Package report — top-of-report reconnaissance panel data builder. The panel
+// surfaces pentester-relevant snapshot facts at the top of the HTML report so a
+// reader can grasp blast radius, who already owns the cluster, what is exposed,
+// and what guardrails are missing before scrolling to the Findings tab.
+//
+// Everything here is derived from a Snapshot at render time — adding or removing
+// rows is a report-layer concern only, no collector or model change required.
+package report
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// Recon is the rendered cluster-reconnaissance panel: a four-section view plus a
+// nested provenance section, with a row of headline chips shown on the closed
+// disclosure summary so even the collapsed state hints at what's inside.
+type Recon struct {
+	Shape         ReconShape
+	Ownership     ReconOwnership
+	Surface       ReconSurface
+	Guardrails    ReconGuardrails
+	Provenance    ReconProvenance
+	HeadlineChips []ReconChip
+}
+
+// ReconShape — "where am I, how big is it" facts.
+type ReconShape struct {
+	Distribution    string // "EKS v1.28.5" | "v1.28.5" | ""
+	CloudLabel      string // "AWS / us-east-1" | "On-prem / unknown"
+	NodeCount       int
+	ArchBreakdown   string   // "10×amd64, 2×arm64"
+	OSImage         string   // most common Status.NodeInfo.OSImage
+	KubeletVersions []string // distinct, "vX.Y.Z ×N" rows (sorted descending by count)
+	RuntimeVersions []string // same shape for ContainerRuntimeVersion
+	NamespaceCount  int
+	PodCount        int
+	SACount         int
+	APIHost         string // host portion of APIServerURL
+	APIReachability string // "private" | "public" | "loopback" | "linklocal" | "unknown"
+}
+
+// ReconOwnership — who already owns the cluster.
+type ReconOwnership struct {
+	ClusterAdmins        ReconSubjectList
+	WildcardVerbSubjects ReconSubjectList
+	SecretReaders        ReconSubjectList
+	PrivescToAdminCount  int
+	PrivescToAdminAnchor string // "finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN" or ""
+	NodeEscapeCount      int
+	NodeEscapeAnchor     string
+}
+
+// ReconSurface — what an outside scanner sees.
+type ReconSurface struct {
+	LoadBalancers        ReconResourceList
+	NodePorts            int
+	ExternalIPs          int
+	HostNetworkPods      ReconResourceList
+	PrivilegedPods       ReconResourceList
+	MutatingWebhooks     int
+	OutOfClusterWebhooks int
+}
+
+// ReconGuardrails — what is/isn't protecting the cluster.
+type ReconGuardrails struct {
+	NetworkPolicies       int
+	NamespacesProtected   int
+	NamespacesUnprotected int
+	PSAEnforce            map[string]int // mode → namespace count (e.g. "restricted" → 4)
+	Engines               []string       // "Kyverno", "Gatekeeper", "VAP"
+	DefaultSATokenMounts  int
+}
+
+// ReconProvenance — collection-time meta. Tucked behind a nested disclosure since
+// it's operational metadata rather than a recon "wow" fact.
+type ReconProvenance struct {
+	CollectorIdentity     string
+	PermissionsAvailable  []string
+	PermissionsMissing    []string
+	CollectionWarnings    []string
+	NamespacesScanned     []string
+	CollectionDurationSec float64
+}
+
+// ReconSubjectList is the count + sample-of-three pattern for RBAC subjects.
+type ReconSubjectList struct {
+	Total     int
+	Sample    []string // up to 3 "Kind/[Namespace/]Name" labels, sorted alphabetically
+	MoreCount int      // Total - len(Sample); zero when nothing was elided
+	Anchor    string   // optional Findings-tab deep link
+}
+
+// ReconResourceList is the parallel pattern for Pod/Service object samples.
+type ReconResourceList struct {
+	Total     int
+	Sample    []string // up to 3 "namespace/name" labels
+	MoreCount int
+}
+
+// ReconChip is a small headline pill rendered in the collapsed disclosure summary.
+// Tone is "ok" | "warn" | "danger"; the template maps each to a CSS class.
+type ReconChip struct {
+	Label string
+	Value string
+	Tone  string
+}
+
+// buildRecon aggregates a snapshot into a Recon panel. Safe on empty inputs —
+// nil maps/slices are returned unmodified so the template can range over them.
+func buildRecon(
+	snapshot models.Snapshot,
+	findings []models.Finding,
+	subjects map[string]*permissions.EffectivePermissions,
+) Recon {
+	r := Recon{
+		Shape:      buildReconShape(snapshot),
+		Ownership:  buildReconOwnership(snapshot, findings, subjects),
+		Surface:    buildReconSurface(snapshot),
+		Guardrails: buildReconGuardrails(snapshot),
+		Provenance: buildReconProvenance(snapshot),
+	}
+	r.HeadlineChips = buildHeadlineChips(r)
+	return r
+}
+
+func buildReconShape(s models.Snapshot) ReconShape {
+	shape := ReconShape{
+		NamespaceCount: len(s.Resources.Namespaces),
+		PodCount:       len(s.Resources.Pods),
+		SACount:        len(s.Resources.ServiceAccounts),
+		NodeCount:      len(s.Resources.Nodes),
+		CloudLabel:     "On-prem / unknown",
+	}
+
+	clusterVersion := strings.TrimSpace(s.Metadata.ClusterVersion)
+	var firstKubelet string
+	if len(s.Resources.Nodes) > 0 {
+		firstKubelet = s.Resources.Nodes[0].Status.NodeInfo.KubeletVersion
+	}
+	shape.Distribution = distroFromVersion(clusterVersion, firstKubelet)
+
+	if cloud := strings.TrimSpace(s.Metadata.CloudProvider); cloud != "" && !strings.EqualFold(cloud, "none") {
+		region := mostCommonNodeLabel(s.Resources.Nodes, "topology.kubernetes.io/region")
+		if region != "" {
+			shape.CloudLabel = strings.ToUpper(cloud) + " / " + region
+		} else {
+			shape.CloudLabel = strings.ToUpper(cloud)
+		}
+	} else if c := cloudFromNodes(s.Resources.Nodes); c != "" {
+		shape.CloudLabel = c
+	}
+
+	shape.ArchBreakdown = nodeArchBreakdown(s.Resources.Nodes)
+	shape.OSImage = mostCommonOSImage(s.Resources.Nodes)
+	shape.KubeletVersions = nodeFieldHistogram(s.Resources.Nodes, func(n corev1.Node) string {
+		return n.Status.NodeInfo.KubeletVersion
+	})
+	shape.RuntimeVersions = nodeFieldHistogram(s.Resources.Nodes, func(n corev1.Node) string {
+		return n.Status.NodeInfo.ContainerRuntimeVersion
+	})
+
+	shape.APIHost, shape.APIReachability = apiReachability(s.Metadata.APIServerURL)
+	return shape
+}
+
+// distroFromVersion sniffs managed-Kubernetes flavour suffixes (-eks, -gke, -aks)
+// in the cluster + kubelet version strings, falling back to the cluster version
+// alone when no flavour signature is found.
+func distroFromVersion(clusterVersion, kubeletVersion string) string {
+	v := strings.TrimSpace(clusterVersion)
+	if v == "" {
+		v = strings.TrimSpace(kubeletVersion)
+	}
+	if v == "" {
+		return ""
+	}
+	merged := strings.ToLower(clusterVersion + " " + kubeletVersion)
+	switch {
+	case strings.Contains(merged, "-eks") || strings.Contains(merged, "+eks"):
+		return "EKS " + v
+	case strings.Contains(merged, "-gke") || strings.Contains(merged, "+gke"):
+		return "GKE " + v
+	case strings.Contains(merged, "-aks") || strings.Contains(merged, "+aks"):
+		return "AKS " + v
+	}
+	return v
+}
+
+// cloudFromNodes infers a cloud-provider label from the first node's ProviderID
+// scheme combined with the most common topology.kubernetes.io/region label.
+func cloudFromNodes(nodes []corev1.Node) string {
+	if len(nodes) == 0 {
+		return ""
+	}
+	provider := ""
+	for _, n := range nodes {
+		if pid := n.Spec.ProviderID; pid != "" {
+			if i := strings.Index(pid, ":"); i > 0 {
+				provider = strings.ToUpper(pid[:i])
+				break
+			}
+		}
+	}
+	region := mostCommonNodeLabel(nodes, "topology.kubernetes.io/region")
+	switch {
+	case provider != "" && region != "":
+		return provider + " / " + region
+	case provider != "":
+		return provider
+	case region != "":
+		return region
+	}
+	return ""
+}
+
+func mostCommonNodeLabel(nodes []corev1.Node, key string) string {
+	counts := map[string]int{}
+	for _, n := range nodes {
+		if v := n.Labels[key]; v != "" {
+			counts[v]++
+		}
+	}
+	return mostCommonKey(counts)
+}
+
+// mostCommonKey returns the highest-count key with an alphabetical tiebreak so
+// repeated calls on the same input return a stable result.
+func mostCommonKey(m map[string]int) string {
+	best := ""
+	bestN := 0
+	for k, n := range m {
+		if n > bestN || (n == bestN && (best == "" || k < best)) {
+			best, bestN = k, n
+		}
+	}
+	return best
+}
+
+func nodeArchBreakdown(nodes []corev1.Node) string {
+	if len(nodes) == 0 {
+		return ""
+	}
+	counts := map[string]int{}
+	for _, n := range nodes {
+		arch := strings.TrimSpace(n.Status.NodeInfo.Architecture)
+		if arch == "" {
+			arch = "unknown"
+		}
+		counts[arch]++
+	}
+	keys := sortedKeysByCount(counts)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%d×%s", counts[k], k))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func mostCommonOSImage(nodes []corev1.Node) string {
+	counts := map[string]int{}
+	for _, n := range nodes {
+		img := strings.TrimSpace(n.Status.NodeInfo.OSImage)
+		if img != "" {
+			counts[img]++
+		}
+	}
+	return mostCommonKey(counts)
+}
+
+func nodeFieldHistogram(nodes []corev1.Node, get func(corev1.Node) string) []string {
+	if len(nodes) == 0 {
+		return nil
+	}
+	counts := map[string]int{}
+	for _, n := range nodes {
+		v := strings.TrimSpace(get(n))
+		if v != "" {
+			counts[v]++
+		}
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	keys := sortedKeysByCount(counts)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf("%s ×%d", k, counts[k]))
+	}
+	return out
+}
+
+// sortedKeysByCount sorts map keys by descending count, alphabetical tiebreak.
+func sortedKeysByCount(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if m[keys[i]] != m[keys[j]] {
+			return m[keys[i]] > m[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+// apiReachability classifies the API-server host as private/public/loopback/linklocal
+// based on a literal IP. DNS names yield "unknown" — we never resolve, by design.
+func apiReachability(rawURL string) (host, label string) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", "unknown"
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL, "unknown"
+	}
+	host = u.Hostname()
+	if host == "" {
+		return rawURL, "unknown"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return host, "unknown"
+	}
+	switch {
+	case ip.IsLoopback():
+		return host, "loopback"
+	case ip.IsLinkLocalUnicast():
+		return host, "linklocal"
+	case ip.IsPrivate():
+		return host, "private"
+	default:
+		return host, "public"
+	}
+}
+
+func buildReconOwnership(s models.Snapshot, findings []models.Finding, subjects map[string]*permissions.EffectivePermissions) ReconOwnership {
+	o := ReconOwnership{}
+	o.ClusterAdmins = collectClusterAdmins(s.Resources.ClusterRoleBindings)
+	o.WildcardVerbSubjects = collectWildcardVerbSubjects(subjects)
+	o.SecretReaders = collectSecretReaders(subjects)
+
+	for _, f := range findings {
+		switch f.RuleID {
+		case "KUBE-PRIVESC-PATH-CLUSTER-ADMIN":
+			o.PrivescToAdminCount++
+			if o.PrivescToAdminAnchor == "" {
+				o.PrivescToAdminAnchor = "finding-" + f.RuleID
+			}
+		case "KUBE-PRIVESC-PATH-NODE-ESCAPE":
+			o.NodeEscapeCount++
+			if o.NodeEscapeAnchor == "" {
+				o.NodeEscapeAnchor = "finding-" + f.RuleID
+			}
+		}
+	}
+	return o
+}
+
+// collectClusterAdmins walks ClusterRoleBindings for refs to the well-known
+// `cluster-admin` ClusterRole and emits the bound subjects. The canonical
+// `system:masters` group is filtered out — it's the bootstrap binding present
+// on every cluster, and surfacing it would dominate the list with a single
+// line of meaningless "every cluster has this" noise.
+func collectClusterAdmins(bindings []rbacv1.ClusterRoleBinding) ReconSubjectList {
+	names := []string{}
+	for _, b := range bindings {
+		if b.RoleRef.Kind != "ClusterRole" || b.RoleRef.Name != "cluster-admin" {
+			continue
+		}
+		for _, sub := range b.Subjects {
+			if sub.Kind == "Group" && sub.Name == "system:masters" {
+				continue
+			}
+			ref := models.SubjectRef{Kind: sub.Kind, Name: sub.Name, Namespace: sub.Namespace}
+			names = append(names, ref.Key())
+		}
+	}
+	return makeSubjectList(names, "finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN")
+}
+
+func collectWildcardVerbSubjects(subjects map[string]*permissions.EffectivePermissions) ReconSubjectList {
+	keys := []string{}
+	for key, perm := range subjects {
+		if hasWildcardEffective(perm.Rules) {
+			keys = append(keys, key)
+		}
+	}
+	return makeSubjectList(keys, "")
+}
+
+// hasWildcardEffective flags subjects whose effective rules wildcard verbs against
+// a non-trivial resource/apiGroup footprint. Rules that wildcard verbs against a
+// single named resource are excluded — "secrets get/list/watch" already lights up
+// SecretReaders without inflating the wildcard count.
+func hasWildcardEffective(rules []permissions.EffectiveRule) bool {
+	for _, r := range rules {
+		if !sliceContains(r.Verbs, "*") {
+			continue
+		}
+		if sliceContains(r.Resources, "*") || sliceContains(r.APIGroups, "*") || len(r.Resources) >= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+func collectSecretReaders(subjects map[string]*permissions.EffectivePermissions) ReconSubjectList {
+	keys := []string{}
+	for key, perm := range subjects {
+		if grantsSecretRead(perm.Rules) {
+			keys = append(keys, key)
+		}
+	}
+	return makeSubjectList(keys, "")
+}
+
+func grantsSecretRead(rules []permissions.EffectiveRule) bool {
+	for _, r := range rules {
+		if !(sliceContains(r.Resources, "secrets") || sliceContains(r.Resources, "*")) {
+			continue
+		}
+		if !(sliceContains(r.APIGroups, "") || sliceContains(r.APIGroups, "*")) {
+			continue
+		}
+		if sliceContains(r.Verbs, "*") || sliceContains(r.Verbs, "get") || sliceContains(r.Verbs, "list") || sliceContains(r.Verbs, "watch") {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func makeSubjectList(keys []string, anchor string) ReconSubjectList {
+	uniq := uniqueSorted(keys)
+	if len(uniq) == 0 {
+		return ReconSubjectList{Anchor: anchor}
+	}
+	sample := uniq
+	if len(sample) > 3 {
+		sample = sample[:3]
+	}
+	return ReconSubjectList{
+		Total:     len(uniq),
+		Sample:    append([]string(nil), sample...),
+		MoreCount: len(uniq) - len(sample),
+		Anchor:    anchor,
+	}
+}
+
+func uniqueSorted(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func buildReconSurface(s models.Snapshot) ReconSurface {
+	sf := ReconSurface{}
+	lbNames := []string{}
+	for _, svc := range s.Resources.Services {
+		switch svc.Spec.Type {
+		case corev1.ServiceTypeLoadBalancer:
+			lbNames = append(lbNames, svc.Namespace+"/"+svc.Name)
+		case corev1.ServiceTypeNodePort:
+			sf.NodePorts++
+		}
+		if len(svc.Spec.ExternalIPs) > 0 {
+			sf.ExternalIPs++
+		}
+	}
+	sf.LoadBalancers = makeResourceList(lbNames)
+
+	hostNet := []string{}
+	priv := []string{}
+	for _, p := range s.Resources.Pods {
+		if p.Spec.HostNetwork {
+			hostNet = append(hostNet, p.Namespace+"/"+p.Name)
+		}
+		if podHasPrivilegedContainer(p) {
+			priv = append(priv, p.Namespace+"/"+p.Name)
+		}
+	}
+	sf.HostNetworkPods = makeResourceList(hostNet)
+	sf.PrivilegedPods = makeResourceList(priv)
+
+	sf.MutatingWebhooks = len(s.Resources.MutatingWebhookConfigs)
+	for _, m := range s.Resources.MutatingWebhookConfigs {
+		for _, w := range m.Webhooks {
+			if w.ClientConfig.URL != nil && *w.ClientConfig.URL != "" {
+				sf.OutOfClusterWebhooks++
+				break
+			}
+		}
+	}
+	return sf
+}
+
+func podHasPrivilegedContainer(p corev1.Pod) bool {
+	if containerListIsPrivileged(p.Spec.Containers) {
+		return true
+	}
+	return containerListIsPrivileged(p.Spec.InitContainers)
+}
+
+func containerListIsPrivileged(containers []corev1.Container) bool {
+	for _, c := range containers {
+		if c.SecurityContext != nil && c.SecurityContext.Privileged != nil && *c.SecurityContext.Privileged {
+			return true
+		}
+	}
+	return false
+}
+
+func makeResourceList(items []string) ReconResourceList {
+	uniq := uniqueSorted(items)
+	if len(uniq) == 0 {
+		return ReconResourceList{}
+	}
+	sample := uniq
+	if len(sample) > 3 {
+		sample = sample[:3]
+	}
+	return ReconResourceList{
+		Total:     len(uniq),
+		Sample:    append([]string(nil), sample...),
+		MoreCount: len(uniq) - len(sample),
+	}
+}
+
+func buildReconGuardrails(s models.Snapshot) ReconGuardrails {
+	g := ReconGuardrails{
+		NetworkPolicies: len(s.Resources.NetworkPolicies),
+		PSAEnforce:      map[string]int{},
+	}
+
+	npByNamespace := map[string]bool{}
+	for _, np := range s.Resources.NetworkPolicies {
+		npByNamespace[np.Namespace] = true
+	}
+	g.NamespacesProtected = len(npByNamespace)
+
+	podByNamespace := map[string]bool{}
+	for _, p := range s.Resources.Pods {
+		if p.Namespace != "" {
+			podByNamespace[p.Namespace] = true
+		}
+	}
+	for ns := range podByNamespace {
+		if !npByNamespace[ns] {
+			g.NamespacesUnprotected++
+		}
+	}
+
+	for _, ns := range s.Resources.Namespaces {
+		if mode := strings.TrimSpace(ns.Labels["pod-security.kubernetes.io/enforce"]); mode != "" {
+			g.PSAEnforce[mode]++
+		}
+	}
+
+	if len(s.Resources.KyvernoClusterPolicies)+len(s.Resources.KyvernoPolicies) > 0 {
+		g.Engines = append(g.Engines, "Kyverno")
+	}
+	if len(s.Resources.GatekeeperConstraintTemplates) > 0 {
+		g.Engines = append(g.Engines, "Gatekeeper")
+	}
+	if len(s.Resources.ValidatingAdmissionPolicies) > 0 {
+		g.Engines = append(g.Engines, "VAP")
+	}
+
+	for _, p := range s.Resources.Pods {
+		sa := p.Spec.ServiceAccountName
+		if sa != "" && sa != "default" {
+			continue
+		}
+		// AutomountServiceAccountToken == nil means the apiserver default applies (true).
+		if p.Spec.AutomountServiceAccountToken != nil && !*p.Spec.AutomountServiceAccountToken {
+			continue
+		}
+		g.DefaultSATokenMounts++
+	}
+	return g
+}
+
+func buildReconProvenance(s models.Snapshot) ReconProvenance {
+	return ReconProvenance{
+		CollectorIdentity:     s.Metadata.CollectorIdentity,
+		PermissionsAvailable:  append([]string(nil), s.Metadata.PermissionsAvailable...),
+		PermissionsMissing:    append([]string(nil), s.Metadata.PermissionsMissing...),
+		CollectionWarnings:    append([]string(nil), s.Metadata.CollectionWarnings...),
+		NamespacesScanned:     append([]string(nil), s.Metadata.NamespacesScanned...),
+		CollectionDurationSec: s.Metadata.CollectionDurationSecond,
+	}
+}
+
+// buildHeadlineChips picks the four numbers that best tell the story at a glance:
+// node count (size), cluster-admin holders (compromise blast radius),
+// LoadBalancers (external attack surface), and NetworkPolicies (lateral-movement
+// containment). Each tone reflects whether the count is alarming for a pentester.
+func buildHeadlineChips(r Recon) []ReconChip {
+	return []ReconChip{
+		{
+			Label: pluralizeSimple(r.Shape.NodeCount, "node", "nodes"),
+			Value: strconv.Itoa(r.Shape.NodeCount),
+			Tone:  toneIf(r.Shape.NodeCount == 0, "warn", "ok"),
+		},
+		{
+			Label: pluralizeSimple(r.Ownership.ClusterAdmins.Total, "cluster-admin", "cluster-admins"),
+			Value: strconv.Itoa(r.Ownership.ClusterAdmins.Total),
+			Tone:  toneIf(r.Ownership.ClusterAdmins.Total > 0, "danger", "ok"),
+		},
+		{
+			Label: pluralizeSimple(r.Surface.LoadBalancers.Total, "LoadBalancer", "LoadBalancers"),
+			Value: strconv.Itoa(r.Surface.LoadBalancers.Total),
+			Tone:  toneIf(r.Surface.LoadBalancers.Total > 0, "warn", "ok"),
+		},
+		{
+			Label: pluralizeSimple(r.Guardrails.NetworkPolicies, "NetworkPolicy", "NetworkPolicies"),
+			Value: strconv.Itoa(r.Guardrails.NetworkPolicies),
+			Tone:  toneIf(r.Guardrails.NetworkPolicies == 0, "danger", "ok"),
+		},
+	}
+}
+
+func toneIf(condition bool, ifTrue, ifFalse string) string {
+	if condition {
+		return ifTrue
+	}
+	return ifFalse
+}

--- a/internal/report/recon_test.go
+++ b/internal/report/recon_test.go
@@ -1,0 +1,352 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// urlMutatingWebhook builds a single MutatingWebhookConfiguration whose only
+// webhook routes via an out-of-cluster URL — used to exercise the OutOfClusterWebhooks
+// counter without depending on the fixture's service-typed webhook.
+func urlMutatingWebhook(url string) admissionregistrationv1.MutatingWebhookConfiguration {
+	return admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "url-hook"},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			Name:         "ext.example.com",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{URL: &url},
+		}},
+	}
+}
+
+func TestApiReachability(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw       string
+		wantHost  string
+		wantLabel string
+	}{
+		{"", "", "unknown"},
+		{"https://127.0.0.1:43123", "127.0.0.1", "loopback"},
+		{"https://10.0.0.1:6443", "10.0.0.1", "private"},
+		{"https://192.168.1.10:6443", "192.168.1.10", "private"},
+		{"https://172.16.0.5:6443", "172.16.0.5", "private"},
+		{"https://203.0.113.10:6443", "203.0.113.10", "public"},
+		{"https://169.254.169.254", "169.254.169.254", "linklocal"},
+		{"https://eks.example.com", "eks.example.com", "unknown"},
+	}
+	for _, tc := range cases {
+		host, label := apiReachability(tc.raw)
+		if host != tc.wantHost || label != tc.wantLabel {
+			t.Errorf("apiReachability(%q) = (%q, %q), want (%q, %q)",
+				tc.raw, host, label, tc.wantHost, tc.wantLabel)
+		}
+	}
+}
+
+func TestDistroFromVersion(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		cluster string
+		kubelet string
+		want    string
+	}{
+		{"v1.28.5", "v1.28.5-eks-1234abcd", "EKS v1.28.5"},
+		{"v1.28.5", "v1.28.5", "v1.28.5"},
+		{"v1.28.5-gke.100", "v1.28.5-gke.100", "GKE v1.28.5-gke.100"},
+		{"v1.28.5", "v1.28.5+aks-patch1", "AKS v1.28.5"},
+		{"", "v1.30.0", "v1.30.0"},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		got := distroFromVersion(tc.cluster, tc.kubelet)
+		if got != tc.want {
+			t.Errorf("distroFromVersion(%q, %q) = %q, want %q",
+				tc.cluster, tc.kubelet, got, tc.want)
+		}
+	}
+}
+
+func TestCloudFromNodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		nodes []corev1.Node
+		want  string
+	}{
+		{"empty", nil, ""},
+		{
+			name: "aws with region",
+			nodes: []corev1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"topology.kubernetes.io/region": "us-east-1"}},
+				Spec:       corev1.NodeSpec{ProviderID: "aws:///us-east-1a/i-0abcd"},
+			}},
+			want: "AWS / us-east-1",
+		},
+		{
+			name: "gce no region",
+			nodes: []corev1.Node{{
+				Spec: corev1.NodeSpec{ProviderID: "gce://project/zone/instance"},
+			}},
+			want: "GCE",
+		},
+		{
+			name: "no providerID, region only",
+			nodes: []corev1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"topology.kubernetes.io/region": "eu-west-2"}},
+			}},
+			want: "eu-west-2",
+		},
+	}
+	for _, tc := range cases {
+		got := cloudFromNodes(tc.nodes)
+		if got != tc.want {
+			t.Errorf("%s: cloudFromNodes() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestBuildReconEmptySnapshot(t *testing.T) {
+	t.Parallel()
+	r := buildRecon(models.NewSnapshot(), nil, nil)
+
+	// Headline chips must always be present so the collapsed disclosure isn't blank.
+	if got := len(r.HeadlineChips); got != 4 {
+		t.Fatalf("HeadlineChips: want 4, got %d (%#v)", got, r.HeadlineChips)
+	}
+	if r.Shape.NodeCount != 0 || r.Shape.PodCount != 0 {
+		t.Errorf("expected zero counts on empty snapshot, got %#v", r.Shape)
+	}
+	if r.Ownership.ClusterAdmins.Total != 0 {
+		t.Errorf("expected zero cluster-admins, got %d", r.Ownership.ClusterAdmins.Total)
+	}
+	if r.Shape.APIReachability != "unknown" {
+		t.Errorf("expected APIReachability=unknown when no URL, got %q", r.Shape.APIReachability)
+	}
+	if r.Shape.CloudLabel == "" {
+		t.Errorf("CloudLabel should default to a non-empty placeholder, got empty")
+	}
+}
+
+func TestBuildReconMinimalRiskyFixture(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join("..", "..", "testdata", "snapshots", "minimal-risky.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var snap models.Snapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	subjects := permissions.Aggregate(snap)
+	r := buildRecon(snap, nil, subjects)
+
+	// Cluster shape — fixture has 2 namespaces, 1 pod, 0 nodes.
+	if r.Shape.NamespaceCount != 2 {
+		t.Errorf("NamespaceCount: want 2, got %d", r.Shape.NamespaceCount)
+	}
+	if r.Shape.PodCount != 1 {
+		t.Errorf("PodCount: want 1, got %d", r.Shape.PodCount)
+	}
+	if r.Shape.NodeCount != 0 {
+		t.Errorf("NodeCount: want 0, got %d", r.Shape.NodeCount)
+	}
+	// fixture.local is a DNS name → unknown reachability (we never resolve).
+	if r.Shape.APIReachability != "unknown" {
+		t.Errorf("APIReachability: want unknown, got %q", r.Shape.APIReachability)
+	}
+
+	// Ownership — fixture has no cluster-admin binding.
+	if r.Ownership.ClusterAdmins.Total != 0 {
+		t.Errorf("ClusterAdmins.Total: want 0, got %d", r.Ownership.ClusterAdmins.Total)
+	}
+	// reader-role grants get,list on secrets via cluster-role-binding to ServiceAccount/default/reader.
+	if r.Ownership.SecretReaders.Total != 1 {
+		t.Errorf("SecretReaders.Total: want 1, got %d (sample=%v)",
+			r.Ownership.SecretReaders.Total, r.Ownership.SecretReaders.Sample)
+	}
+
+	// Surface — fixture has 1 mutating webhook (service-typed → 0 out-of-cluster).
+	if r.Surface.MutatingWebhooks != 1 {
+		t.Errorf("MutatingWebhooks: want 1, got %d", r.Surface.MutatingWebhooks)
+	}
+	if r.Surface.OutOfClusterWebhooks != 0 {
+		t.Errorf("OutOfClusterWebhooks: want 0, got %d", r.Surface.OutOfClusterWebhooks)
+	}
+
+	// Guardrails — 1 NetworkPolicy (in flat-network); default namespace has pods + no NetPol.
+	if r.Guardrails.NetworkPolicies != 1 {
+		t.Errorf("NetworkPolicies: want 1, got %d", r.Guardrails.NetworkPolicies)
+	}
+	if r.Guardrails.NamespacesProtected != 1 {
+		t.Errorf("NamespacesProtected: want 1, got %d", r.Guardrails.NamespacesProtected)
+	}
+	if r.Guardrails.NamespacesUnprotected != 1 {
+		t.Errorf("NamespacesUnprotected: want 1 (default has pod, no netpol), got %d",
+			r.Guardrails.NamespacesUnprotected)
+	}
+}
+
+func TestBuildReconClusterAdminFiltersSystemMasters(t *testing.T) {
+	t.Parallel()
+	snap := models.NewSnapshot()
+	snap.Resources.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+			Subjects: []rbacv1.Subject{
+				{Kind: "Group", Name: "system:masters"}, // bootstrap binding — must be filtered
+				{Kind: "ServiceAccount", Name: "ops", Namespace: "kube-system"},
+				{Kind: "User", Name: "alice@example.com"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "irrelevant"},
+			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "view"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "viewer"}},
+		},
+	}
+
+	r := buildRecon(snap, nil, permissions.Aggregate(snap))
+
+	if r.Ownership.ClusterAdmins.Total != 2 {
+		t.Errorf("ClusterAdmins.Total: want 2 (system:masters filtered), got %d (sample=%v)",
+			r.Ownership.ClusterAdmins.Total, r.Ownership.ClusterAdmins.Sample)
+	}
+	for _, s := range r.Ownership.ClusterAdmins.Sample {
+		if s == "Group/system:masters" {
+			t.Errorf("ClusterAdmins.Sample contains system:masters, expected filtered: %v",
+				r.Ownership.ClusterAdmins.Sample)
+		}
+	}
+	if r.Ownership.ClusterAdmins.Anchor == "" {
+		t.Errorf("ClusterAdmins.Anchor: want non-empty deep-link, got empty")
+	}
+}
+
+func TestBuildReconHeadlineChips(t *testing.T) {
+	t.Parallel()
+	snap := models.NewSnapshot()
+	// One cluster-admin holder + zero NetworkPolicies should both flag danger.
+	snap.Resources.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{{
+		ObjectMeta: metav1.ObjectMeta{Name: "ca"},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice"}},
+	}}
+
+	r := buildRecon(snap, nil, permissions.Aggregate(snap))
+	if len(r.HeadlineChips) != 4 {
+		t.Fatalf("want 4 chips, got %d", len(r.HeadlineChips))
+	}
+	// Order is fixed by buildHeadlineChips: nodes, cluster-admins, LoadBalancers, NetworkPolicies.
+	if r.HeadlineChips[1].Tone != "danger" {
+		t.Errorf("cluster-admins chip tone: want danger when >0, got %q", r.HeadlineChips[1].Tone)
+	}
+	if r.HeadlineChips[3].Tone != "danger" {
+		t.Errorf("NetworkPolicies chip tone: want danger when 0, got %q", r.HeadlineChips[3].Tone)
+	}
+	if r.HeadlineChips[0].Value != "0" {
+		t.Errorf("nodes chip value: want 0, got %q", r.HeadlineChips[0].Value)
+	}
+}
+
+func TestBuildReconPrivescAnchorsSurfaceFromFindings(t *testing.T) {
+	t.Parallel()
+	snap := models.NewSnapshot()
+	findings := []models.Finding{
+		{
+			ID:       "f1",
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "x", Namespace: "y"},
+			Tags:     []string{"module:privesc"},
+		},
+		{
+			ID:       "f2",
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "z", Namespace: "y"},
+			Tags:     []string{"module:privesc"},
+		},
+		{
+			ID:       "f3",
+			RuleID:   "KUBE-PRIVESC-PATH-NODE-ESCAPE",
+			Severity: models.SeverityHigh,
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "n", Namespace: "y"},
+			Tags:     []string{"module:privesc"},
+		},
+	}
+
+	r := buildRecon(snap, findings, nil)
+	if r.Ownership.PrivescToAdminCount != 2 {
+		t.Errorf("PrivescToAdminCount: want 2, got %d", r.Ownership.PrivescToAdminCount)
+	}
+	if r.Ownership.PrivescToAdminAnchor != "finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN" {
+		t.Errorf("PrivescToAdminAnchor: want finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN, got %q",
+			r.Ownership.PrivescToAdminAnchor)
+	}
+	if r.Ownership.NodeEscapeCount != 1 {
+		t.Errorf("NodeEscapeCount: want 1, got %d", r.Ownership.NodeEscapeCount)
+	}
+}
+
+func TestBuildReconExposedSurfaceCounts(t *testing.T) {
+	t.Parallel()
+	snap := models.NewSnapshot()
+	priv := true
+	snap.Resources.Pods = []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "host-net", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				HostNetwork: true,
+				Containers:  []corev1.Container{{Name: "app"}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "rooty", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "app", SecurityContext: &corev1.SecurityContext{Privileged: &priv}},
+				},
+			},
+		},
+	}
+	snap.Resources.MutatingWebhookConfigs = []admissionregistrationv1.MutatingWebhookConfiguration{
+		urlMutatingWebhook("https://hooks.example.com/mutate"),
+	}
+	snap.Resources.Services = []corev1.Service{
+		{ObjectMeta: metav1.ObjectMeta{Name: "frontend", Namespace: "default"}, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "internal", Namespace: "default"}, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "weird", Namespace: "default"}, Spec: corev1.ServiceSpec{ExternalIPs: []string{"203.0.113.5"}}},
+	}
+
+	r := buildRecon(snap, nil, nil)
+	if r.Surface.HostNetworkPods.Total != 1 {
+		t.Errorf("HostNetworkPods.Total: want 1, got %d", r.Surface.HostNetworkPods.Total)
+	}
+	if r.Surface.PrivilegedPods.Total != 1 {
+		t.Errorf("PrivilegedPods.Total: want 1, got %d", r.Surface.PrivilegedPods.Total)
+	}
+	if r.Surface.LoadBalancers.Total != 1 {
+		t.Errorf("LoadBalancers.Total: want 1, got %d", r.Surface.LoadBalancers.Total)
+	}
+	if r.Surface.NodePorts != 1 {
+		t.Errorf("NodePorts: want 1, got %d", r.Surface.NodePorts)
+	}
+	if r.Surface.ExternalIPs != 1 {
+		t.Errorf("ExternalIPs: want 1, got %d", r.Surface.ExternalIPs)
+	}
+	if r.Surface.OutOfClusterWebhooks != 1 {
+		t.Errorf("OutOfClusterWebhooks: want 1 (URL-typed), got %d", r.Surface.OutOfClusterWebhooks)
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -128,6 +128,43 @@ func TestBuildHTMLDataGroupsFindings(t *testing.T) {
 	if len(data.TopNamespaces) == 0 || data.TopNamespaces[0].Label != "default" {
 		t.Fatalf("unexpected top namespaces: %#v", data.TopNamespaces)
 	}
+	// The recon panel must always be populated end-to-end so the template never
+	// nil-derefs; HeadlineChips is the four-pill teaser shown on the closed disclosure.
+	if got := len(data.Recon.HeadlineChips); got != 4 {
+		t.Fatalf("Recon.HeadlineChips: want 4, got %d", got)
+	}
+	if data.Recon.Shape.NodeCount != 0 {
+		t.Errorf("Recon.Shape.NodeCount: want 0 from empty snapshot, got %d", data.Recon.Shape.NodeCount)
+	}
+}
+
+// TestBuildHTMLDataReconPlumbsPrivescAnchor verifies that a privesc finding present in
+// the input slice surfaces a clickable anchor on the recon panel — the cheapest end-to-end
+// proof that buildRecon is wired into BuildHTMLData rather than left dangling.
+func TestBuildHTMLDataReconPlumbsPrivescAnchor(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.NewSnapshot()
+	findings := []models.Finding{
+		{
+			ID:       "f-privesc",
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Category: models.CategoryPrivilegeEscalation,
+			Title:    "privesc path",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "risky", Namespace: "default"},
+			Tags:     []string{"module:privesc"},
+		},
+	}
+
+	data := BuildHTMLData(snapshot, findings)
+	if data.Recon.Ownership.PrivescToAdminCount != 1 {
+		t.Errorf("PrivescToAdminCount: want 1, got %d", data.Recon.Ownership.PrivescToAdminCount)
+	}
+	if data.Recon.Ownership.PrivescToAdminAnchor != "finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN" {
+		t.Errorf("PrivescToAdminAnchor: want finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN, got %q",
+			data.Recon.Ownership.PrivescToAdminAnchor)
+	}
 }
 
 func TestBuildHTMLDataTOCEntries(t *testing.T) {
@@ -440,6 +477,9 @@ func TestHTMLReportInteractiveGraph(t *testing.T) {
 		`class="kp-detail"`,
 		`class="kp-tooltip"`,
 		`KUBE-PRIVESC-009`,
+		// Cluster-reconnaissance panel — collapsed by default but always rendered.
+		`class="recon-card"`,
+		`Cluster reconnaissance`,
 	}
 	for _, needle := range mustContain {
 		if !strings.Contains(html, needle) {

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
 )
 
 // BuildSummary counts findings by severity to produce a Summary.
@@ -96,6 +97,8 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 	summary := BuildSummary(findings)
 	risk, level, gaugeColor := computeRiskIndex(summary)
 	graph, graphPayload := buildAttackGraph(findings)
+	subjects := permissions.Aggregate(snapshot)
+	recon := buildRecon(snapshot, findings, subjects)
 
 	// AnchorByFindingID maps Finding.ID → the rule-level anchor ("finding-<RuleID>") on
 	// the FIRST occurrence of each rule across all modules in render order. The narrative
@@ -127,6 +130,7 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 
 	data := htmlReportData{
 		Snapshot:      snapshot,
+		Recon:         recon,
 		Summary:       summary,
 		Findings:      findings,
 		Modules:       modules,

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -238,6 +238,7 @@ type HopView struct {
 // htmlReportData is the template input for the HTML dashboard; assembled by BuildHTMLData.
 type htmlReportData struct {
 	Snapshot      models.Snapshot
+	Recon         Recon
 	Summary       Summary
 	Findings      []models.Finding
 	Modules       []ModuleSection


### PR DESCRIPTION
## Summary

- New collapsible **Cluster reconnaissance** panel above the executive-summary card. Closed by default with a four-pill teaser (`1 node · 2 cluster-admins · 4 LoadBalancers · 0 NetworkPolicies`) so even the collapsed state already hints at what's inside.
- Expanded view groups pentester-relevant facts into four sections — **Cluster shape** (distribution, cloud, API reachability, node arch/OS, kubelet/runtime versions, inventory), **Who already owns this cluster** (cluster-admin holders, wildcard-verb subjects, secret readers, deep-linked privesc-path counts), **Exposed surface** (LoadBalancers, NodePorts, externalIPs, hostNetwork pods, privileged pods, mutating webhooks), **Guardrails** (NetworkPolicies coverage, PSA labels, policy engines, default-SA token mounts) — plus a nested **Collection provenance** sub-disclosure.
- All data is derived from the existing `models.Snapshot` at render time. No collector or model changes; `permissions.Aggregate` powers the ownership rows and the existing `KUBE-PRIVESC-PATH-*` RuleIDs become deep-link chips into the Findings tab.

## Notes

- `system:masters` group binding is filtered from the cluster-admin list so the row reflects real human/SA admins, not the bootstrap.
- API-server URL classification (`public`/`private`/`loopback`/`linklocal`) uses literal-IP RFC1918 / loopback / link-local checks; DNS names are labelled `unknown` (we never resolve).
- Cloud / region inferred from `Spec.ProviderID` scheme + `topology.kubernetes.io/region` label when `Snapshot.Metadata.CloudProvider` is empty or `none`.
- Mobile: long monospace identifiers (`ServiceAccount/rbac-fixtures/sa-cluster-admin`) wrap mid-token via `overflow-wrap: anywhere`. Disclosure marker is a 22×22 outlined `▶` chip so the affordance reads as a button on phones.
- Sample on the e2e kind cluster (97 findings): correctly surfaces 8 → cluster-admin and 6 → node-escape privesc paths, 7 hostNetwork pods, 3 privileged pods, 5 unprotected namespaces, and 13 default-SA pods with token automount.

## Test plan

- [x] `make build`
- [x] `make test` (8 new unit tests in `internal/report/recon_test.go` + extended `report_test.go` assertions; all green)
- [x] `make lint` (`gofmt` + `go vet`)
- [x] `make e2e` against kind cluster — recon panel rendered with valid live data
- [x] Eyeball expanded panel on iPhone 17 Pro Max viewport
- [x] Verify deep-link chips jump to the right finding anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)