### PR TITLE
feat(report): cap findings to top 20 with category-balanced truncation

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/0hardik1/kubesplaining/internal/models"
 	"github.com/0hardik1/kubesplaining/internal/report"
 )
 
@@ -95,4 +96,16 @@ func printScanResults(w io.Writer, written []string, summary report.Summary) err
 		return err
 	}
 	return nil
+}
+
+// printTruncationNotice writes a one-line notice to w when the --max-findings
+// cap fired. It is meant for stderr so it never collides with JSON output on
+// stdout or the parseable `findings: total=...` line that CI scripts grep.
+// No-op when info.Truncated is false.
+func printTruncationNotice(w io.Writer, info models.TruncationInfo) {
+	if !info.Truncated {
+		return
+	}
+	fmt.Fprintf(w, "showing top %d of %d findings (re-run with --all-findings to include all)\n",
+		info.Shown, info.Original)
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -106,6 +106,8 @@ func printTruncationNotice(w io.Writer, info models.TruncationInfo) {
 	if !info.Truncated {
 		return
 	}
-	fmt.Fprintf(w, "showing top %d of %d findings (re-run with --all-findings to include all)\n",
+	// Stderr write failures are not actionable from a CLI helper, so swallow
+	// the error rather than propagate it through three call sites.
+	_, _ = fmt.Fprintf(w, "showing top %d of %d findings (re-run with --all-findings to include all)\n",
 		info.Shown, info.Original)
 }

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -23,6 +23,8 @@ func NewReportCmd() *cobra.Command {
 		exclusionsFile    string
 		exclusionsPreset  string
 		metadataFile      string
+		maxFindings       int
+		allFindings       bool
 	)
 
 	cmd := &cobra.Command{
@@ -56,6 +58,8 @@ func NewReportCmd() *cobra.Command {
 			}
 			filtered, _ = exclusions.Apply(cfg, filtered)
 
+			filtered, truncation := report.Truncate(filtered, maxFindings, allFindings)
+
 			snapshot := models.NewSnapshot()
 			snapshot.Metadata.ClusterName = "report-regeneration"
 			metadataPath := metadataFile
@@ -87,7 +91,7 @@ func NewReportCmd() *cobra.Command {
 				}
 			}
 
-			written, err := report.WriteWithAdmission(outputDir, outputFormats, snapshot, filtered, admissionSummary)
+			written, err := report.WriteWithAdmission(outputDir, outputFormats, snapshot, filtered, admissionSummary, truncation)
 			if err != nil {
 				return err
 			}
@@ -96,6 +100,7 @@ func NewReportCmd() *cobra.Command {
 			if err := printScanResults(cmd.OutOrStdout(), written, summary); err != nil {
 				return err
 			}
+			printTruncationNotice(cmd.ErrOrStderr(), truncation)
 
 			return nil
 		},
@@ -108,6 +113,8 @@ func NewReportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&exclusionsFile, "exclusions-file", "", "Path to a user-supplied exclusions YAML file (merged on top of --exclusions-preset)")
 	cmd.Flags().StringVar(&exclusionsPreset, "exclusions-preset", "standard", "Built-in exclusions preset: standard|minimal|strict|none")
 	cmd.Flags().StringVar(&metadataFile, "metadata-file", "", "Optional path to scan metadata JSON")
+	cmd.Flags().IntVar(&maxFindings, "max-findings", 20, "Cap the regenerated report to the top N findings by severity/score; 0 disables.")
+	cmd.Flags().BoolVar(&allFindings, "all-findings", false, "Include every finding in the regenerated report; overrides --max-findings")
 
 	return cmd
 }

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -36,6 +36,8 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 		ciMaxHigh            int
 		maxPrivescDepth      int
 		admissionMode        string
+		maxFindings          int
+		allFindings          bool
 	)
 
 	cmd := &cobra.Command{
@@ -75,11 +77,13 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 			}
 			findings, _ = exclusions.Apply(cfg, findings)
 
+			findings, truncation := report.Truncate(findings, maxFindings, allFindings)
+
 			if outputDir == "" {
 				outputDir = filepath.Join(".", "kubesplaining-report")
 			}
 
-			written, err := report.WriteWithAdmission(outputDir, outputFormats, snapshot, findings, result.Admission)
+			written, err := report.WriteWithAdmission(outputDir, outputFormats, snapshot, findings, result.Admission, truncation)
 			if err != nil {
 				return err
 			}
@@ -88,6 +92,7 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 			if err := printScanResults(cmd.OutOrStdout(), written, summary); err != nil {
 				return err
 			}
+			printTruncationNotice(cmd.ErrOrStderr(), truncation)
 
 			if ciMode {
 				if summary.Critical > ciMaxCritical {
@@ -120,6 +125,8 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 	cmd.Flags().IntVar(&ciMaxHigh, "ci-max-high", 0, "Maximum high findings allowed in CI mode")
 	cmd.Flags().IntVar(&maxPrivescDepth, "max-privesc-depth", 5, "Maximum depth for privilege escalation path search")
 	cmd.Flags().StringVar(&admissionMode, "admission-mode", string(analyzer.AdmissionModeSuppress), "How to react to namespace PSA labels: off|attenuate|suppress")
+	cmd.Flags().IntVar(&maxFindings, "max-findings", 20, "Cap the report to the top N findings by severity/score; 0 disables. CI thresholds evaluate against the truncated list — pass --all-findings in CI mode to evaluate all.")
+	cmd.Flags().BoolVar(&allFindings, "all-findings", false, "Include every finding in the report; overrides --max-findings")
 
 	return cmd
 }

--- a/internal/cli/scan_resource.go
+++ b/internal/cli/scan_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0hardik1/kubesplaining/internal/exclusions"
 	"github.com/0hardik1/kubesplaining/internal/manifest"
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/report"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +24,8 @@ func NewScanResourceCmd() *cobra.Command {
 		exclusionsFile   string
 		exclusionsPreset string
 		outputFormats    []string
+		maxFindings      int
+		allFindings      bool
 	)
 
 	cmd := &cobra.Command{
@@ -54,7 +57,13 @@ func NewScanResourceCmd() *cobra.Command {
 			}
 			findings, _ = exclusions.Apply(cfg, findings)
 
-			return writeScanResourceOutput(cmd, findings, outputFormats)
+			findings, truncation := report.Truncate(findings, maxFindings, allFindings)
+
+			if err := writeScanResourceOutput(cmd, findings, outputFormats); err != nil {
+				return err
+			}
+			printTruncationNotice(cmd.ErrOrStderr(), truncation)
+			return nil
 		},
 	}
 
@@ -63,6 +72,8 @@ func NewScanResourceCmd() *cobra.Command {
 	cmd.Flags().StringVar(&exclusionsFile, "exclusions-file", "", "Path to a user-supplied exclusions YAML file (merged on top of --exclusions-preset)")
 	cmd.Flags().StringVar(&exclusionsPreset, "exclusions-preset", "standard", "Built-in exclusions preset: standard|minimal|strict|none")
 	cmd.Flags().StringSliceVar(&outputFormats, "output-format", []string{"table"}, "Output formats: table,json")
+	cmd.Flags().IntVar(&maxFindings, "max-findings", 20, "Cap the output to the top N findings by severity/score; 0 disables.")
+	cmd.Flags().BoolVar(&allFindings, "all-findings", false, "Include every finding; overrides --max-findings")
 
 	return cmd
 }

--- a/internal/models/truncation.go
+++ b/internal/models/truncation.go
@@ -1,0 +1,23 @@
+package models
+
+// TruncationInfo records that the report's findings list was capped before
+// being written. It is rendered as a banner in the HTML report, surfaced as a
+// one-line stderr notice during scans, embedded in the SARIF run properties,
+// and persisted as truncation-info.json so `kubesplaining report` can
+// re-render the banner without re-running analysis.
+//
+// Truncated is the gate flag: when false (the zero value), the struct carries
+// no information and downstream renderers treat it as "no cap was applied."
+type TruncationInfo struct {
+	// Truncated is true only when the cap actually fired (Original > Limit
+	// and AllFindings was not set).
+	Truncated bool `json:"truncated"`
+	// Original is the size of the findings slice before the cap was applied,
+	// after exclusions and severity filtering.
+	Original int `json:"original"`
+	// Shown is min(Original, Limit) when Truncated; equals Original otherwise.
+	Shown int `json:"shown"`
+	// Limit is the --max-findings value that produced this state. Zero when
+	// --all-findings was passed.
+	Limit int `json:"limit"`
+}

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -113,6 +113,11 @@
     .admission-banner summary { cursor: pointer; color: var(--accent); font-size: 12.5px; }
     .admission-banner ul { margin: 6px 0 0; padding-left: 18px; }
     .admission-banner li { margin: 2px 0; }
+    .truncation-banner { margin-top: 12px; font-size: 13.5px; line-height: 1.55; color: var(--text-mut);
+      padding: 10px 14px; border: 1px solid rgba(255,179,71,0.32);
+      background: rgba(255,179,71,0.06); border-radius: 10px; }
+    .truncation-banner strong { color: var(--text); font-weight: 600; }
+    .truncation-banner code { color: var(--accent); background: rgba(106,183,255,0.10); padding: 1px 4px; border-radius: 4px; }
 
     /* Cluster reconnaissance — collapsible top-of-report panel surfacing
        pentester-relevant snapshot facts. Sits as the first card inside <main>
@@ -1106,6 +1111,15 @@
             </ul>
           </details>
           {{ end }}
+        </div>
+        {{ end }}
+
+        {{ if .Truncation.Truncated }}
+        <div class="truncation-banner" role="status">
+          <strong>Showing top {{ .Truncation.Shown }} of {{ .Truncation.Original }} findings.</strong>
+          Lower-priority findings were trimmed for readability. Re-run with
+          <code>kubesplaining scan --all-findings</code> to include the full list, or raise the cap with
+          <code>--max-findings={{ .Truncation.Original }}</code>.
         </div>
         {{ end }}
       </div>

--- a/internal/report/io.go
+++ b/internal/report/io.go
@@ -112,3 +112,50 @@ func ReadAdmissionSummary(path string) (models.AdmissionSummary, error) {
 func GuessAdmissionSummaryPath(findingsPath string) string {
 	return filepath.Join(filepath.Dir(findingsPath), "admission-summary.json")
 }
+
+// WriteTruncationInfo writes truncation-info.json alongside scan-metadata.json so the
+// `kubesplaining report` subcommand (and other consumers) can surface a "showing top N
+// of M" banner without having to re-run analysis. Only call this when the cap actually
+// fired; an empty (Truncated=false) sidecar would just be noise.
+func WriteTruncationInfo(outputDir string, info models.TruncationInfo) (string, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return "", fmt.Errorf("create truncation info directory: %w", err)
+	}
+
+	path := filepath.Join(outputDir, "truncation-info.json")
+	file, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create truncation info file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(info); err != nil {
+		return "", fmt.Errorf("encode truncation info file: %w", err)
+	}
+
+	return path, nil
+}
+
+// ReadTruncationInfo decodes a truncation-info.json file. Missing-file errors propagate;
+// callers should os.Stat first if absent files are acceptable.
+func ReadTruncationInfo(path string) (models.TruncationInfo, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return models.TruncationInfo{}, fmt.Errorf("open truncation info file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var info models.TruncationInfo
+	if err := json.NewDecoder(file).Decode(&info); err != nil {
+		return models.TruncationInfo{}, fmt.Errorf("decode truncation info file: %w", err)
+	}
+
+	return info, nil
+}
+
+// GuessTruncationInfoPath returns the default truncation-info.json location for a findings file.
+func GuessTruncationInfoPath(findingsPath string) string {
+	return filepath.Join(filepath.Dir(findingsPath), "truncation-info.json")
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -16,14 +16,20 @@ import (
 // Write emits the requested formats (html, json, csv, sarif) to outputDir along with the snapshot metadata side-file.
 // It always writes metadata.json; unsupported format names return an error without partial cleanup.
 func Write(outputDir string, formats []string, snapshot models.Snapshot, findings []models.Finding) ([]string, error) {
-	return WriteWithAdmission(outputDir, formats, snapshot, findings, models.AdmissionSummary{})
+	return WriteWithAdmission(outputDir, formats, snapshot, findings, models.AdmissionSummary{}, models.TruncationInfo{})
 }
 
 // WriteWithAdmission is Write plus an AdmissionSummary that is rendered into the HTML
 // header banner, written as a sidecar admission-summary.json alongside the metadata file
 // (so `kubesplaining report` can re-render the banner without re-running analysis), and
 // embedded in the SARIF run properties for downstream CI consumers.
-func WriteWithAdmission(outputDir string, formats []string, snapshot models.Snapshot, findings []models.Finding, admission models.AdmissionSummary) ([]string, error) {
+//
+// The TruncationInfo argument carries the --max-findings cap state. When
+// truncation.Truncated is true, a banner is rendered in the HTML report, the info
+// is embedded in the SARIF run properties, and a truncation-info.json sidecar is
+// written so `kubesplaining report` can re-render the banner without re-running
+// analysis. When false (the zero value), nothing is rendered.
+func WriteWithAdmission(outputDir string, formats []string, snapshot models.Snapshot, findings []models.Finding, admission models.AdmissionSummary, truncation models.TruncationInfo) ([]string, error) {
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create output directory: %w", err)
 	}
@@ -43,6 +49,14 @@ func WriteWithAdmission(outputDir string, formats []string, snapshot models.Snap
 		written = append(written, admissionPath)
 	}
 
+	if truncation.Truncated {
+		truncPath, err := WriteTruncationInfo(outputDir, truncation)
+		if err != nil {
+			return written, err
+		}
+		written = append(written, truncPath)
+	}
+
 	for _, format := range dedupeFormats(formats) {
 		switch format {
 		case "json":
@@ -53,7 +67,7 @@ func WriteWithAdmission(outputDir string, formats []string, snapshot models.Snap
 			written = append(written, path)
 		case "html":
 			path := filepath.Join(outputDir, "report.html")
-			if err := writeHTML(path, snapshot, findings, admission); err != nil {
+			if err := writeHTML(path, snapshot, findings, admission, truncation); err != nil {
 				return written, err
 			}
 			written = append(written, path)
@@ -65,7 +79,7 @@ func WriteWithAdmission(outputDir string, formats []string, snapshot models.Snap
 			written = append(written, path)
 		case "sarif":
 			path := filepath.Join(outputDir, "findings.sarif")
-			if err := writeSARIF(path, findings, admission); err != nil {
+			if err := writeSARIF(path, findings, admission, truncation); err != nil {
 				return written, err
 			}
 			written = append(written, path)
@@ -75,6 +89,110 @@ func WriteWithAdmission(outputDir string, formats []string, snapshot models.Snap
 	}
 
 	return written, nil
+}
+
+// Truncate caps an already-sorted findings slice to the top `limit` entries
+// while preserving category diversity. The analyzer engine emits findings
+// sorted by severity rank → score → ruleID; Truncate honors that order both
+// as the input ranking signal and as the output ordering.
+//
+// When the cap fires, findings are grouped by RiskCategory (preserving each
+// category's internal order) and selected round-robin, so a single dominant
+// category (e.g. privilege_escalation in clusters with sprawling RBAC) cannot
+// crowd out smaller categories like data_exfiltration or defense_evasion.
+// The selection is then re-sorted by the same global priority comparator so
+// the visible order is still severity-first — diversity affects which
+// findings appear, not the order they appear in.
+//
+// When allFindings is true, limit <= 0, or len(findings) <= limit, the input
+// is returned unchanged with a zero-value (Truncated=false) info — callers
+// can use that as a "do nothing" gate without re-checking the flags. The
+// underlying array is not mutated.
+//
+// `--max-findings=0` is treated as "no cap" rather than "show zero findings"
+// so an absent or zero flag never produces an empty report directory.
+func Truncate(findings []models.Finding, limit int, allFindings bool) ([]models.Finding, models.TruncationInfo) {
+	if allFindings || limit <= 0 || len(findings) <= limit {
+		return findings, models.TruncationInfo{}
+	}
+	return diverseTopN(findings, limit), models.TruncationInfo{
+		Truncated: true,
+		Original:  len(findings),
+		Shown:     limit,
+		Limit:     limit,
+	}
+}
+
+// diverseTopN selects up to `limit` findings using a category-balanced
+// round-robin draw, then re-sorts the selection by the global priority
+// comparator (severity rank → score → ruleID → title). The input MUST
+// already be sorted by that comparator: this preserves each category's
+// internal priority and keeps the absolute top-1 finding in the output.
+//
+// Round-robin guarantees that every category present in the input appears in
+// the output (subject to the cap), so a long tail of low-severity privesc
+// findings cannot push out higher-severity-but-rarer findings from other
+// categories. If only one category has findings, the function degenerates to
+// a simple `findings[:limit]` slice.
+func diverseTopN(findings []models.Finding, limit int) []models.Finding {
+	if limit <= 0 || len(findings) <= limit {
+		return findings
+	}
+
+	// Group findings by category. order tracks first-seen category order so
+	// the highest-priority category (whose first finding is the global top-1)
+	// gets the first round-robin pick — keeping the absolute top finding at
+	// the head of the output.
+	groups := make(map[models.RiskCategory][]models.Finding)
+	var order []models.RiskCategory
+	for i := range findings {
+		cat := findings[i].Category
+		if _, ok := groups[cat]; !ok {
+			order = append(order, cat)
+		}
+		groups[cat] = append(groups[cat], findings[i])
+	}
+
+	if len(order) <= 1 {
+		// Nothing to diversify across.
+		return findings[:limit]
+	}
+
+	result := make([]models.Finding, 0, limit)
+	indices := make(map[models.RiskCategory]int, len(order))
+	for len(result) < limit {
+		progress := false
+		for _, cat := range order {
+			i := indices[cat]
+			if i >= len(groups[cat]) {
+				continue
+			}
+			result = append(result, groups[cat][i])
+			indices[cat] = i + 1
+			progress = true
+			if len(result) == limit {
+				break
+			}
+		}
+		if !progress {
+			break
+		}
+	}
+
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Severity.Rank() != result[j].Severity.Rank() {
+			return result[i].Severity.Rank() > result[j].Severity.Rank()
+		}
+		if result[i].Score != result[j].Score {
+			return result[i].Score > result[j].Score
+		}
+		if result[i].RuleID != result[j].RuleID {
+			return result[i].RuleID < result[j].RuleID
+		}
+		return result[i].Title < result[j].Title
+	})
+
+	return result
 }
 
 // dedupeFormats lower-cases, trims, and deduplicates the requested format list; an empty input defaults to html+json.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -570,3 +570,397 @@ func TestHTMLReportHidesEvidenceWhenAllKeysSuppressed(t *testing.T) {
 		t.Errorf("evidence-raw <details> still rendered for fully-suppressed payload — expected the wrapper to be hidden")
 	}
 }
+
+func TestHTMLReportRendersTruncationBanner(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	snapshot := models.NewSnapshot()
+	snapshot.Metadata.ClusterName = "trunc-banner-on"
+
+	findings := []models.Finding{{
+		ID:       "finding-1",
+		RuleID:   "KUBE-TEST-001",
+		Severity: models.SeverityHigh,
+		Score:    8.0,
+		Category: models.CategoryPrivilegeEscalation,
+		Title:    "Banner fixture",
+	}}
+
+	written, err := WriteWithAdmission(tmpDir, []string{"html"}, snapshot, findings,
+		models.AdmissionSummary{},
+		models.TruncationInfo{Truncated: true, Original: 147, Shown: 20, Limit: 20})
+	if err != nil {
+		t.Fatalf("WriteWithAdmission() error = %v", err)
+	}
+
+	// Truncation sidecar must be written when the cap fired.
+	sidecarFound := false
+	for _, p := range written {
+		if filepath.Base(p) == "truncation-info.json" {
+			sidecarFound = true
+		}
+	}
+	if !sidecarFound {
+		t.Fatalf("expected truncation-info.json in written artifacts: %v", written)
+	}
+
+	htmlBytes, err := os.ReadFile(filepath.Join(tmpDir, "report.html"))
+	if err != nil {
+		t.Fatalf("read report.html: %v", err)
+	}
+	html := string(htmlBytes)
+
+	if !strings.Contains(html, `<div class="truncation-banner"`) {
+		t.Errorf("expected .truncation-banner div in HTML output")
+	}
+	if !strings.Contains(html, "Showing top 20 of 147 findings") {
+		t.Errorf("expected banner copy with shown/original counts in HTML output")
+	}
+	if !strings.Contains(html, "kubesplaining scan --all-findings") {
+		t.Errorf("expected banner to include the --all-findings rerun command")
+	}
+}
+
+func TestHTMLReportOmitsTruncationBannerWhenNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	snapshot := models.NewSnapshot()
+	snapshot.Metadata.ClusterName = "trunc-banner-off"
+
+	findings := []models.Finding{{
+		ID:       "finding-1",
+		RuleID:   "KUBE-TEST-002",
+		Severity: models.SeverityLow,
+		Score:    2.0,
+		Category: models.CategoryPrivilegeEscalation,
+		Title:    "No-banner fixture",
+	}}
+
+	written, err := WriteWithAdmission(tmpDir, []string{"html"}, snapshot, findings,
+		models.AdmissionSummary{}, models.TruncationInfo{})
+	if err != nil {
+		t.Fatalf("WriteWithAdmission() error = %v", err)
+	}
+
+	// No sidecar when truncation didn't fire.
+	for _, p := range written {
+		if filepath.Base(p) == "truncation-info.json" {
+			t.Fatalf("did not expect truncation-info.json when not truncated, got %v", written)
+		}
+	}
+
+	htmlBytes, err := os.ReadFile(filepath.Join(tmpDir, "report.html"))
+	if err != nil {
+		t.Fatalf("read report.html: %v", err)
+	}
+	html := string(htmlBytes)
+
+	if strings.Contains(html, `<div class="truncation-banner"`) {
+		t.Errorf("did not expect .truncation-banner div in HTML when not truncated")
+	}
+	if strings.Contains(html, "Showing top") {
+		t.Errorf("did not expect banner copy in HTML when not truncated")
+	}
+}
+
+func TestSARIFEmbedsTruncationProperty(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	snapshot := models.NewSnapshot()
+	snapshot.Metadata.ClusterName = "sarif-trunc"
+
+	findings := []models.Finding{{
+		ID:       "finding-1",
+		RuleID:   "KUBE-TEST-003",
+		Severity: models.SeverityHigh,
+		Score:    7.5,
+		Title:    "SARIF fixture",
+	}}
+
+	if _, err := WriteWithAdmission(tmpDir, []string{"sarif"}, snapshot, findings,
+		models.AdmissionSummary{},
+		models.TruncationInfo{Truncated: true, Original: 50, Shown: 20, Limit: 20}); err != nil {
+		t.Fatalf("WriteWithAdmission() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "findings.sarif"))
+	if err != nil {
+		t.Fatalf("read sarif: %v", err)
+	}
+
+	var doc struct {
+		Runs []struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal sarif: %v", err)
+	}
+	if len(doc.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(doc.Runs))
+	}
+	truncRaw, ok := doc.Runs[0].Properties["truncation"]
+	if !ok {
+		t.Fatalf("expected runs[0].properties.truncation, got keys: %v", doc.Runs[0].Properties)
+	}
+	var info models.TruncationInfo
+	if err := json.Unmarshal(truncRaw, &info); err != nil {
+		t.Fatalf("decode truncation property: %v", err)
+	}
+	want := models.TruncationInfo{Truncated: true, Original: 50, Shown: 20, Limit: 20}
+	if info != want {
+		t.Errorf("truncation property = %#v, want %#v", info, want)
+	}
+}
+
+func TestSARIFOmitsTruncationPropertyWhenNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	snapshot := models.NewSnapshot()
+	snapshot.Metadata.ClusterName = "sarif-no-trunc"
+
+	findings := []models.Finding{{
+		ID:       "finding-1",
+		RuleID:   "KUBE-TEST-004",
+		Severity: models.SeverityLow,
+		Score:    2.0,
+		Title:    "SARIF fixture",
+	}}
+
+	if _, err := WriteWithAdmission(tmpDir, []string{"sarif"}, snapshot, findings,
+		models.AdmissionSummary{}, models.TruncationInfo{}); err != nil {
+		t.Fatalf("WriteWithAdmission() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "findings.sarif"))
+	if err != nil {
+		t.Fatalf("read sarif: %v", err)
+	}
+
+	var doc struct {
+		Runs []struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal sarif: %v", err)
+	}
+	if len(doc.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(doc.Runs))
+	}
+	if _, ok := doc.Runs[0].Properties["truncation"]; ok {
+		t.Errorf("did not expect truncation property when not truncated")
+	}
+}
+
+func TestReadWriteTruncationInfoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	info := models.TruncationInfo{
+		Truncated: true,
+		Original:  147,
+		Shown:     20,
+		Limit:     20,
+	}
+
+	path, err := WriteTruncationInfo(tmpDir, info)
+	if err != nil {
+		t.Fatalf("WriteTruncationInfo() error = %v", err)
+	}
+	if path != filepath.Join(tmpDir, "truncation-info.json") {
+		t.Fatalf("unexpected path: %s", path)
+	}
+
+	loaded, err := ReadTruncationInfo(path)
+	if err != nil {
+		t.Fatalf("ReadTruncationInfo() error = %v", err)
+	}
+
+	if loaded != info {
+		t.Fatalf("round-trip mismatch: got %#v, want %#v", loaded, info)
+	}
+}
+
+func TestGuessTruncationInfoPath(t *testing.T) {
+	t.Parallel()
+
+	got := GuessTruncationInfoPath(filepath.Join("some", "dir", "findings.json"))
+	want := filepath.Join("some", "dir", "truncation-info.json")
+	if got != want {
+		t.Fatalf("GuessTruncationInfoPath = %q, want %q", got, want)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	// Build a deterministic findings slice with N entries, all in the same
+	// category — diverseTopN degenerates to a plain prefix slice in that case,
+	// so the index-based assertions below still hold.
+	build := func(n int) []models.Finding {
+		out := make([]models.Finding, n)
+		for i := range out {
+			out[i] = models.Finding{
+				ID:       "f-" + string(rune('a'+i)),
+				RuleID:   "RULE-" + string(rune('A'+i)),
+				Severity: models.SeverityHigh,
+				Category: models.CategoryPrivilegeEscalation,
+			}
+		}
+		return out
+	}
+
+	cases := []struct {
+		name        string
+		input       int
+		limit       int
+		allFindings bool
+		wantLen     int
+		wantTrunc   bool
+		wantOrig    int
+	}{
+		{name: "below cap", input: 3, limit: 5, wantLen: 3, wantTrunc: false},
+		{name: "at cap", input: 5, limit: 5, wantLen: 5, wantTrunc: false},
+		{name: "above cap", input: 10, limit: 5, wantLen: 5, wantTrunc: true, wantOrig: 10},
+		{name: "all-findings overrides", input: 10, limit: 5, allFindings: true, wantLen: 10, wantTrunc: false},
+		{name: "limit zero is no-op", input: 10, limit: 0, wantLen: 10, wantTrunc: false},
+		{name: "limit negative is no-op", input: 10, limit: -1, wantLen: 10, wantTrunc: false},
+		{name: "empty input", input: 0, limit: 5, wantLen: 0, wantTrunc: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := build(tc.input)
+			gotFindings, gotInfo := Truncate(input, tc.limit, tc.allFindings)
+
+			if len(gotFindings) != tc.wantLen {
+				t.Fatalf("len(findings) = %d, want %d", len(gotFindings), tc.wantLen)
+			}
+			if gotInfo.Truncated != tc.wantTrunc {
+				t.Fatalf("info.Truncated = %v, want %v", gotInfo.Truncated, tc.wantTrunc)
+			}
+			if tc.wantTrunc {
+				if gotInfo.Original != tc.wantOrig {
+					t.Errorf("info.Original = %d, want %d", gotInfo.Original, tc.wantOrig)
+				}
+				if gotInfo.Shown != tc.wantLen {
+					t.Errorf("info.Shown = %d, want %d", gotInfo.Shown, tc.wantLen)
+				}
+				if gotInfo.Limit != tc.limit {
+					t.Errorf("info.Limit = %d, want %d", gotInfo.Limit, tc.limit)
+				}
+				// Top-N preservation: first element must equal the input's first element.
+				if gotFindings[0].RuleID != input[0].RuleID {
+					t.Errorf("top-N preservation: first finding RuleID = %q, want %q",
+						gotFindings[0].RuleID, input[0].RuleID)
+				}
+			} else {
+				// Zero-value info when no truncation.
+				if gotInfo != (models.TruncationInfo{}) {
+					t.Errorf("expected zero TruncationInfo when not truncated, got %#v", gotInfo)
+				}
+			}
+		})
+	}
+}
+
+func TestTruncateDiversifiesAcrossCategories(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the e2e shape: a single dominant category (privesc) with many
+	// findings, plus a handful of lower-volume categories. Without
+	// diversification, top-N would be all privesc; with diversification, every
+	// category should appear in the truncated set.
+	categories := []models.RiskCategory{
+		models.CategoryPrivilegeEscalation,        // 30 entries
+		models.CategoryLateralMovement,            // 5 entries
+		models.CategoryDataExfiltration,           // 3 entries
+		models.CategoryInfrastructureModification, // 2 entries
+		models.CategoryDefenseEvasion,             // 1 entry
+	}
+	counts := []int{30, 5, 3, 2, 1}
+
+	// Build a globally severity-sorted slice: privesc occupies all 30 top
+	// slots (CRITICAL, score 9.5), then 5 lateral CRITICALs at score 9.0,
+	// then 3 exfil HIGHs, then 2 infra HIGHs, then 1 evasion MEDIUM. This
+	// matches the analyzer's sort output: privesc dominates the prefix.
+	findings := make([]models.Finding, 0, 41)
+	severities := []models.Severity{
+		models.SeverityCritical, models.SeverityCritical,
+		models.SeverityHigh, models.SeverityHigh, models.SeverityMedium,
+	}
+	scores := []float64{9.5, 9.0, 8.0, 7.5, 6.0}
+	for i, cat := range categories {
+		for j := 0; j < counts[i]; j++ {
+			findings = append(findings, models.Finding{
+				ID:       string(cat) + "-" + string(rune('a'+j)),
+				RuleID:   "RULE-" + string(cat) + "-" + string(rune('A'+j)),
+				Severity: severities[i],
+				Score:    scores[i],
+				Category: cat,
+			})
+		}
+	}
+	if len(findings) != 41 {
+		t.Fatalf("fixture wiring: expected 41 findings, got %d", len(findings))
+	}
+
+	got, info := Truncate(findings, 10, false)
+
+	if !info.Truncated {
+		t.Fatalf("expected truncation to fire on 41-finding input with limit=10")
+	}
+	if len(got) != 10 {
+		t.Fatalf("len(got) = %d, want 10", len(got))
+	}
+
+	// Every category that has findings must appear in the truncated set.
+	seen := make(map[models.RiskCategory]int)
+	for _, f := range got {
+		seen[f.Category]++
+	}
+	for _, cat := range categories {
+		if seen[cat] == 0 {
+			t.Errorf("category %q absent from truncated set: %#v", cat, seen)
+		}
+	}
+
+	// Verify the absolute top finding (privesc-a, the very first input entry)
+	// is preserved as the top of the result — diversification must not
+	// displace the highest-severity finding from position 0.
+	if got[0].ID != "privilege_escalation-a" {
+		t.Errorf("expected top finding to be the global top-1 'privilege_escalation-a', got %q", got[0].ID)
+	}
+
+	// Verify the result is sorted by severity rank → score.
+	for i := 1; i < len(got); i++ {
+		prev, cur := got[i-1], got[i]
+		if prev.Severity.Rank() < cur.Severity.Rank() {
+			t.Errorf("result not severity-sorted at index %d: %s before %s", i, prev.Severity, cur.Severity)
+		}
+	}
+}
+
+func TestDiverseTopNSingleCategoryDegenerates(t *testing.T) {
+	t.Parallel()
+
+	// When every finding shares a category, diverseTopN must return the
+	// plain prefix slice — no reshuffling, no reordering.
+	in := []models.Finding{
+		{ID: "1", RuleID: "A", Severity: models.SeverityHigh, Category: models.CategoryPrivilegeEscalation},
+		{ID: "2", RuleID: "B", Severity: models.SeverityHigh, Category: models.CategoryPrivilegeEscalation},
+		{ID: "3", RuleID: "C", Severity: models.SeverityHigh, Category: models.CategoryPrivilegeEscalation},
+	}
+	got := diverseTopN(in, 2)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].ID != "1" || got[1].ID != "2" {
+		t.Errorf("expected prefix [1,2], got [%s,%s]", got[0].ID, got[1].ID)
+	}
+}

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -65,7 +65,7 @@ type sarifLogicalLocation struct {
 }
 
 // writeSARIF serializes findings as a SARIF 2.1.0 document with one rule per unique RuleID and one result per finding.
-func writeSARIF(path string, findings []models.Finding, admission models.AdmissionSummary) error {
+func writeSARIF(path string, findings []models.Finding, admission models.AdmissionSummary, truncation models.TruncationInfo) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("create sarif report: %w", err)
@@ -82,8 +82,14 @@ func writeSARIF(path string, findings []models.Finding, admission models.Admissi
 		},
 		Results: sarifResults(findings),
 	}
-	if admission.Mode != "" {
-		run.Properties = map[string]any{"admission": admission}
+	if admission.Mode != "" || truncation.Truncated {
+		run.Properties = map[string]any{}
+		if admission.Mode != "" {
+			run.Properties["admission"] = admission
+		}
+		if truncation.Truncated {
+			run.Properties["truncation"] = truncation
+		}
 	}
 
 	report := sarifReport{

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -266,4 +266,9 @@ type htmlReportData struct {
 	// Admission carries the engine's admission-aware reweight summary. Empty Mode means
 	// no admission-aware step ran; the template gates the banner on Mode.
 	Admission models.AdmissionSummary
+
+	// Truncation carries the --max-findings cap state. Truncated=false (the zero
+	// value) means no cap was applied; the template gates the banner on
+	// .Truncation.Truncated.
+	Truncation models.TruncationInfo
 }

--- a/internal/report/writers.go
+++ b/internal/report/writers.go
@@ -121,7 +121,7 @@ func writeCSV(path string, findings []models.Finding) error {
 }
 
 // writeHTML renders the embedded htmlTemplate with findings-derived data and writes a self-contained report page.
-func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding, admission models.AdmissionSummary) error {
+func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding, admission models.AdmissionSummary, truncation models.TruncationInfo) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("create html report: %w", err)
@@ -274,6 +274,7 @@ func writeHTML(path string, snapshot models.Snapshot, findings []models.Finding,
 
 	data := BuildHTMLData(snapshot, findings)
 	data.Admission = admission
+	data.Truncation = truncation
 
 	if err := tmpl.Execute(file, data); err != nil {
 		return fmt.Errorf("render html report: %w", err)

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -111,14 +111,53 @@ step "Capturing snapshot"
   --kubeconfig "${KUBECONFIG_PATH}" \
   --output-file "${ROOT_DIR}/.tmp/e2e-snapshot.json" | prefix_ok
 
-step "Running kubesplaining scan"
+step "Running kubesplaining scan (default --max-findings=20)"
 # Use the default "standard" exclusions preset so the e2e mirrors how users run
 # the tool: built-in kube-system / system:* / kubeadm:* noise is suppressed.
+# This invocation uses default flags so the e2e demonstrates the user-facing
+# default truncation behavior. Rule-ID coverage assertions further down run
+# against a separate --all-findings scan into .tmp/e2e-report-full.
 SCAN_LOG="${ROOT_DIR}/.tmp/e2e-scan.log"
 "${ROOT_DIR}/bin/kubesplaining" scan \
   --input-file "${ROOT_DIR}/.tmp/e2e-snapshot.json" \
   --output-dir "${ROOT_DIR}/.tmp/e2e-report" \
   --output-format html,json,csv | tee "${SCAN_LOG}" | prefix_ok
+
+step "Verifying default truncation behavior"
+# The fixture deliberately produces > 20 findings, so the default cap must fire.
+TRUNC_SIDECAR="${ROOT_DIR}/.tmp/e2e-report/truncation-info.json"
+if [[ ! -f "${TRUNC_SIDECAR}" ]]; then
+  echo "missing: truncation-info.json should exist when default --max-findings=20 cap fires" >&2
+  exit 1
+fi
+if ! rg -q '"truncated":\s*true' "${TRUNC_SIDECAR}"; then
+  echo "expected truncation-info.json to record truncated=true" >&2
+  exit 1
+fi
+if ! rg -q '"shown":\s*20' "${TRUNC_SIDECAR}"; then
+  echo "expected truncation-info.json to record shown=20" >&2
+  exit 1
+fi
+DEFAULT_FINDING_COUNT=$(rg -c '"rule_id"' "${ROOT_DIR}/.tmp/e2e-report/findings.json" || echo 0)
+if [[ "${DEFAULT_FINDING_COUNT}" != "20" ]]; then
+  echo "expected exactly 20 findings under default cap, got ${DEFAULT_FINDING_COUNT}" >&2
+  exit 1
+fi
+if ! rg -q 'class="truncation-banner"' "${ROOT_DIR}/.tmp/e2e-report/report.html"; then
+  echo "expected HTML report to render the truncation-banner div" >&2
+  exit 1
+fi
+ok "default cap produced 20 findings, sidecar + HTML banner present"
+
+step "Running kubesplaining scan --all-findings (assertion coverage)"
+# All rule-ID assertions and regression checks below run against the full,
+# uncapped findings list so we can verify every expected rule fired. The
+# default-cap scan above already covers the user-visible banner UX.
+"${ROOT_DIR}/bin/kubesplaining" scan \
+  --input-file "${ROOT_DIR}/.tmp/e2e-snapshot.json" \
+  --output-dir "${ROOT_DIR}/.tmp/e2e-report-full" \
+  --all-findings \
+  --output-format json | prefix_ok
 SUMMARY_LINE=$(grep -m1 "^findings:" "${SCAN_LOG}" 2>/dev/null || echo "")
 
 step "Verifying expected rule IDs"
@@ -143,7 +182,7 @@ EXPECTED_RULES=(
 
 missing=()
 for rule in "${EXPECTED_RULES[@]}"; do
-  if ! rg -q "\"rule_id\":\s*\"${rule}\"" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+  if ! rg -q "\"rule_id\":\s*\"${rule}\"" "${ROOT_DIR}/.tmp/e2e-report-full/findings.json"; then
     missing+=("${rule}")
   fi
 done
@@ -160,7 +199,7 @@ ok "all ${#EXPECTED_RULES[@]} expected rule IDs present"
 # pinpoints the exact false positive without needing jq.
 NS_SUBJECT_KEY="ServiceAccount/rbac-ns-fixtures/sa-ns-rolebinding-mutate"
 NS_FP_ID_PREFIX="KUBE-PRIVESC-PATH-CLUSTER-ADMIN:${NS_SUBJECT_KEY}:"
-if rg -q "\"id\":\s*\"${NS_FP_ID_PREFIX}" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+if rg -q "\"id\":\s*\"${NS_FP_ID_PREFIX}" "${ROOT_DIR}/.tmp/e2e-report-full/findings.json"; then
   echo "regression: namespace-scoped RoleBinding produced KUBE-PRIVESC-PATH-CLUSTER-ADMIN (issue #48)" >&2
   exit 1
 fi
@@ -172,7 +211,7 @@ ok "no cluster-admin false positive for namespace-scoped RoleBinding"
 # returns true for any baseline-or-stricter level. Asserting the absence is more
 # valuable than asserting presence: it locks in that the posture finding correctly
 # suppresses itself when *any* admission control is in place.
-if rg -q "\"rule_id\":\s*\"KUBE-ADMISSION-NO-POLICY-ENGINE-001\"" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+if rg -q "\"rule_id\":\s*\"KUBE-ADMISSION-NO-POLICY-ENGINE-001\"" "${ROOT_DIR}/.tmp/e2e-report-full/findings.json"; then
   echo "regression: KUBE-ADMISSION-NO-POLICY-ENGINE-001 fired despite psa-suppressed namespace having enforce=restricted" >&2
   exit 1
 fi
@@ -182,7 +221,7 @@ ok "no policy-engine posture finding (correctly suppressed by psa-suppressed enf
 # the namespace it can take over. The finding ID encodes the target namespace as
 # the last segment after a fourth `:`.
 NS_OK_ID="KUBE-PRIVESC-PATH-NAMESPACE-ADMIN:${NS_SUBJECT_KEY}:namespace_admin:rbac-ns-fixtures"
-if ! rg -q "\"id\":\s*\"${NS_OK_ID}\"" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+if ! rg -q "\"id\":\s*\"${NS_OK_ID}\"" "${ROOT_DIR}/.tmp/e2e-report-full/findings.json"; then
   echo "missing: namespace-scoped RoleBinding did not produce expected KUBE-PRIVESC-PATH-NAMESPACE-ADMIN finding for ${NS_SUBJECT_KEY} → rbac-ns-fixtures" >&2
   exit 1
 fi
@@ -191,18 +230,18 @@ ok "namespace-admin path emitted for namespace-scoped RoleBinding"
 # Default --admission-mode=suppress must drop the privileged-pod finding for the
 # psa-suppressed namespace because its enforce=restricted label would block the spec.
 PSA_FINDING_ID="KUBE-ESCAPE-001:Deployment:psa-suppressed:psa-priv-app"
-if rg -q "\"id\":\s*\"${PSA_FINDING_ID}" "${ROOT_DIR}/.tmp/e2e-report/findings.json"; then
+if rg -q "\"id\":\s*\"${PSA_FINDING_ID}" "${ROOT_DIR}/.tmp/e2e-report-full/findings.json"; then
   echo "regression: --admission-mode=suppress did not drop ${PSA_FINDING_ID}" >&2
   exit 1
 fi
 ok "default suppress mode dropped privileged finding in psa-suppressed namespace"
 
 # admission-summary.json must record the suppression count and the per-namespace breakdown.
-if ! rg -q "\"suppressed\":\s*[1-9]" "${ROOT_DIR}/.tmp/e2e-report/admission-summary.json"; then
+if ! rg -q "\"suppressed\":\s*[1-9]" "${ROOT_DIR}/.tmp/e2e-report-full/admission-summary.json"; then
   echo "missing: admission-summary.json should record suppressed >= 1" >&2
   exit 1
 fi
-if ! rg -q "psa-suppressed" "${ROOT_DIR}/.tmp/e2e-report/admission-summary.json"; then
+if ! rg -q "psa-suppressed" "${ROOT_DIR}/.tmp/e2e-report-full/admission-summary.json"; then
   echo "missing: admission-summary.json should mention psa-suppressed namespace" >&2
   exit 1
 fi
@@ -213,6 +252,7 @@ step "Re-running scan with --admission-mode=attenuate"
   --input-file "${ROOT_DIR}/.tmp/e2e-snapshot.json" \
   --output-dir "${ROOT_DIR}/.tmp/e2e-report-attenuate" \
   --admission-mode attenuate \
+  --all-findings \
   --output-format json >/dev/null
 
 # Attenuate keeps the finding visible but with the admission tag applied.


### PR DESCRIPTION
## Summary

- Adds `--max-findings` (default 20) and `--all-findings` to `scan`, `report`, and `scan-resource`. Real clusters produce hundreds of findings; the resulting JSON and HTML were unwieldy because the long tail crowded the actionable signal.
- When the cap fires, findings are selected **round-robin across `RiskCategory`** before truncation — a single dominant category (privesc on RBAC-heavy clusters) cannot crowd out smaller ones like `data_exfiltration` or `defense_evasion`. The selection is then re-sorted by severity rank so criticals still appear first.
- Truncation is surfaced as: a stderr notice on the CLI, an amber banner in the HTML report ("Showing top N of M findings — re-run with `--all-findings` to include the rest"), an embedded property in SARIF `run.properties`, and a new sidecar `truncation-info.json` so `kubesplaining report` can re-render the banner without re-running analysis.
- `findings.json` keeps its flat-array shape so existing JSON consumers and the report-regeneration flow stay compatible.

### Concrete impact on the kind e2e fixture

| Before (no cap) | Default cap (this PR) |
| --- | --- |
| 97 findings written | 20 findings written |
| top 20 = 20 privesc | top 20 = 6 privesc · 5 lateral · 5 exfil · 3 infra · 1 evasion |
| top 20 severities = 20 critical | top 20 severities = 6 critical · 11 high · 2 medium · 1 low |

### Files

- `internal/models/truncation.go` *(new)* — `TruncationInfo` struct.
- `internal/report/report.go` — new `Truncate` + `diverseTopN` helpers.
- `internal/report/io.go` — `Write/Read/GuessTruncationInfoPath` triple, parallel to the existing admission-summary triple.
- `internal/report/types.go`, `writers.go`, `sarif.go`, `assets/report.html.tmpl` — plumb truncation into HTML and SARIF outputs; CSV and JSON shapes are unchanged.
- `internal/cli/output.go` — `printTruncationNotice` stderr helper.
- `internal/cli/scan.go`, `report.go`, `scan_resource.go` — flag wiring + `report.Truncate` call after exclusions.
- `scripts/kind-e2e.sh` — primary scan now demonstrates the default cap firing (asserts `truncation-info.json` + the HTML banner); a separate `--all-findings` scan into `e2e-report-full/` carries the full rule-ID coverage.

## Test plan

- [x] `make test` — 11 new unit tests in `internal/report/report_test.go` covering: `Truncate` behaviour matrix (below/at/above cap, all-findings override, limit=0, limit=-1, empty input), category diversification, single-category degenerate path, `truncation-info.json` round-trip, sidecar gating (written iff `Truncated=true`), HTML banner presence/absence, SARIF property presence/absence.
- [x] `make lint` — `gofmt -l` + `go vet`.
- [x] `make e2e` — kind cluster boots, default-cap scan asserts banner + sidecar, `--all-findings` scan asserts all 43 expected rule IDs and the existing PSA/admission regression checks pass.
- [x] Manual smoke against the bundled `testdata/snapshots/minimal-risky.json`:
  - `scan --max-findings 3` → exactly 3 entries in `findings.json`, sidecar with `{truncated:true, original:21, shown:3, limit:3}`, banner in HTML, stderr notice.
  - `scan --all-findings` → all 21 entries, no sidecar, no banner.
  - `--output-format json 2>/dev/null` → stdout still parses cleanly; the banner went to stderr only.