### PR TITLE
docs: link BeyondTrust Phantom Labs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Kubernetes security assessment CLI that maps every RBAC subject's privilege-es
 
 * [Live example report](https://0hardik1.github.io/kubesplaining/)
 
-> <video src="https://github.com/0hardik1/kubesplaining/raw/main/docs/assets/kubesplaining.mp4" controls width="100%"></video>
+> <video src="https://github.com/user-attachments/assets/b32aa71e-4220-437d-8676-2a58a466a5e1" controls width="100%"></video>
 
 Inspired by [Kinnaird McQuade](https://www.linkedin.com/in/kmcquade3/) at [BeyondTrust Phantom Labs](https://www.linkedin.com/company/beyondtrust-phantom-labs/) and his [Cloudsplaining](https://github.com/salesforce/cloudsplaining), which does the same job for AWS IAM. Kubesplaining reads a live cluster or a previously captured snapshot, analyzes it against a library of techniques, and produces a prioritized list of findings: explanation, not just detection.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Kubernetes security assessment CLI that maps every RBAC subject's privilege-es
 
 > <video src="https://github.com/0hardik1/kubesplaining/raw/main/docs/assets/kubesplaining.mp4" controls width="100%"></video>
 
-Inspired by [Kinnaird McQuade](https://www.linkedin.com/in/kmcquade3/) at BeyondTrust Phantom Labs and his [Cloudsplaining](https://github.com/salesforce/cloudsplaining), which does the same job for AWS IAM. Kubesplaining reads a live cluster or a previously captured snapshot, analyzes it against a library of techniques, and produces a prioritized list of findings: explanation, not just detection.
+Inspired by [Kinnaird McQuade](https://www.linkedin.com/in/kmcquade3/) at [BeyondTrust Phantom Labs](https://www.linkedin.com/company/beyondtrust-phantom-labs/) and his [Cloudsplaining](https://github.com/salesforce/cloudsplaining), which does the same job for AWS IAM. Kubesplaining reads a live cluster or a previously captured snapshot, analyzes it against a library of techniques, and produces a prioritized list of findings: explanation, not just detection.
 
 ## Why kubesplaining
 


### PR DESCRIPTION
## Summary

- Wrap the "BeyondTrust Phantom Labs" mention in the README's inspiration line with a link to https://www.linkedin.com/company/beyondtrust-phantom-labs/, matching the existing `[Kinnaird McQuade](...)` and `[Cloudsplaining](...)` links on the same line.

## Test plan

- [x] Confirm the rendered README shows "BeyondTrust Phantom Labs" as a clickable link to the LinkedIn company page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)