### PR TITLE
docs: point README video at GitHub user-attachments asset URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Kubernetes security assessment CLI that maps every RBAC subject's privilege-es
 
 * [Live example report](https://0hardik1.github.io/kubesplaining/)
 
-> <video src="https://github.com/0hardik1/kubesplaining/raw/main/docs/assets/kubesplaining.mp4" controls width="100%"></video>
+> <video src="https://github.com/user-attachments/assets/b32aa71e-4220-437d-8676-2a58a466a5e1" controls width="100%"></video>
 
 Inspired by [Kinnaird McQuade](https://www.linkedin.com/in/kmcquade3/) at BeyondTrust Phantom Labs and his [Cloudsplaining](https://github.com/salesforce/cloudsplaining), which does the same job for AWS IAM. Kubesplaining reads a live cluster or a previously captured snapshot, analyzes it against a library of techniques, and produces a prioritized list of findings: explanation, not just detection.
 


### PR DESCRIPTION
## Summary

- Replace the broken `raw.githubusercontent.com` `<video>` source on README line 13 with the `github.com/user-attachments/assets/...` URL produced by uploading the MP4 through GitHub's UI.
- This fixes #59's regression where the hero demo rendered as an empty blockquote.

## Why the previous URL didn't work

1. GitHub's README HTML sanitizer strips `<video>` tags whose `src` points at `raw.githubusercontent.com` — the rendered HTML for line 13 was an empty `<p>` inside the blockquote.
2. The raw endpoint serves the file as `Content-Type: application/octet-stream` with `X-Content-Type-Options: nosniff`, so even if the tag survived sanitization the browser would refuse to play it inline.
3. The page CSP's `media-src` directive doesn't allowlist `raw.githubusercontent.com`.

The `user-attachments/assets/` host (which `github.com` is the front for) clears all three checks because it's how GitHub itself serves drag-and-drop video uploads in issues/PRs.

## Test plan

- [ ] After merge, view README on github.com and confirm the inline `<video>` player renders and plays.
- [ ] Confirm the rendered HTML for line 13 contains a `<video>` element (e.g. `gh api repos/0hardik1/kubesplaining/readme -H "Accept: application/vnd.github.html" | grep video`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)