### PR TITLE
feat(leastprivilege): cluster-admin inventory + readable verb chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ It emits four rule IDs:
 - `KUBE-RBAC-UNUSED-VERB-001` — Some verbs in a Role rule are unused; suggests a narrower verb list.
 - `KUBE-RBAC-WILDCARD-USED-PARTIAL-001` — `verbs: ["*"]` is granted but the SA only used a subset.
 
-The pre-existing `KUBE-RBAC-STALE-*` and `KUBE-RBAC-OVERBROAD-001` rules surface alongside in the Least Privilege HTML tab so every "this grant is broader than needed" signal lives in one view.
+The pre-existing `KUBE-RBAC-STALE-*` rules surface alongside in the Least Privilege HTML tab so dangling-binding cleanup and verb-level narrowing live in one view. Cluster-admin grants live in their own "Subjects bound to cluster-admin" inventory table on the same tab — directly bound subjects are listed for review rather than each one being flagged CRITICAL, because cluster-admin has legitimate uses (`system:masters`, break-glass groups) that vary by cluster. The standalone `KUBE-RBAC-OVERBROAD-001` finding still fires from the rbac module and shows up in the main Findings tab (and in JSON/CSV/SARIF output) for operators who want the per-binding alert.
 
 ### When does it fire?
 

--- a/internal/analyzer/leastprivilege/prefixes.go
+++ b/internal/analyzer/leastprivilege/prefixes.go
@@ -3,16 +3,18 @@ package leastprivilege
 import "strings"
 
 // TabRuleIDPrefixes is the canonical set of rule-ID prefixes that surface in the
-// "Least Privilege" HTML tab and the `--least-privilege-only` CLI mode. The list
-// includes both the new audit-driven rules and the pre-existing static RBAC cleanup
-// rules (`STALE-*`, `OVERBROAD-*`) because operators tightening Roles want them all in
-// one view - dangling references, over-broad bindings, and unused verbs are different
-// flavors of the same "this grant is broader than the workload needs" story.
+// "Least Privilege" HTML tab and the `--least-privilege-only` CLI mode. Covers the
+// audit-driven narrowing rules (UNUSED-*, WILDCARD-USED-PARTIAL-*) and the static
+// stale-binding cleanup rules (STALE-*); operators tightening Roles want both in one
+// view because dangling references and unused verbs are flavors of the same "this
+// grant is broader than the workload needs" story. KUBE-RBAC-OVERBROAD-001 is
+// intentionally absent: cluster-admin bindings have legitimate uses, and the LP tab
+// now ships a dedicated "Subjects bound to cluster-admin" inventory table that lets
+// operators review the list without each entry being flagged CRITICAL.
 var TabRuleIDPrefixes = []string{
 	"KUBE-RBAC-UNUSED-",
 	"KUBE-RBAC-WILDCARD-USED-PARTIAL-",
 	"KUBE-RBAC-STALE-",
-	"KUBE-RBAC-OVERBROAD-",
 }
 
 // IsLeastPrivilegeRule reports whether ruleID belongs to the least-privilege tab/filter.

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -70,19 +70,19 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 			}
 
 			// Pre-flight: --least-privilege-only without --audit-log would produce a
-			// near-empty tab (only STALE/OVERBROAD findings, no UNUSED-* signal).
-			// Surface the missing input explicitly so the operator knows to point us
-			// at an audit log.
+			// near-empty tab (only STALE findings, no UNUSED-* signal). Surface the
+			// missing input explicitly so the operator knows to point us at an audit log.
 			if leastPrivilegeOnly && len(auditLogPaths) == 0 {
 				return fmt.Errorf("--least-privilege-only requires --audit-log <path>; see docs/audit-logs.md for how to obtain one")
 			}
 
 			// --least-privilege-only is a "focus mode" shortcut. It overrides --only-modules
-			// to the modules that produce least-privilege findings (rbac for the existing
-			// STALE/OVERBROAD rules + leastprivilege for the new UNUSED/WILDCARD rules),
-			// then applies a rule-ID post-filter so other rbac findings (privesc-related)
-			// don't leak through. The HTML report's default tab is also flipped to
-			// "leastprivilege" so the focus mode lands the operator there directly.
+			// to the modules that produce least-privilege findings (rbac for STALE rules +
+			// leastprivilege for the UNUSED/WILDCARD rules), then applies a rule-ID
+			// post-filter so other rbac findings (privesc-related, OVERBROAD) don't leak
+			// through — the LP tab's dedicated cluster-admin inventory table covers the
+			// "who has cluster-admin" picture. The HTML report's default tab is also
+			// flipped to "leastprivilege" so the focus mode lands the operator there.
 			if leastPrivilegeOnly {
 				onlyModules = []string{"rbac", "leastprivilege"}
 			}
@@ -188,7 +188,7 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 	cmd.Flags().StringSliceVar(&auditLogPaths, "audit-log", nil, "Path to a kube-apiserver audit log file or directory (repeatable). See docs/audit-logs.md for how to obtain one.")
 	cmd.Flags().StringVar(&auditSource, "audit-source", "native", "Audit-log format: native (kube-apiserver JSON-lines) or eks (CloudWatch export from filter-log-events)")
 	cmd.Flags().IntVar(&auditWindowDays, "audit-window-days", 30, "How many days of audit history to consider when computing unused-permission findings")
-	cmd.Flags().BoolVar(&leastPrivilegeOnly, "least-privilege-only", false, "Focus mode: only emit least-privilege findings (UNUSED-*, WILDCARD-USED-PARTIAL-*, STALE-*, OVERBROAD-*) and open the Least Privilege tab by default. Requires --audit-log.")
+	cmd.Flags().BoolVar(&leastPrivilegeOnly, "least-privilege-only", false, "Focus mode: only emit least-privilege findings (UNUSED-*, WILDCARD-USED-PARTIAL-*, STALE-*) and open the Least Privilege tab by default. Requires --audit-log. Cluster-admin bindings are listed for review in the LP tab's inventory table instead of firing as findings.")
 
 	return cmd
 }

--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -178,7 +178,11 @@
       font-size: 11px; line-height: 1.4; min-width: 0; }
     .lp-verb-list .lp-verb-label { color: #e8b86b; font-weight: 700; letter-spacing: 0.01em;
       margin-right: 4px; }
-    .lp-verb-list .lp-resource-sep { color: var(--text-mut); opacity: 0.55; margin: 0 4px; }
+    .lp-verb-list .lp-verb-resource { display: block; padding-left: 10px; line-height: 1.45; }
+    .lp-verb-list .lp-verb-resource-more { display: block; padding-left: 10px;
+      color: var(--text-mut); font-style: italic; font-size: 10.5px; line-height: 1.45; }
+    .lp-verb-foot-note { margin-top: 6px; font-size: 11px; color: var(--text-mut);
+      font-style: italic; line-height: 1.5; }
     .lp-bind-row { font-size: 12px; line-height: 1.5; white-space: nowrap; }
     .lp-bind-row + .lp-bind-row { margin-top: 2px; }
     .lp-bind-label { color: var(--text-mut); font-size: 10.5px; letter-spacing: 0.02em;
@@ -208,6 +212,18 @@
     .lp-cell-used { background: rgba(80,200,150,0.04); }
     .lp-cell-unused { background: rgba(255,120,120,0.04); }
     .lp-verb-none { color: var(--text-mut); font-size: 11.5px; font-style: italic; }
+
+    .lp-ca-table tbody tr.lp-row-system td { opacity: 0.62; }
+    .lp-ca-table tbody tr.lp-row-system td code { color: var(--text-mut); }
+    .lp-subj-kind { color: var(--text-mut); font-size: 10px; letter-spacing: 0.08em;
+      text-transform: uppercase; margin-right: 6px; font-weight: 600; }
+    .lp-tag { display: inline-block; font-size: 10px; font-weight: 700; padding: 2px 8px;
+      border-radius: 999px; letter-spacing: 0.06em; text-transform: uppercase;
+      vertical-align: middle; }
+    .lp-tag-system { background: rgba(255,255,255,0.05); color: var(--text-mut);
+      border: 1px solid var(--border); }
+    .lp-tag-review { background: var(--high-soft); color: var(--high);
+      border: 1px solid rgba(255,120,120,0.35); }
 
     main { max-width: 1280px; margin: 0 auto; padding: 24px 28px 80px; }
     section { margin-bottom: 24px; }
@@ -1815,6 +1831,36 @@
               <td class="lp-cell-used">{{ .UsedVerbs }}</td>
               <td class="lp-cell-unused">{{ .UnusedVerbs }}</td>
               <td><div class="lp-action">{{ .Action }}</div></td>
+            </tr>
+            {{ end }}
+          </tbody>
+        </table>
+      </div>
+      {{ end }}
+
+      {{ if .LeastPrivilege.ClusterAdminInventory }}
+      <div class="lp-table-wrap">
+        <h2 class="lp-table-title">Subjects bound to cluster-admin</h2>
+        <p class="lp-table-sub">Every identity directly bound to the built-in <code>cluster-admin</code> ClusterRole. This is an inventory view, not a finding list: <span class="lp-tag lp-tag-system">built-in</span> rows are expected (the API server hard-codes <code>system:masters</code>; a handful of control-plane bindings are required), while <span class="lp-tag lp-tag-review">review</span> rows are discretionary grants worth a "is this still legitimate?" check. Cluster-admin has legitimate uses (break-glass groups, JIT admin), so kubesplaining no longer flags each row as <code>CRITICAL</code> in this view — review the list and prune what you don't recognize.</p>
+        <table class="lp-table lp-ca-table">
+          <thead>
+            <tr><th>Subject</th><th>ClusterRoleBinding</th><th>Type</th></tr>
+          </thead>
+          <tbody>
+            {{ range .LeastPrivilege.ClusterAdminInventory }}
+            <tr{{ if .IsSystem }} class="lp-row-system"{{ end }}>
+              <td>
+                <span class="lp-subj-kind">{{ .SubjectKind }}</span>
+                <code>{{ if .SubjectNs }}{{ .SubjectNs }}/{{ end }}{{ .SubjectName }}</code>
+              </td>
+              <td><code>{{ .Binding }}</code></td>
+              <td>
+                {{ if .IsSystem }}
+                  <span class="lp-tag lp-tag-system">built-in</span>
+                {{ else }}
+                  <span class="lp-tag lp-tag-review">review</span>
+                {{ end }}
+              </td>
             </tr>
             {{ end }}
           </tbody>

--- a/internal/report/leastprivilege_section.go
+++ b/internal/report/leastprivilege_section.go
@@ -19,7 +19,7 @@ import (
 // verbs mapping), and groups the same findings per-subject for the detailed cards. The
 // tables and cards share the same underlying finding slice; the tables are a denser view
 // for triage, the cards carry the full prose + remediation YAML.
-func buildLeastPrivilegeSection(findings []models.Finding, usageInfo *UsageInfo) LeastPrivilegeSection {
+func buildLeastPrivilegeSection(snapshot models.Snapshot, findings []models.Finding, usageInfo *UsageInfo) LeastPrivilegeSection {
 	section := LeastPrivilegeSection{}
 	if usageInfo != nil {
 		section.HasAuditData = true
@@ -29,6 +29,7 @@ func buildLeastPrivilegeSection(findings []models.Finding, usageInfo *UsageInfo)
 		section.EventsProcessed = usageInfo.EventsProcessed
 		section.NonSAUsernames = usageInfo.NonSAUsernames
 	}
+	section.ClusterAdminInventory = buildClusterAdminInventory(snapshot)
 
 	bySubject := map[string]*LeastPrivilegeGroup{}
 	order := []string{}
@@ -128,9 +129,8 @@ func newCard(f models.Finding) LeastPrivilegeFindingCard {
 // ok=false for findings that don't fit this table (per-verb narrowing, wildcard).
 //
 // Resource is rendered as "<Kind>/<name>" so the table doesn't need a separate Kind
-// column. For OVERBROAD-001 the rbac analyzer sets Resource.Kind to the synthetic
-// "RBACRule" label (not a real k8s kind), so we override with "ClusterRole" - the rule
-// only fires on ClusterRoleBinding -> cluster-admin grants.
+// column. cluster-admin bindings are handled by the dedicated inventory table built
+// from the snapshot, not this row builder, so OVERBROAD-001 is intentionally absent.
 //
 // Action carries the concrete "what to delete" instruction with the binding name pulled
 // from evidence so an operator can act on the row without expanding the card. The
@@ -157,13 +157,6 @@ func unusedResourceRowFor(f models.Finding) (LPUnusedResourceRow, bool) {
 	case "KUBE-RBAC-STALE-002":
 		row.Why = "Binding lists a ServiceAccount subject that does not exist"
 		row.Action = actionDeleteBinding(ev, "subject missing")
-	case "KUBE-RBAC-OVERBROAD-001":
-		row.Why = "Direct binding to cluster-admin"
-		// findingFromContent labels the resource as "RBACRule" - a placeholder, not a
-		// real Kind. cluster-admin is always a ClusterRole, so override here rather
-		// than across the rbac analyzer where other reports rely on the existing shape.
-		kind = "ClusterRole"
-		row.Action = actionDeleteBinding(ev, "scope down to a narrower ClusterRole")
 	default:
 		return LPUnusedResourceRow{}, false
 	}
@@ -285,10 +278,15 @@ func roleVerbRowFor(f models.Finding) (LPRoleVerbRow, bool) {
 		// The wildcard rule fires because verbs: ["*"] grants the entire standard verb
 		// set, of which the SA only exercised a few. Showing both sides lets the
 		// operator see "here's what's actually used; here's the over-grant" without
-		// having to reason about what `*` means on this resource.
+		// having to reason about what `*` means on this resource. The unused side is
+		// synthetic — (standard verbs) x (resources on the rule) — so it gets capped
+		// per-verb with a footnote that names the wildcard as the source of the bloat.
 		used, unused := wildcardTriples(f.Evidence)
 		row.UsedVerbs = renderVerbsGrouped(used)
-		row.UnusedVerbs = renderVerbsGrouped(unused)
+		row.UnusedVerbs = renderVerbsGroupedOpts(unused, verbRenderOpts{
+			ResourceCapPerVerb: 4,
+			FootNote:           `Truncated — verbs: ["*"] expands to every standard verb the wildcard covers, multiplied by every resource on the matching rule.`,
+		})
 		row.Action = actionNarrowWildcard(roleLabel)
 	default:
 		return LPRoleVerbRow{}, false
@@ -297,6 +295,48 @@ func roleVerbRowFor(f models.Finding) (LPRoleVerbRow, bool) {
 		return LPRoleVerbRow{}, false
 	}
 	return row, true
+}
+
+// buildClusterAdminInventory walks every ClusterRoleBinding that targets the built-in
+// cluster-admin ClusterRole and emits one row per subject. system:* subjects are kept
+// because the inventory exists for visibility, not narrowing — operators need to see the
+// built-in grants alongside the discretionary ones to recognize "what's expected" vs.
+// "what someone added". Sorting puts non-system rows first so the entries operators
+// actually act on surface at the top of the table.
+func buildClusterAdminInventory(snapshot models.Snapshot) []LPClusterAdminRow {
+	var rows []LPClusterAdminRow
+	for _, binding := range snapshot.Resources.ClusterRoleBindings {
+		if binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != "cluster-admin" {
+			continue
+		}
+		for _, subject := range binding.Subjects {
+			isSystem := strings.HasPrefix(subject.Name, "system:") ||
+				(subject.Kind == "Group" && strings.HasPrefix(subject.Name, "system:"))
+			rows = append(rows, LPClusterAdminRow{
+				Binding:     binding.Name,
+				SubjectKind: subject.Kind,
+				SubjectNs:   subject.Namespace,
+				SubjectName: subject.Name,
+				IsSystem:    isSystem,
+			})
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].IsSystem != rows[j].IsSystem {
+			return !rows[i].IsSystem
+		}
+		if rows[i].SubjectKind != rows[j].SubjectKind {
+			return rows[i].SubjectKind < rows[j].SubjectKind
+		}
+		if rows[i].SubjectNs != rows[j].SubjectNs {
+			return rows[i].SubjectNs < rows[j].SubjectNs
+		}
+		if rows[i].SubjectName != rows[j].SubjectName {
+			return rows[i].SubjectName < rows[j].SubjectName
+		}
+		return rows[i].Binding < rows[j].Binding
+	})
+	return rows
 }
 
 // formatVerbsNone renders the empty-state for the Used column when every granted verb is
@@ -450,12 +490,30 @@ func triplesToVR(triples []map[string]string) []verbResource {
 	return out
 }
 
-// renderVerbsGrouped renders verb/resource pairs grouped by verb: one row per verb with
-// the resources it applies to stacked vertically inside a single resource chip. The
-// "one chip per verb" shape keeps each verb's blast radius visually grouped instead of
-// scattered across many separate chips. Caps at 8 verbs with "+N more" overflow; empty
-// input returns the "none" placeholder so the column never goes blank.
+// verbRenderOpts controls optional sizing and explanatory copy for renderVerbsGroupedOpts.
+// The zero value reproduces the original uncapped, footnote-less rendering.
+type verbRenderOpts struct {
+	// ResourceCapPerVerb truncates each chip to its first N resources with a
+	// "+M more resources" tail. 0 means unlimited.
+	ResourceCapPerVerb int
+	// FootNote renders once below the chip list when at least one chip was capped.
+	FootNote string
+}
+
+// renderVerbsGrouped is the unoptioned form: every resource shown, no footnote. Used by
+// formatVerbList (UNUSED-VERB / UNUSED-RULE) and by the Used side of WILDCARD-USED-PARTIAL.
 func renderVerbsGrouped(items []verbResource) template.HTML {
+	return renderVerbsGroupedOpts(items, verbRenderOpts{})
+}
+
+// renderVerbsGroupedOpts groups (verb, resource) pairs by verb into one bordered chip per
+// verb. Single-resource verbs render inline ("list: pods") so the common case stays on one
+// line; verbs with 2+ resources stack each resource on its own block-level line beneath
+// the label so a wildcard-expanded list does not force the cell to scroll horizontally.
+// opts.ResourceCapPerVerb caps each chip with a "+M more resources" tail; opts.FootNote,
+// if set, is rendered once under the chip list when any chip got capped. Caps at 8 verbs
+// total with a "+N more verbs" overflow; empty input returns the "none" placeholder.
+func renderVerbsGroupedOpts(items []verbResource, opts verbRenderOpts) template.HTML {
 	if len(items) == 0 {
 		return formatVerbsNone()
 	}
@@ -475,28 +533,42 @@ func renderVerbsGrouped(items []verbResource) template.HTML {
 	}
 	var b strings.Builder
 	b.WriteString(`<ul class="lp-verb-list">`)
+	anyCapped := false
 	for i := 0; i < limit; i++ {
 		verb := order[i]
 		resources := dedupeStrings(byVerb[verb])
 		sort.Strings(resources)
-		// Single chip per verb: the verb label leads, the resources stack below.
-		// Keeping them in one bordered <code> visually anchors each verb's blast
-		// radius to one cell rather than two adjacent chips that could be mistaken
-		// for unrelated grants.
 		b.WriteString(`<li><code class="lp-verb-chip"><span class="lp-verb-label">`)
 		b.WriteString(template.HTMLEscapeString(verb))
 		b.WriteString(`:</span>`)
-		for j, r := range resources {
-			if j > 0 {
-				b.WriteString(`<span class="lp-resource-sep">|</span>`)
+		if len(resources) == 1 {
+			b.WriteString(` `)
+			b.WriteString(template.HTMLEscapeString(resources[0]))
+		} else {
+			show := len(resources)
+			if opts.ResourceCapPerVerb > 0 && show > opts.ResourceCapPerVerb {
+				show = opts.ResourceCapPerVerb
 			}
-			b.WriteString(template.HTMLEscapeString(r))
+			for j := 0; j < show; j++ {
+				b.WriteString(`<span class="lp-verb-resource">`)
+				b.WriteString(template.HTMLEscapeString(resources[j]))
+				b.WriteString(`</span>`)
+			}
+			if show < len(resources) {
+				fmt.Fprintf(&b, `<span class="lp-verb-resource-more">+%d more resources</span>`, len(resources)-show)
+				anyCapped = true
+			}
 		}
 		b.WriteString(`</code></li>`)
 	}
 	b.WriteString(`</ul>`)
 	if len(order) > limit {
 		fmt.Fprintf(&b, `<div class="lp-verb-more">+%d more verbs</div>`, len(order)-limit)
+	}
+	if anyCapped && opts.FootNote != "" {
+		b.WriteString(`<div class="lp-verb-foot-note">`)
+		b.WriteString(template.HTMLEscapeString(opts.FootNote))
+		b.WriteString(`</div>`)
 	}
 	return template.HTML(b.String())
 }

--- a/internal/report/leastprivilege_section_test.go
+++ b/internal/report/leastprivilege_section_test.go
@@ -1,0 +1,155 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRenderVerbsGroupedSingleResourceInline(t *testing.T) {
+	got := string(renderVerbsGrouped([]verbResource{
+		{Verb: "list", Resource: "pods"},
+	}))
+	if !strings.Contains(got, `<span class="lp-verb-label">list:</span> pods`) {
+		t.Fatalf("expected single-resource inline form, got: %s", got)
+	}
+	if strings.Contains(got, `lp-verb-resource`) {
+		t.Fatalf("single-resource verb should not use block resource spans, got: %s", got)
+	}
+	if strings.Contains(got, `lp-resource-sep`) {
+		t.Fatalf("pipe separator should be gone, got: %s", got)
+	}
+}
+
+func TestRenderVerbsGroupedMultiResourceStacks(t *testing.T) {
+	got := string(renderVerbsGrouped([]verbResource{
+		{Verb: "get", Resource: "deployments"},
+		{Verb: "get", Resource: "pods"},
+		{Verb: "get", Resource: "services"},
+	}))
+	for _, r := range []string{
+		`<span class="lp-verb-resource">deployments</span>`,
+		`<span class="lp-verb-resource">pods</span>`,
+		`<span class="lp-verb-resource">services</span>`,
+	} {
+		if !strings.Contains(got, r) {
+			t.Fatalf("expected stacked resource %q in: %s", r, got)
+		}
+	}
+	if strings.Contains(got, `lp-resource-sep`) || strings.Contains(got, "|</span>") {
+		t.Fatalf("pipe separator should be gone, got: %s", got)
+	}
+	if strings.Contains(got, `lp-verb-resource-more`) {
+		t.Fatalf("no cap requested, should not see overflow tail: %s", got)
+	}
+}
+
+func TestRenderVerbsGroupedCapTruncatesAndFootnoteFires(t *testing.T) {
+	got := string(renderVerbsGroupedOpts([]verbResource{
+		{Verb: "get", Resource: "configmaps"},
+		{Verb: "get", Resource: "deployments"},
+		{Verb: "get", Resource: "nodes"},
+		{Verb: "get", Resource: "pods"},
+		{Verb: "get", Resource: "secrets"},
+		{Verb: "get", Resource: "services"},
+	}, verbRenderOpts{
+		ResourceCapPerVerb: 4,
+		FootNote:           `Truncated — verbs: ["*"] expands to every standard verb the wildcard covers.`,
+	}))
+	for _, r := range []string{"configmaps", "deployments", "nodes", "pods"} {
+		if !strings.Contains(got, `<span class="lp-verb-resource">`+r+`</span>`) {
+			t.Fatalf("expected capped chip to keep %q, got: %s", r, got)
+		}
+	}
+	for _, r := range []string{"secrets", "services"} {
+		if strings.Contains(got, `<span class="lp-verb-resource">`+r+`</span>`) {
+			t.Fatalf("expected %q to be hidden behind the cap, got: %s", r, got)
+		}
+	}
+	if !strings.Contains(got, `<span class="lp-verb-resource-more">+2 more resources</span>`) {
+		t.Fatalf("expected +2 more resources tail, got: %s", got)
+	}
+	if !strings.Contains(got, `<div class="lp-verb-foot-note">Truncated`) {
+		t.Fatalf("expected footnote when cap fires, got: %s", got)
+	}
+}
+
+func TestRenderVerbsGroupedFootnoteSuppressedWithoutTruncation(t *testing.T) {
+	got := string(renderVerbsGroupedOpts([]verbResource{
+		{Verb: "get", Resource: "pods"},
+		{Verb: "get", Resource: "services"},
+	}, verbRenderOpts{
+		ResourceCapPerVerb: 4,
+		FootNote:           `should not appear`,
+	}))
+	if strings.Contains(got, "lp-verb-foot-note") {
+		t.Fatalf("footnote should be hidden when nothing got capped, got: %s", got)
+	}
+	if strings.Contains(got, "lp-verb-resource-more") {
+		t.Fatalf("overflow tail should be hidden when nothing got capped, got: %s", got)
+	}
+}
+
+func TestRenderVerbsGroupedEmpty(t *testing.T) {
+	got := string(renderVerbsGrouped(nil))
+	if !strings.Contains(got, "none observed") {
+		t.Fatalf("empty input should render the 'none observed' placeholder, got: %s", got)
+	}
+}
+
+func TestBuildClusterAdminInventory(t *testing.T) {
+	snap := models.Snapshot{
+		Resources: models.SnapshotResources{
+			ClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+					Subjects: []rbacv1.Subject{
+						{Kind: "Group", Name: "system:masters"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "ops-admin"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+					Subjects: []rbacv1.Subject{
+						{Kind: "User", Name: "alice@example.com"},
+						{Kind: "ServiceAccount", Namespace: "ops", Name: "deployer"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "view-binding"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "view"},
+					Subjects:   []rbacv1.Subject{{Kind: "User", Name: "bob@example.com"}},
+				},
+			},
+		},
+	}
+
+	rows := buildClusterAdminInventory(snap)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 cluster-admin rows (the view binding should be ignored), got %d: %+v", len(rows), rows)
+	}
+	// Non-system entries must come first.
+	if rows[0].IsSystem || rows[1].IsSystem {
+		t.Fatalf("expected non-system rows first, got: %+v", rows)
+	}
+	if !rows[2].IsSystem {
+		t.Fatalf("expected the system:masters row last, got: %+v", rows)
+	}
+	if rows[2].SubjectName != "system:masters" {
+		t.Fatalf("expected last row to be system:masters, got %+v", rows[2])
+	}
+	// Among non-system rows, ServiceAccount (kind alpha-first) precedes User.
+	if rows[0].SubjectKind != "ServiceAccount" || rows[1].SubjectKind != "User" {
+		t.Fatalf("expected ServiceAccount then User ordering among non-system rows, got: %+v", rows)
+	}
+}
+
+func TestBuildClusterAdminInventoryEmpty(t *testing.T) {
+	if rows := buildClusterAdminInventory(models.Snapshot{}); rows != nil {
+		t.Fatalf("empty snapshot should produce no rows, got: %+v", rows)
+	}
+}

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -149,7 +149,7 @@ func BuildHTMLData(snapshot models.Snapshot, findings []models.Finding) htmlRepo
 		GraphJSON:      marshalGraphPayload(graphPayload),
 		GraphScript:    template.JS(kpGraphScript),
 		AnchorByID:     anchorByID,
-		LeastPrivilege: buildLeastPrivilegeSection(findings, nil),
+		LeastPrivilege: buildLeastPrivilegeSection(snapshot, findings, nil),
 	}
 	if len(findings) > 5 {
 		data.TopFindings = append([]models.Finding(nil), findings[:5]...)

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -242,16 +242,31 @@ type HopView struct {
 // operator can scan "what's unused" and "what verbs to drop" without expanding every
 // card; the cards carry the full prose and remediation YAML for the picked target.
 type LeastPrivilegeSection struct {
-	Total           int
-	WindowStart     string // pre-formatted "YYYY-MM-DD", empty when no audit data
-	WindowEnd       string
-	WindowDays      int
-	EventsProcessed int
-	NonSAUsernames  int // unique non-ServiceAccount callers in the window (humans, groups, system:node:*); surfaces an explicit "out of scope" note in the tab
-	HasAuditData    bool
-	UnusedResources []LPUnusedResourceRow
-	RoleVerbMap     []LPRoleVerbRow
-	Groups          []LeastPrivilegeGroup
+	Total                 int
+	WindowStart           string // pre-formatted "YYYY-MM-DD", empty when no audit data
+	WindowEnd             string
+	WindowDays            int
+	EventsProcessed       int
+	NonSAUsernames        int // unique non-ServiceAccount callers in the window (humans, groups, system:node:*); surfaces an explicit "out of scope" note in the tab
+	HasAuditData          bool
+	UnusedResources       []LPUnusedResourceRow
+	RoleVerbMap           []LPRoleVerbRow
+	ClusterAdminInventory []LPClusterAdminRow // inventory of every subject bound to the built-in cluster-admin ClusterRole
+	Groups                []LeastPrivilegeGroup
+}
+
+// LPClusterAdminRow is one subject directly bound to the built-in cluster-admin
+// ClusterRole. The "Subjects bound to cluster-admin" table is an inventory view sitting
+// alongside the actionable narrowing tables: operators get a single scannable list of
+// every identity that holds full cluster control so they can decide which entries are
+// legitimate (built-in system:* subjects, the break-glass group) and which need to be
+// pared back. IsSystem drives a softer visual treatment for the rows that are expected.
+type LPClusterAdminRow struct {
+	Binding     string
+	SubjectKind string
+	SubjectNs   string
+	SubjectName string
+	IsSystem    bool
 }
 
 // LPUnusedResourceRow is a single row in the "Unused RBAC resources" summary table at the

--- a/internal/report/writers.go
+++ b/internal/report/writers.go
@@ -282,7 +282,7 @@ func writeHTMLWithOptions(path string, snapshot models.Snapshot, findings []mode
 	// Re-build the Least Privilege section with the UsageInfo from opts so the tab can
 	// show the audit-log window header. BuildHTMLData itself builds it with nil
 	// usageInfo (the legacy path) — overwriting here keeps both call paths working.
-	data.LeastPrivilege = buildLeastPrivilegeSection(findings, opts.UsageInfo)
+	data.LeastPrivilege = buildLeastPrivilegeSection(snapshot, findings, opts.UsageInfo)
 	data.DefaultTab = opts.DefaultTab
 	data.UsageInfo = opts.UsageInfo
 	data.LeastPrivilegeOnly = opts.LeastPrivilegeOnly


### PR DESCRIPTION
## Summary

Two changes to the Least Privilege tab, both prompted by the focus-mode (`--least-privilege-only`) view:

- **New "Subjects bound to cluster-admin" inventory table** replaces the standalone `KUBE-RBAC-OVERBROAD-001` row in the LP tab. Every identity directly bound to `cluster-admin` lists once, with built-in `system:*` subjects rendered muted (tagged `built-in`) and non-system grants tagged `review`. Cluster-admin has legitimate uses (`system:masters`, break-glass groups, JIT admin), so an inventory beats a CRITICAL-per-row finding when the operator's actual question is "who currently has it?". The OVERBROAD-001 rule still fires from the rbac module and surfaces in the main Findings tab + JSON/CSV/SARIF outputs — only the focus-mode LP view is cluster-admin-finding-free now.
- **Verb chips no longer pipe-cram resources.** Single-resource verbs stay inline (`list: pods`); verbs with 2+ resources stack each resource on its own block-level line, so a wildcard rule no longer produces `get: deployments|pods|services|secrets|...` on a single horizontal-scroll line. The Unused column for `KUBE-RBAC-WILDCARD-USED-PARTIAL-001` caps at 4 resources per verb with a `+N more resources` tail and a footnote explaining the wildcard expansion; the Used column stays uncapped because operators want to see the full "this is what's actually exercised" list.

Unit tests added for the new `buildClusterAdminInventory` builder and the verb-renderer paths (inline, stacked, cap-and-footnote, footnote-suppression-when-not-truncated, empty input).

## Test plan

- [x] `make lint` passes (`gofmt -l`, `go vet ./...`)
- [x] `./bin/golangci-lint run ./...` — 0 issues (CI-only gate)
- [x] `go test ./...` passes; 7 new unit tests cover both pieces
- [x] Local smoke render against `testdata/snapshots/leastprivilege-demo.json` + `testdata/audit/native/leastprivilege-demo-audit.log` with `--least-privilege-only`:
  - The new "Subjects bound to cluster-admin" table appears with one `review` row for `dashboard/admin-sa`.
  - `KUBE-RBAC-OVERBROAD-001` count in `report.html` and `findings.json`: **0** in LP-only mode (was 1 critical before).
  - Verb chips render `list: configmaps` inline and stack multi-resource verbs vertically; no pipe glyphs anywhere in the rendered HTML.