### PR TITLE
refactor: simplify code for first-time readers (no behavior change)

### DIFF
--- a/internal/analyzer/correlate.go
+++ b/internal/analyzer/correlate.go
@@ -69,10 +69,10 @@ func correlate(findings []models.Finding) []models.Finding {
 // dedupe collapses findings that describe the same (RuleID, Subject, Resource) combination across modules,
 // keeping the one with the highest Score and merging tags. Within-module ID collisions are already handled by analyzers.
 func dedupe(findings []models.Finding) []models.Finding {
-	type keyed struct {
-		idx int
-	}
-	seen := map[string]keyed{}
+	// indexByKey maps each dedupe key to the index in `out` where its winning finding lives.
+	// We keep an index (rather than a *models.Finding) because the slice may grow and
+	// reallocate as we append, invalidating any stored pointer.
+	indexByKey := map[string]int{}
 	out := make([]models.Finding, 0, len(findings))
 	for _, finding := range findings {
 		key := dedupeKey(finding)
@@ -80,15 +80,15 @@ func dedupe(findings []models.Finding) []models.Finding {
 			out = append(out, finding)
 			continue
 		}
-		if prev, ok := seen[key]; ok {
-			if finding.Score > out[prev.idx].Score {
-				out[prev.idx].Score = finding.Score
-				out[prev.idx].Severity = finding.Severity
+		if prevIdx, ok := indexByKey[key]; ok {
+			if finding.Score > out[prevIdx].Score {
+				out[prevIdx].Score = finding.Score
+				out[prevIdx].Severity = finding.Severity
 			}
-			out[prev.idx].Tags = mergeTags(out[prev.idx].Tags, finding.Tags)
+			out[prevIdx].Tags = mergeTags(out[prevIdx].Tags, finding.Tags)
 			continue
 		}
-		seen[key] = keyed{idx: len(out)}
+		indexByKey[key] = len(out)
 		out = append(out, finding)
 	}
 	return out

--- a/internal/analyzer/engine.go
+++ b/internal/analyzer/engine.go
@@ -88,12 +88,35 @@ func NewWithConfig(cfg Config) *Engine {
 // correlates and dedupes the results, filters at or above the severity threshold, and
 // returns them sorted by severity then score along with an AdmissionSummary describing
 // what the reweight stage did.
+//
+// The pipeline is broken into four named stages below so a first-time reader can follow
+// the data flow: snapshot → selected modules → raw findings → reweighted/correlated/
+// deduped findings → sorted slice ready for the report writer.
 func (e *Engine) Analyze(ctx context.Context, snapshot models.Snapshot, opts Options) (AnalyzeResult, error) {
 	mode := opts.AdmissionMode
 	if mode == "" {
 		mode = AdmissionModeSuppress
 	}
 
+	selected, err := e.selectModules(opts)
+	if err != nil {
+		return AnalyzeResult{}, err
+	}
+
+	findings, firstErr := runModulesInParallel(ctx, snapshot, selected)
+
+	findings, admissionSummary := postProcess(findings, snapshot, mode)
+
+	filtered := filterByThreshold(findings, opts.Threshold)
+	sortFindings(filtered)
+
+	return AnalyzeResult{Findings: filtered, Admission: admissionSummary}, firstErr
+}
+
+// selectModules applies the --only-modules / --skip-modules filters and rebinds the
+// leastprivilege module with the per-call UsageIndex. The engine itself is stateless on
+// options; rebinding here keeps the module's audit data scoped to one Analyze call.
+func (e *Engine) selectModules(opts Options) ([]Module, error) {
 	selected := make([]Module, 0, len(e.modules))
 	for _, module := range e.modules {
 		if len(opts.OnlyModules) > 0 && !slices.Contains(opts.OnlyModules, module.Name()) {
@@ -102,27 +125,29 @@ func (e *Engine) Analyze(ctx context.Context, snapshot models.Snapshot, opts Opt
 		if slices.Contains(opts.SkipModules, module.Name()) {
 			continue
 		}
-		// Rebind the leastprivilege module with the per-call UsageIndex. The engine
-		// itself is stateless on options; this keeps the module's audit data scoped
-		// to one Analyze call.
 		if module.Name() == "leastprivilege" {
 			module = leastprivilege.New(opts.UsageIndex)
 		}
 		selected = append(selected, module)
 	}
-
 	if len(selected) == 0 {
-		return AnalyzeResult{}, fmt.Errorf("no analysis modules selected")
+		return nil, fmt.Errorf("no analysis modules selected")
 	}
+	return selected, nil
+}
 
+// runModulesInParallel fans out each module to its own goroutine, waits for all of them,
+// and returns the merged findings slice. If any module returns an error, only the first
+// one is reported; the other modules' findings still come back so a single misbehaving
+// analyzer can't blank the whole report.
+func runModulesInParallel(ctx context.Context, snapshot models.Snapshot, modules []Module) ([]models.Finding, error) {
 	var (
 		wg       sync.WaitGroup
 		mu       sync.Mutex
 		findings []models.Finding
 		firstErr error
 	)
-
-	for _, module := range selected {
+	for _, module := range modules {
 		module := module
 		wg.Add(1)
 		go func() {
@@ -136,33 +161,50 @@ func (e *Engine) Analyze(ctx context.Context, snapshot models.Snapshot, opts Opt
 			findings = append(findings, moduleFindings...)
 		}()
 	}
-
 	wg.Wait()
+	return findings, firstErr
+}
 
+// postProcess runs the cross-module passes that need every module's output in one place:
+// admission-aware reweighting, policy-engine presence tagging, chain-amplification
+// correlation, and cross-module deduplication. Returns the surviving findings and the
+// AdmissionSummary describing what the reweight stage did.
+func postProcess(findings []models.Finding, snapshot models.Snapshot, mode AdmissionMode) ([]models.Finding, models.AdmissionSummary) {
 	findings, admissionSummary := applyAdmissionMitigations(findings, snapshot, mode)
 	findings, admissionSummary = applyPolicyEnginePresenceTags(findings, snapshot, admissionSummary, mode)
 	findings = correlate(findings)
 	findings = dedupe(findings)
+	return findings, admissionSummary
+}
 
+// filterByThreshold drops findings whose severity falls below the operator-supplied
+// threshold. We reuse the input slice's backing array (findings[:0]) because the input
+// is no longer needed after this point - this avoids an allocation but is only safe
+// because no later code reads the pre-filter slice.
+func filterByThreshold(findings []models.Finding, threshold models.Severity) []models.Finding {
 	filtered := findings[:0]
 	for _, finding := range findings {
-		if scoring.AboveThreshold(finding, opts.Threshold) {
+		if scoring.AboveThreshold(finding, threshold) {
 			filtered = append(filtered, finding)
 		}
 	}
+	return filtered
+}
 
-	sort.Slice(filtered, func(i, j int) bool {
-		if filtered[i].Severity.Rank() != filtered[j].Severity.Rank() {
-			return filtered[i].Severity.Rank() > filtered[j].Severity.Rank()
+// sortFindings sorts in place by severity (descending), then score (descending), then
+// rule ID (ascending), then title (ascending). Stable ordering matters: tests, golden
+// files, and SARIF consumers all depend on the same input yielding the same output.
+func sortFindings(findings []models.Finding) {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Severity.Rank() != findings[j].Severity.Rank() {
+			return findings[i].Severity.Rank() > findings[j].Severity.Rank()
 		}
-		if filtered[i].Score != filtered[j].Score {
-			return filtered[i].Score > filtered[j].Score
+		if findings[i].Score != findings[j].Score {
+			return findings[i].Score > findings[j].Score
 		}
-		if filtered[i].RuleID != filtered[j].RuleID {
-			return filtered[i].RuleID < filtered[j].RuleID
+		if findings[i].RuleID != findings[j].RuleID {
+			return findings[i].RuleID < findings[j].RuleID
 		}
-		return filtered[i].Title < filtered[j].Title
+		return findings[i].Title < findings[j].Title
 	})
-
-	return AnalyzeResult{Findings: filtered, Admission: admissionSummary}, firstErr
 }

--- a/internal/analyzer/leastprivilege/analyzer.go
+++ b/internal/analyzer/leastprivilege/analyzer.go
@@ -59,34 +59,34 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 	mounted := mountedServiceAccounts(snapshot)
 
 	findings := make([]models.Finding, 0)
-	for _, p := range perms {
+	for _, subjectPerms := range perms {
 		// Skip built-in / control-plane subjects. The standard exclusions preset drops
 		// these later too, but skipping here avoids producing the findings at all so
 		// the leastprivilege tab's count badge stays accurate.
-		if strings.HasPrefix(p.Subject.Name, "system:") || p.Subject.Kind != "ServiceAccount" {
+		if strings.HasPrefix(subjectPerms.Subject.Name, "system:") || subjectPerms.Subject.Kind != "ServiceAccount" {
 			continue
 		}
 
 		// Only analyze SAs a workload actually mounts. Unmounted SAs are a separate
 		// concern handled by KUBE-RBAC-STALE-* in the rbac module - firing here would
 		// duplicate that signal without adding usage-aware data.
-		if !mounted[p.Subject.Key()] {
+		if !mounted[subjectPerms.Subject.Key()] {
 			continue
 		}
 
 		// Whole-role dead grant: mounted subject with zero observed events anywhere in
 		// the window. Emit one finding per distinct SourceRole.
-		if !a.idx.HasAnyEventsFor(p.Subject) {
-			roles := distinctSourceRoles(p.Rules)
+		if !a.idx.HasAnyEventsFor(subjectPerms.Subject) {
+			roles := distinctSourceRoles(subjectPerms.Rules)
 			for _, role := range roles {
-				findings = append(findings, a.findingForRole(p.Subject, role, p.Rules))
+				findings = append(findings, a.findingForRole(subjectPerms.Subject, role, subjectPerms.Rules))
 			}
 			continue
 		}
 
 		// Per-role narrowing: group rules by SourceRole, compute granted vs observed
 		// triples per group, emit one finding when the diff is non-empty.
-		byRole := groupRulesByRole(p.Rules)
+		byRole := groupRulesByRole(subjectPerms.Rules)
 		roleNames := make([]string, 0, len(byRole))
 		for name := range byRole {
 			roleNames = append(roleNames, name)
@@ -95,7 +95,7 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 		for _, roleName := range roleNames {
 			rules := byRole[roleName]
-			unused, used, allUnused, wildcardObserved := a.analyzeRoleForSubject(p.Subject, rules)
+			unused, used, allUnused, wildcardObserved := a.analyzeRoleForSubject(subjectPerms.Subject, rules)
 			if len(unused) == 0 && len(wildcardObserved) == 0 {
 				continue
 			}
@@ -103,11 +103,11 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 			case allUnused:
 				// Every (verb, resource) triple in this Role is unused → suggest
 				// removing the whole Rule block, not just trimming verbs.
-				findings = append(findings, a.findingForUnusedRule(p.Subject, roleName, rules, unused))
+				findings = append(findings, a.findingForUnusedRule(subjectPerms.Subject, roleName, rules, unused))
 			case len(wildcardObserved) > 0:
-				findings = append(findings, a.findingForWildcardNarrowing(p.Subject, roleName, rules, wildcardObserved))
+				findings = append(findings, a.findingForWildcardNarrowing(subjectPerms.Subject, roleName, rules, wildcardObserved))
 			default:
-				findings = append(findings, a.findingForUnusedVerbs(p.Subject, roleName, rules, unused, used))
+				findings = append(findings, a.findingForUnusedVerbs(subjectPerms.Subject, roleName, rules, unused, used))
 			}
 		}
 	}
@@ -230,17 +230,32 @@ func (a *Analyzer) analyzeRoleForSubject(subj models.SubjectRef, rules []permiss
 	return keptUnused, keptUsed, allUnused, wildcards
 }
 
+// windowEvidence returns a base evidence map containing the four fields every
+// least-privilege finding needs (source_role + the audit-window context), with any
+// extras merged in. Callers append rule-specific fields like unused_triples or
+// suggested_role_yaml via `extras`. encoding/json sorts map keys alphabetically, so
+// the resulting JSON output is independent of insertion order.
+func (a *Analyzer) windowEvidence(roleName string, extras map[string]any) json.RawMessage {
+	out := map[string]any{
+		"source_role":      roleName,
+		"window_start":     a.idx.WindowStart,
+		"window_end":       a.idx.WindowEnd,
+		"events_processed": a.idx.EventsProcessed,
+	}
+	for k, v := range extras {
+		out[k] = v
+	}
+	encoded, _ := json.Marshal(out)
+	return encoded
+}
+
 // findingForRole emits KUBE-RBAC-UNUSED-ROLE-001 - the strongest signal, fired when the
 // subject has zero observed events in the window and a workload still references it.
 func (a *Analyzer) findingForRole(subj models.SubjectRef, roleName string, rules []permissions.EffectiveRule) models.Finding {
 	c := contentUnusedRole(subj, roleName, a.idx)
 	res := &models.ResourceRef{Kind: roleKindFor(rules, roleName), Name: roleName, APIGroup: "rbac.authorization.k8s.io"}
-	evidence, _ := json.Marshal(map[string]any{
-		"source_role":      roleName,
-		"window_start":     a.idx.WindowStart,
-		"window_end":       a.idx.WindowEnd,
-		"events_processed": a.idx.EventsProcessed,
-		"signal":           "no_observed_events_for_subject",
+	evidence := a.windowEvidence(roleName, map[string]any{
+		"signal": "no_observed_events_for_subject",
 	})
 	return buildFinding(
 		"KUBE-RBAC-UNUSED-ROLE-001",
@@ -259,12 +274,8 @@ func (a *Analyzer) findingForRole(subj models.SubjectRef, roleName string, rules
 func (a *Analyzer) findingForUnusedRule(subj models.SubjectRef, roleName string, rules []permissions.EffectiveRule, unused []triple) models.Finding {
 	c := contentUnusedRule(subj, roleName, unused, a.idx)
 	res := &models.ResourceRef{Kind: roleKindFor(rules, roleName), Name: roleName, APIGroup: "rbac.authorization.k8s.io"}
-	evidence, _ := json.Marshal(map[string]any{
-		"source_role":      roleName,
-		"unused_triples":   tripleListJSON(unused),
-		"window_start":     a.idx.WindowStart,
-		"window_end":       a.idx.WindowEnd,
-		"events_processed": a.idx.EventsProcessed,
+	evidence := a.windowEvidence(roleName, map[string]any{
+		"unused_triples": tripleListJSON(unused),
 	})
 	return buildFinding(
 		"KUBE-RBAC-UNUSED-RULE-001",
@@ -286,13 +297,9 @@ func (a *Analyzer) findingForUnusedRule(subj models.SubjectRef, roleName string,
 func (a *Analyzer) findingForUnusedVerbs(subj models.SubjectRef, roleName string, rules []permissions.EffectiveRule, unused, used []triple) models.Finding {
 	c := contentUnusedVerbs(subj, roleName, unused, a.idx)
 	res := &models.ResourceRef{Kind: roleKindFor(rules, roleName), Name: roleName, APIGroup: "rbac.authorization.k8s.io"}
-	evidence, _ := json.Marshal(map[string]any{
-		"source_role":         roleName,
+	evidence := a.windowEvidence(roleName, map[string]any{
 		"unused_triples":      tripleListJSON(unused),
 		"used_triples":        tripleListJSON(used),
-		"window_start":        a.idx.WindowStart,
-		"window_end":          a.idx.WindowEnd,
-		"events_processed":    a.idx.EventsProcessed,
 		"suggested_role_yaml": c.SuggestedRoleYAML,
 	})
 	return buildFinding(
@@ -319,12 +326,8 @@ func (a *Analyzer) findingForWildcardNarrowing(subj models.SubjectRef, roleName 
 			"observed_verbs": w.ObservedVerbs,
 		})
 	}
-	evidence, _ := json.Marshal(map[string]any{
-		"source_role":         roleName,
+	evidence := a.windowEvidence(roleName, map[string]any{
 		"wildcards":           wildcardsJSON,
-		"window_start":        a.idx.WindowStart,
-		"window_end":          a.idx.WindowEnd,
-		"events_processed":    a.idx.EventsProcessed,
 		"suggested_role_yaml": c.SuggestedRoleYAML,
 	})
 	return buildFinding(

--- a/internal/analyzer/privesc/analyzer.go
+++ b/internal/analyzer/privesc/analyzer.go
@@ -155,6 +155,12 @@ func targetScoring(target models.EscalationTarget, hops int) (models.Severity, f
 	default:
 		base, severity, ruleID = 7.0, models.SeverityHigh, "KUBE-PRIVESC-PATH-GENERIC"
 	}
+	// Attenuate by chain length so shorter, more directly-exploitable paths outrank
+	// longer ones to the same sink. Each extra hop costs 0.5 score points, and chains
+	// of 3+ hops drop one severity bucket - long chains usually require operator
+	// missteps at every step, so they're real but lower-priority than a 1- or 2-hop
+	// path. Scores stay in [1, 10] so even a deeply attenuated path is still
+	// flagged rather than disappearing under the threshold.
 	score := base
 	if hops > 1 {
 		score -= 0.5 * float64(hops-1)

--- a/internal/analyzer/rbac/analyzer.go
+++ b/internal/analyzer/rbac/analyzer.go
@@ -134,6 +134,12 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 
 	for _, perms := range subjects {
 		for _, rule := range perms.Rules {
+			// Score multipliers (applied to each rule's base score below):
+			//   blastRadius     - cluster-scoped grants reach every namespace, so we bump them 20%
+			//                     over namespace-scoped grants of the same permission.
+			//   exploitability  - a ServiceAccount that is actually mounted by a pod can be reached
+			//                     by an attacker who lands in that pod; an unused SA is a paper risk
+			//                     until something starts mounting it, so the mounted ones get +20%.
 			blastRadius := 1.0
 			if rule.Namespace == "" {
 				blastRadius = 1.2
@@ -142,57 +148,67 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 			if perms.Subject.Kind == "ServiceAccount" && usedServiceAccounts[perms.Subject.Key()] {
 				exploitability = 1.2
 			}
+			// scaledScore captures the per-rule multipliers above so each case below
+			// only has to declare its base score - the formula is named once instead of
+			// duplicated nine times.
+			scaledScore := func(base float64) float64 {
+				return scoring.Clamp(base * exploitability * blastRadius)
+			}
 
 			bindingRef := rule.formattedBinding()
 			roleRef := rule.formattedRole()
 
+			// Each case detects one privilege-escalation primitive and emits the matching
+			// finding. switch (not if/else chain) so a rule that matches several cases
+			// only fires the first - we prefer the most specific framing and let dedupe
+			// merge cross-module overlaps later.
 			switch {
 			case hasWildcard(rule.Verbs) && hasWildcard(rule.Resources) && hasWildcard(rule.APIGroups):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-017", models.SeverityCritical, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(9.8*exploitability*blastRadius),
+					scaledScore(9.8),
 					contentPrivesc017(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get", "list", "watch"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-005", models.SeverityHigh, models.CategoryDataExfiltration,
-					scoring.Clamp(8.2*exploitability*blastRadius),
+					scaledScore(8.2),
 					contentPrivesc005(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-001", models.SeverityHigh, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(8.4*exploitability*blastRadius),
+					scaledScore(8.4),
 					contentPrivesc001(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-003", models.SeverityHigh, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(8.1*exploitability*blastRadius),
+					scaledScore(8.1),
 					contentPrivesc003(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"users", "groups", "serviceaccounts"}) && hasAnyVerb(rule.Verbs, "impersonate"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-008", models.SeverityCritical, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(9.4*exploitability*blastRadius),
+					scaledScore(9.4),
 					contentPrivesc008(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"roles", "clusterroles"}) && hasAnyVerb(rule.Verbs, "bind", "escalate"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-009", models.SeverityCritical, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(9.2*exploitability*blastRadius),
+					scaledScore(9.2),
 					contentPrivesc009(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasAnyResource(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-010", models.SeverityCritical, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(9.0*exploitability*blastRadius),
+					scaledScore(9.0),
 					contentPrivesc010(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "nodes/proxy") && hasAnyVerb(rule.Verbs, "get"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-012", models.SeverityCritical, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(9.3*exploitability*blastRadius),
+					scaledScore(9.3),
 					contentPrivesc012(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			case hasResource(rule.Resources, "serviceaccounts/token") && hasAnyVerb(rule.Verbs, "create"):
 				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-014", models.SeverityHigh, models.CategoryPrivilegeEscalation,
-					scoring.Clamp(8.0*exploitability*blastRadius),
+					scaledScore(8.0),
 					contentPrivesc014(rule.Namespace, perms.Subject, bindingRef, roleRef)))
 			}
 		}

--- a/internal/analyzer/serviceaccount/analyzer.go
+++ b/internal/analyzer/serviceaccount/analyzer.go
@@ -261,6 +261,12 @@ func scoreForRules(rules []permissions.EffectiveRule, defaultSA bool) float64 {
 }
 
 // severityForRules maps the numeric scoreForRules result to a Severity bucket.
+//
+// This intentionally duplicates the bucket cutoffs from scoring.SeverityForScore rather
+// than calling that helper, so the ServiceAccount module can tune them independently if
+// SA-specific heuristics ever drift from the global scale. If you change scoreForRules,
+// re-check the boundaries here so a small numeric shift doesn't accidentally drop a SA
+// from "high" to "medium".
 func severityForRules(rules []permissions.EffectiveRule, defaultSA bool) models.Severity {
 	score := scoreForRules(rules, defaultSA)
 	switch {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -28,6 +28,19 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// Well-known kube-system ConfigMaps whose payloads must be preserved verbatim:
+//   - aws-auth maps IAM principals to Kubernetes RBAC subjects on EKS clusters; its
+//     mappingRoles/mapUsers contents are needed for accurate impersonation analysis.
+//   - coredns carries the cluster DNS Corefile, which is useful when reasoning about
+//     name-resolution shortcuts an attacker might abuse.
+//
+// Every other ConfigMap goes through redactConfigMapValues so keys (which are searched
+// for credential-looking names) survive but payloads never enter the snapshot.
+const (
+	configMapAWSAuth = "aws-auth"
+	configMapCoreDNS = "coredns"
+)
+
 // Options controls namespace filtering, managedFields retention, and API concurrency for a collection run.
 type Options struct {
 	Namespaces           []string
@@ -70,12 +83,16 @@ func (c *Collector) Collect(ctx context.Context) (models.Snapshot, error) {
 	snapshot.Metadata.APIServerURL = c.config.Host
 
 	var (
-		mu       sync.Mutex
-		wg       sync.WaitGroup
-		sem      = make(chan struct{}, c.opts.Parallelism)
-		fatals   []error
-		warnings []string
-		missing  []string
+		mu sync.Mutex
+		wg sync.WaitGroup
+		// concurrencyLimiter caps how many list calls run against the apiserver at once.
+		// It's used as a counting semaphore: send into the channel before doing work,
+		// receive when done, so at most `Parallelism` goroutines are inside fn() at any
+		// moment. A buffered channel of struct{} is the idiomatic Go semaphore pattern.
+		concurrencyLimiter = make(chan struct{}, c.opts.Parallelism)
+		fatals             []error
+		warnings           []string
+		missing            []string
 	)
 
 	recordWarning := func(message string) {
@@ -95,8 +112,8 @@ func (c *Collector) Collect(ctx context.Context) (models.Snapshot, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+			concurrencyLimiter <- struct{}{}
+			defer func() { <-concurrencyLimiter }()
 
 			if err := fn(); err != nil {
 				switch {
@@ -394,7 +411,7 @@ func (c *Collector) Collect(ctx context.Context) (models.Snapshot, error) {
 				Labels:      item.Labels,
 				Annotations: item.Annotations,
 			}
-			if item.Namespace == "kube-system" && (item.Name == "aws-auth" || item.Name == "coredns") {
+			if item.Namespace == "kube-system" && (item.Name == configMapAWSAuth || item.Name == configMapCoreDNS) {
 				snapshotItem.Data = item.Data
 			} else if len(item.Data) > 0 {
 				snapshotItem.Data = redactConfigMapValues(item.Data)
@@ -681,6 +698,11 @@ func redactConfigMapValues(data map[string]string) map[string]string {
 	}
 	return redacted
 }
+
+// The sanitize* helpers below all share one body - drop ManagedFields when the operator
+// didn't ask to keep them - but they exist per concrete type because Go generics cannot
+// access the .ManagedFields struct field by name. Keep them in sync; if you change one,
+// change all of them (or grep for `maybeManagedFields`).
 
 func sanitizeNamespace(obj corev1.Namespace, includeManagedFields bool) corev1.Namespace {
 	obj.ManagedFields = maybeManagedFields(nil, includeManagedFields, obj.ManagedFields)

--- a/internal/manifest/loader.go
+++ b/internal/manifest/loader.go
@@ -23,7 +23,7 @@ import (
 // LoadSnapshot reads a YAML or JSON manifest file (possibly containing multiple documents) and returns a synthetic Snapshot.
 // resourceTypeHint is used when a document lacks an explicit "kind" field (e.g. a headerless YAML fragment).
 func LoadSnapshot(path string, resourceTypeHint string) (models.Snapshot, error) {
-	bytesData, err := os.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return models.Snapshot{}, fmt.Errorf("read manifest file: %w", err)
 	}
@@ -31,7 +31,7 @@ func LoadSnapshot(path string, resourceTypeHint string) (models.Snapshot, error)
 	snapshot := models.NewSnapshot()
 	snapshot.Metadata.ClusterName = "manifest-scan"
 
-	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(bytesData), 4096)
+	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
 	for {
 		var raw map[string]any
 		if err := decoder.Decode(&raw); err != nil {

--- a/internal/report/attack_graph.go
+++ b/internal/report/attack_graph.go
@@ -14,6 +14,25 @@ import (
 	"github.com/0hardik1/kubesplaining/internal/models"
 )
 
+// entryInfo accumulates display metadata for a single "Entry point" node in the attack
+// graph: the subject/resource that owns one or more abused-capability findings. We use
+// a pointer-valued map (map[string]*entryInfo) so each Finding can mutate the same
+// accumulator in place as it gets attributed.
+//
+// representative remembers a sample finding so we can later resolve a Glossary key from
+// its Subject/Resource without re-walking the candidate set.
+type entryInfo struct {
+	Key            string
+	Title          string
+	Subtitle       string
+	Meta           string
+	SevClass       string
+	topScore       float64
+	representative models.Finding
+	hasRep         bool
+	entryKind      string // "Subject" | "Resource" — used by the JS filter chips.
+}
+
 // buildAttackGraph composes a 3-column flow diagram (entries → capabilities → impacts) from findings.
 // Coordinates are deterministic so the template only emits SVG, no layout computation.
 // Returns the cosmetic AttackGraph (for the SVG template) and a detail GraphPayload (for the
@@ -111,19 +130,6 @@ func buildAttackGraph(findings []models.Finding) (AttackGraph, GraphPayload) {
 
 	// Select entry points: the resource/subject each capability is about, deduplicated.
 	// Entry key = subject.Key() when present, else resource.Key(). Label reflects source.
-	// representative remembers a sample finding so we can later resolve a GlossaryKey from
-	// its Subject/Resource without re-walking findings.
-	type entryInfo struct {
-		Key            string
-		Title          string
-		Subtitle       string
-		Meta           string
-		SevClass       string
-		topScore       float64
-		representative models.Finding
-		hasRep         bool
-		entryKind      string // "Subject" | "Resource" — used by the JS filter chips.
-	}
 	entries := map[string]*entryInfo{}
 	entryForCap := make([]string, len(caps))
 	for i, f := range caps {

--- a/internal/report/leastprivilege_section.go
+++ b/internal/report/leastprivilege_section.go
@@ -404,23 +404,12 @@ func compactSubject(s *models.SubjectRef) string {
 	return s.Name
 }
 
-// extractEvidenceString pulls a single string field out of an analyzer-emitted Evidence
-// JSON blob. Returns "" on any miss (malformed JSON, missing key, non-string value) so
-// callers can use the result as a "render this when non-empty" gate.
+// extractEvidenceString is the one-shot form of decodeEvidence + evidenceString for callers
+// that only need one field and don't care to keep the decoded map around. Returns "" on
+// any miss (malformed JSON, missing key, non-string value) so callers can use the result
+// as a "render this when non-empty" gate.
 func extractEvidenceString(raw json.RawMessage, key string) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return ""
-	}
-	v, ok := obj[key]
-	if !ok {
-		return ""
-	}
-	s, _ := v.(string)
-	return s
+	return evidenceString(decodeEvidence(raw), key)
 }
 
 // extractEvidenceTriples decodes the analyzer's "unused_triples" array into a flat

--- a/internal/report/recon.go
+++ b/internal/report/recon.go
@@ -557,6 +557,12 @@ func makeResourceList(items []string) ReconResourceList {
 	}
 }
 
+// buildReconGuardrails populates the "is anything stopping an attacker here?" panel of
+// the Recon tab. It summarizes four defenses: NetworkPolicies (per-namespace coverage),
+// Pod Security Admission enforce-level labels, third-party policy engines (Kyverno,
+// Gatekeeper, VAP), and the count of pods still mounting the default ServiceAccount
+// token. Counts feed the operator-friendly summary; missing data means "we didn't see
+// any" rather than "everything is fine".
 func buildReconGuardrails(s models.Snapshot) ReconGuardrails {
 	g := ReconGuardrails{
 		NetworkPolicies: len(s.Resources.NetworkPolicies),


### PR DESCRIPTION
## Summary
Make the analyzer / collector / report pipeline easier to follow for someone reading the code for the first time, without changing any user-visible output. Each change is either a comment that explains *why* a piece of logic exists, a clearer name, or a structural split that surfaces the pipeline shape without touching the algorithm.

**No behavior change:** SHA256 hashes of every output artifact (\`findings.json\`, \`findings.sarif\`, \`triage.csv\`, \`report.html\`, \`scan-metadata.json\`, \`admission-summary.json\`) across two snapshot fixtures and one manifest fixture all match the pre-refactor baseline. \`make test\`, \`make lint\`, repo-wide \`golangci-lint run ./...\`, and \`make e2e\` (kind-based) all pass with identical finding totals and identical rule-ID assertions.

### Files changed (+207 / -111)
- \`internal/analyzer/engine.go\` — split \`Analyze()\` into \`selectModules\`, \`runModulesInParallel\`, \`postProcess\`, \`filterByThreshold\`, \`sortFindings\` so the pipeline shape is visible at a glance.
- \`internal/analyzer/correlate.go\` — replace the \`type keyed struct{ idx int }\` wrapper with a plain \`map[string]int\` and a comment explaining why we key by index (slice growth invalidates pointers).
- \`internal/analyzer/privesc/analyzer.go\` — explain the score attenuation formula (\`-0.5 * (hops-1)\`) and the 3-hop severity downgrade.
- \`internal/analyzer/rbac/analyzer.go\` — comment the \`blastRadius\` / \`exploitability\` multipliers; introduce a \`scaledScore\` closure so the per-rule formula is named once instead of repeated nine times across the switch.
- \`internal/analyzer/serviceaccount/analyzer.go\` — document the \`scoreForRules\` / \`severityForRules\` coupling.
- \`internal/analyzer/leastprivilege/analyzer.go\` — rename \`p\` to \`subjectPerms\`; extract a \`windowEvidence\` helper that consolidates the four near-identical evidence map literals (encoding/json sorts map keys, so output bytes are unchanged).
- \`internal/collector/collector.go\` — rename \`sem\` to \`concurrencyLimiter\` with a comment on the buffered-channel semaphore idiom; promote the two whitelisted kube-system ConfigMap names (\`aws-auth\`, \`coredns\`) to named constants; add a heading comment explaining why the \`sanitize*\` per-type wrappers exist (Go generics cannot access struct fields by name).
- \`internal/manifest/loader.go\` — rename \`bytesData\` to \`data\`.
- \`internal/report/attack_graph.go\` — promote the anonymous \`entryInfo\` struct (used for ~150 lines of intermediate state) to a package-level named type so its fields are discoverable.
- \`internal/report/leastprivilege_section.go\` — collapse \`extractEvidenceString\` to a one-liner delegating to the existing \`decodeEvidence\` + \`evidenceString\` pair (was a parallel re-implementation).
- \`internal/report/recon.go\` — add doc comment to \`buildReconGuardrails\`.

### What was deliberately *not* touched
- Finding emission order, RuleIDs, score values, severity buckets.
- The rbac \`switch\` statement's case order (first-match semantics).
- HTML byte layout (string-builder calls in \`evidence_render.go\` etc.).
- The collector's per-resource \`runTask\` blocks — table-driving them would be a larger refactor with real reordering risk.

## Test plan
- [x] \`make test\` (all packages pass)
- [x] \`make lint\` (gofmt + go vet)
- [x] \`./bin/golangci-lint run ./...\` (0 issues)
- [x] \`make e2e\` (47 expected rule IDs present, identical counts: total=20 critical=6 high=11 medium=2 low=1)
- [x] SHA256 byte-diff of \`findings.{json,sarif}\`, \`triage.csv\`, \`report.html\`, \`scan-metadata.json\`, \`admission-summary.json\` across \`testdata/snapshots/minimal-risky.json\`, \`testdata/snapshots/leastprivilege-demo.json\`, and \`testdata/manifests/risky-resource.yaml\` — all match pre-refactor baseline.