### PR TITLE
ci(pages): publish uncapped report so LP tab is populated

### DIFF
--- a/.github/workflows/example-report.yml
+++ b/.github/workflows/example-report.yml
@@ -31,9 +31,13 @@ jobs:
       - name: Stage Pages artifact
         run: |
           mkdir -p _site
-          cp .tmp/e2e-report/report.html   _site/index.html
-          cp .tmp/e2e-report/findings.json _site/findings.json
-          cp .tmp/e2e-report/triage.csv    _site/triage.csv
+          # Publish the uncapped report so the public example shows every
+          # tab populated, including Least Privilege. The default-capped
+          # report drops Medium/Low findings (LP advisories, stale RBAC)
+          # via the top-20 cap, which would otherwise leave that tab empty.
+          cp .tmp/e2e-report-full/report.html   _site/index.html
+          cp .tmp/e2e-report-full/findings.json _site/findings.json
+          cp .tmp/e2e-report-full/triage.csv    _site/triage.csv
 
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -180,7 +180,7 @@ step "Running kubesplaining scan --all-findings (assertion coverage)"
   --audit-log "${AUDIT_LOG}" \
   --output-dir "${ROOT_DIR}/.tmp/e2e-report-full" \
   --all-findings \
-  --output-format html,json | prefix_ok
+  --output-format html,json,csv | prefix_ok
 SUMMARY_LINE=$(grep -m1 "^findings:" "${SCAN_LOG}" 2>/dev/null || echo "")
 
 step "Verifying expected rule IDs"


### PR DESCRIPTION
## Summary

PR #77 added the audit-log-driven Least Privilege fixtures and an uncapped HTML report at `.tmp/e2e-report-full/report.html`, but the Pages workflow still stages the default-capped `.tmp/e2e-report/report.html` whose top-20 cap drops every LP finding. Result: https://0hardik1.github.io/kubesplaining/ still shows an empty Least Privilege tab.

This PR switches the Pages artifact to the uncapped report so every tab is populated on the public example. It also adds `csv` to the full-scan output formats so the published `triage.csv` matches what the HTML page shows.

## Test plan

- [x] `make lint` clean
- [x] `make e2e` (locally) produces `.tmp/e2e-report-full/report.html` + `triage.csv`
- [x] After merge, the Pages workflow redeploys https://0hardik1.github.io/kubesplaining/ with the Least Privilege tab populated (6 `UNUSED-ROLE-001`, 1 `UNUSED-VERB-001`, 1 `WILDCARD-USED-PARTIAL-001`, 2 `STALE-*`).