### PR TITLE
ci(action): github action wrapper for sarif scan

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -36,6 +36,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Build the container image locally from the in-tree Dockerfile and tag
+      # it as the `:main` reference the action expects. Lets the smoke test
+      # exercise the action end-to-end before a tagged release has pushed the
+      # image to GHCR (the action's pull step skips when the image already
+      # exists locally).
+      - name: Build kubesplaining image (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build \
+            --build-arg VERSION=smoke \
+            --build-arg COMMIT="${GITHUB_SHA}" \
+            --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -t ghcr.io/0hardik1/kubesplaining:main \
+            .
+
       - name: Run kubesplaining action against minimal-risky fixture
         id: scan
         # `./` references the action defined in this repository so the smoke

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,87 @@
+# Smoke test for the composite action defined in `action.yml`.
+#
+# Runs on PRs that touch the action itself (or this workflow), plus a manual
+# dispatch hook, and exercises the action with the offline snapshot fixture so
+# we don't need a kind cluster or kubeconfig in CI. The assertion is that the
+# action's `report-dir` output exists and contains the artifacts we expect
+# (HTML, JSON, SARIF). Failure of those means the docker invocation broke
+# even if the action exit code happened to be zero.
+name: action-smoke
+
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-smoke.yml'
+      - 'testdata/snapshots/**'
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-smoke.yml'
+      - 'testdata/snapshots/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required by the action's SARIF-upload step. Without it the upload step
+  # would silently no-op (or fail loudly depending on codeql-action version),
+  # and the smoke test would not exercise the real production path.
+  security-events: write
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run kubesplaining action against minimal-risky fixture
+        id: scan
+        # `./` references the action defined in this repository so the smoke
+        # test always exercises the in-tree version of action.yml, not a
+        # released tag.
+        uses: ./
+        with:
+          # Pinned to `main` until slot #1 (.goreleaser image push) lands and
+          # we can bump to `:v1` or `:latest`.
+          version: main
+          input-file: testdata/snapshots/minimal-risky.json
+          severity-threshold: low
+          output-dir: ./kubesplaining-smoke-report
+          # The fixture intentionally contains critical findings (it's the
+          # "minimal-risky" sample), so we must not gate on critical or the
+          # smoke test would always fail.
+          fail-on-critical: 'false'
+          # SARIF upload is exercised in production paths; the smoke test
+          # disables it because we are not asserting against the Security tab
+          # and want this workflow to remain green on forks without the
+          # `security-events: write` token scope.
+          upload-sarif: 'false'
+
+      - name: Assert report artifacts exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPORT_DIR="${{ steps.scan.outputs.report-dir }}"
+          if [ -z "${REPORT_DIR}" ]; then
+            echo "::error::action did not emit report-dir output"
+            exit 1
+          fi
+          echo "Report dir: ${REPORT_DIR}"
+          ls -la "${REPORT_DIR}"
+          for f in report.html findings.json findings.sarif; do
+            if [ ! -s "${REPORT_DIR}/${f}" ]; then
+              echo "::error::missing or empty artifact: ${f}"
+              exit 1
+            fi
+          done
+          echo "All expected artifacts present."
+
+      - name: Upload smoke-test report as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kubesplaining-smoke-report
+          path: ./kubesplaining-smoke-report
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -414,6 +414,66 @@ The `standard` preset suppresses control-plane noise (kube-system, system:*, kub
 - **License**: [Apache-2.0](LICENSE)
 - **End-to-end verification**: `make e2e` provisions a local kind cluster with intentionally risky manifests in `testdata/` and asserts expected findings
 
+## Use the GitHub Action
+
+The repository ships a composite Action at `action.yml`, so you can wire kubesplaining into a workflow without authoring the `docker run` invocation yourself. The action pulls the pinned GHCR image, executes a scan against either a live cluster (via a base64-encoded kubeconfig) or a pre-collected snapshot JSON, and optionally uploads the SARIF result to GitHub code scanning.
+
+```yaml
+# .github/workflows/kubesplaining.yml
+name: Kubesplaining
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write   # required by upload-sarif
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Option A: scan a pre-collected snapshot checked into the repo.
+      - name: Scan offline snapshot
+        uses: 0hardik1/kubesplaining@main
+        with:
+          # Pin to a released tag (e.g. v1) once v1.0.0 ships. `main` tracks
+          # the development image and is fine for early adopters.
+          version: main
+          input-file: testdata/snapshots/minimal-risky.json
+          severity-threshold: medium
+          fail-on-critical: 'true'
+          upload-sarif: 'true'
+
+      # Option B: scan a live cluster. Store the kubeconfig as a base64
+      # secret (e.g. `cat ~/.kube/config | base64 | pbcopy`) under the
+      # `KUBE_CONFIG_B64` repository secret first.
+      # - name: Scan live cluster
+      #   uses: 0hardik1/kubesplaining@main
+      #   with:
+      #     kubeconfig: ${{ secrets.KUBE_CONFIG_B64 }}
+      #     severity-threshold: high
+      #     compliance: cis
+```
+
+Inputs (all optional unless noted):
+
+| Input | Default | Notes |
+| --- | --- | --- |
+| `version` | `main` | GHCR image tag. Bump to `v1` (or `latest`) once a release tag is published. |
+| `kubeconfig` | (none) | Base64-encoded kubeconfig for live scans. Omit when using `input-file`. |
+| `input-file` | (none) | Path (relative to the checkout) to a `kubesplaining download` snapshot JSON. |
+| `severity-threshold` | `medium` | `critical` / `high` / `medium` / `low` / `info`. |
+| `output-dir` | `./kubesplaining-report` | Created if missing. Holds `report.html`, `findings.json`, `findings.sarif`. |
+| `fail-on-critical` | `true` | Adds `--ci-mode --ci-max-critical 0`; flip to `false` to surface findings without failing the build. |
+| `upload-sarif` | `true` | Uploads `findings.sarif` via `github/codeql-action/upload-sarif@v3`. Requires `security-events: write`. |
+| `compliance` | (none) | Optional filter: `cis` or `nsa`. |
+
+Outputs: `report-dir` (absolute path to the report directory) and `sarif-file` (absolute path to `findings.sarif`, when emitted). The `.github/workflows/action-smoke.yml` workflow in this repo exercises the action against `testdata/snapshots/minimal-risky.json` on every PR that touches it.
+
 ## Credits
 
 - [Kinnaird McQuade](https://www.linkedin.com/in/kmcquade3/) — for the tool idea. His [Cloudsplaining](https://github.com/salesforce/cloudsplaining) inspired this project.

--- a/action.yml
+++ b/action.yml
@@ -144,8 +144,15 @@ runs:
         # Workspace-relative output dir for the in-container CLI.
         IN_CONTAINER_OUTPUT="/workspace/${INPUT_OUTPUT_DIR#./}"
 
+        # Run as the host workspace owner so files written under /workspace
+        # (the report dir, scan-metadata.json) land with the caller's uid/gid
+        # and remain readable / cleanable by later workflow steps. The default
+        # distroless `nonroot` user (uid 65532) can't write to dirs owned by
+        # the GitHub runner (typically uid 1001), so without this the report
+        # writes fail with "permission denied".
         DOCKER_ARGS=(
           run --rm
+          --user "$(id -u):$(id -g)"
           -v "${GITHUB_WORKSPACE}:/workspace"
           -w /workspace
         )

--- a/action.yml
+++ b/action.yml
@@ -109,12 +109,20 @@ runs:
 
     # Stage 2: pull the pinned image up front so the run step's failure modes
     # are limited to scan logic (and so the pull is logged separately, which
-    # is easier to debug than an opaque `docker run` failure).
+    # is easier to debug than an opaque `docker run` failure). If the image
+    # already exists locally (for instance, the smoke workflow builds it from
+    # the in-tree Dockerfile so the action can be exercised before a release
+    # has published the registry tag) we skip the pull.
     - name: Pull kubesplaining image
       shell: bash
       run: |
         set -euo pipefail
-        docker pull "ghcr.io/0hardik1/kubesplaining:${INPUT_VERSION}"
+        IMAGE="ghcr.io/0hardik1/kubesplaining:${INPUT_VERSION}"
+        if docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+          echo "Image ${IMAGE} already present locally, skipping pull."
+        else
+          docker pull "${IMAGE}"
+        fi
       env:
         INPUT_VERSION: ${{ inputs.version }}
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,210 @@
+# GitHub Action wrapper for kubesplaining.
+#
+# Runs the pinned GHCR container image inside a Workflow runner so callers don't
+# need Go, Docker buildx, or client-go credentials to ship a SARIF result into
+# the repo's Security tab. The action is intentionally a thin composite over
+# `docker run`: every flag the underlying CLI accepts can still be passed
+# through `--input-file`, kubeconfig, or per-input mappings below.
+#
+# Pinning policy: `version` defaults to `latest` once images are published, but
+# while slot #1 (.goreleaser image push) is still in flight we recommend pinning
+# to `main` (or a Git SHA) so callers don't surprise-update. After v1.0.0 ships,
+# bump the README snippet to `:v1`.
+name: kubesplaining
+description: >-
+  Kubernetes security assessment with multi-hop RBAC privilege-escalation
+  graphs. Runs against a live cluster (via kubeconfig) or a pre-collected
+  snapshot JSON, emits SARIF for GitHub code scanning, and optionally fails
+  the build on critical findings.
+author: 0hardik1
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  version:
+    description: >-
+      GHCR image tag to pull. Defaults to `main` while the release pipeline is
+      bootstrapping; switch to `latest` or a pinned `vX.Y.Z` after v1.0.0.
+    required: false
+    default: main
+  kubeconfig:
+    description: >-
+      Base64-encoded kubeconfig for live-cluster scans. Leave empty when using
+      `input-file`. The action writes it to a temporary file inside the runner
+      and exports `KUBECONFIG` so the CLI picks it up; the file is removed
+      after the scan regardless of exit status.
+    required: false
+    default: ''
+  input-file:
+    description: >-
+      Path (relative to the repo checkout) to a pre-collected snapshot JSON
+      produced by `kubesplaining download`. When set, the action skips live
+      collection and runs `scan --input-file` against the snapshot instead.
+    required: false
+    default: ''
+  severity-threshold:
+    description: >-
+      Minimum severity to include in the report: critical, high, medium, low,
+      or info. Forwarded verbatim to `--severity-threshold`.
+    required: false
+    default: medium
+  output-dir:
+    description: >-
+      Directory (relative to the repo checkout) where the report artifacts will
+      be written. Created if it does not exist.
+    required: false
+    default: ./kubesplaining-report
+  fail-on-critical:
+    description: >-
+      When true, the underlying CLI is invoked with `--ci-mode --ci-max-critical 0`
+      so the workflow step exits non-zero on any critical finding. Set to false
+      to surface findings without failing the build.
+    required: false
+    default: 'true'
+  upload-sarif:
+    description: >-
+      When true, the SARIF result is uploaded to GitHub code scanning via
+      `github/codeql-action/upload-sarif@v3`. Requires the calling workflow to
+      grant `security-events: write` permission.
+    required: false
+    default: 'true'
+  compliance:
+    description: >-
+      Optional compliance filter, forwarded to `--compliance`. Supported values
+      are `cis` and `nsa`. Leave empty to skip the filter.
+    required: false
+    default: ''
+
+outputs:
+  report-dir:
+    description: Absolute path to the directory containing the generated reports.
+    value: ${{ steps.run.outputs.report-dir }}
+  sarif-file:
+    description: Absolute path to the SARIF report (only set when SARIF is emitted).
+    value: ${{ steps.run.outputs.sarif-file }}
+
+runs:
+  using: composite
+  steps:
+    # Stage 1: materialise an optional kubeconfig from the encoded input. We
+    # write to $RUNNER_TEMP so the file lives outside the workspace and is
+    # cleaned up by the runner; the `cleanup` step below also wipes it
+    # defensively in case `RUNNER_TEMP` is persistent across job retries.
+    - name: Prepare kubeconfig
+      id: kubeconfig
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -n "${INPUT_KUBECONFIG}" ]; then
+          KUBECONFIG_PATH="${RUNNER_TEMP}/kubesplaining-kubeconfig"
+          printf '%s' "${INPUT_KUBECONFIG}" | base64 --decode > "${KUBECONFIG_PATH}"
+          chmod 600 "${KUBECONFIG_PATH}"
+          echo "path=${KUBECONFIG_PATH}" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        INPUT_KUBECONFIG: ${{ inputs.kubeconfig }}
+
+    # Stage 2: pull the pinned image up front so the run step's failure modes
+    # are limited to scan logic (and so the pull is logged separately, which
+    # is easier to debug than an opaque `docker run` failure).
+    - name: Pull kubesplaining image
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker pull "ghcr.io/0hardik1/kubesplaining:${INPUT_VERSION}"
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+
+    # Stage 3: run the scan. We always mount the workspace at /workspace so
+    # both `input-file` and `output-dir` can be relative to it, and always
+    # request html + json + sarif so callers get a full report regardless of
+    # which downstream step consumes it. `--exclusions-preset=standard` is the
+    # CLI default and is left implicit.
+    - name: Run kubesplaining scan
+      id: run
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        OUTPUT_DIR_ABS="${GITHUB_WORKSPACE}/${INPUT_OUTPUT_DIR#./}"
+        OUTPUT_DIR_ABS="${OUTPUT_DIR_ABS%/}"
+        mkdir -p "${OUTPUT_DIR_ABS}"
+
+        # Workspace-relative output dir for the in-container CLI.
+        IN_CONTAINER_OUTPUT="/workspace/${INPUT_OUTPUT_DIR#./}"
+
+        DOCKER_ARGS=(
+          run --rm
+          -v "${GITHUB_WORKSPACE}:/workspace"
+          -w /workspace
+        )
+
+        if [ -n "${KUBECONFIG_PATH}" ]; then
+          DOCKER_ARGS+=(
+            -v "${KUBECONFIG_PATH}:/tmp/kubeconfig:ro"
+            -e "KUBECONFIG=/tmp/kubeconfig"
+          )
+        fi
+
+        DOCKER_ARGS+=( "ghcr.io/0hardik1/kubesplaining:${INPUT_VERSION}" )
+
+        SCAN_ARGS=(
+          scan
+          --output-dir "${IN_CONTAINER_OUTPUT}"
+          --output-format html,json,sarif
+          --severity-threshold "${INPUT_SEVERITY_THRESHOLD}"
+        )
+
+        if [ -n "${INPUT_INPUT_FILE}" ]; then
+          SCAN_ARGS+=( --input-file "/workspace/${INPUT_INPUT_FILE#./}" )
+        fi
+
+        if [ "${INPUT_FAIL_ON_CRITICAL}" = "true" ]; then
+          SCAN_ARGS+=( --ci-mode --ci-max-critical 0 )
+        fi
+
+        if [ -n "${INPUT_COMPLIANCE}" ]; then
+          SCAN_ARGS+=( --compliance "${INPUT_COMPLIANCE}" )
+        fi
+
+        echo "::group::kubesplaining invocation"
+        printf 'docker'
+        printf ' %q' "${DOCKER_ARGS[@]}" "${SCAN_ARGS[@]}"
+        printf '\n'
+        echo "::endgroup::"
+
+        docker "${DOCKER_ARGS[@]}" "${SCAN_ARGS[@]}"
+
+        echo "report-dir=${OUTPUT_DIR_ABS}" >> "$GITHUB_OUTPUT"
+        if [ -f "${OUTPUT_DIR_ABS}/findings.sarif" ]; then
+          echo "sarif-file=${OUTPUT_DIR_ABS}/findings.sarif" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_INPUT_FILE: ${{ inputs.input-file }}
+        INPUT_SEVERITY_THRESHOLD: ${{ inputs.severity-threshold }}
+        INPUT_OUTPUT_DIR: ${{ inputs.output-dir }}
+        INPUT_FAIL_ON_CRITICAL: ${{ inputs.fail-on-critical }}
+        INPUT_COMPLIANCE: ${{ inputs.compliance }}
+        KUBECONFIG_PATH: ${{ steps.kubeconfig.outputs.path }}
+
+    # Stage 4: SARIF upload. `if:` guards both the input toggle and presence of
+    # the file (the scan may emit only HTML/JSON if a future tag drops SARIF).
+    # `continue-on-error` keeps the run step's exit code authoritative so
+    # `fail-on-critical=true` still surfaces a red workflow.
+    - name: Upload SARIF to GitHub code scanning
+      if: ${{ always() && inputs.upload-sarif == 'true' && steps.run.outputs.sarif-file != '' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.run.outputs.sarif-file }}
+        category: kubesplaining
+
+    # Stage 5: best-effort kubeconfig cleanup. `always()` ensures we wipe the
+    # decoded credentials even when the scan failed.
+    - name: Clean up kubeconfig
+      if: ${{ always() && steps.kubeconfig.outputs.path != '' }}
+      shell: bash
+      run: rm -f "${{ steps.kubeconfig.outputs.path }}"


### PR DESCRIPTION
## Summary

Adds a composite GitHub Action (`action.yml`) at the repo root so callers can run `kubesplaining` and ship SARIF into GitHub code scanning without authoring their own `docker run`. Implements Wave 1 Slot #2 of the parallel-agent fan-out plan (Track A, Distribution).

Files added/modified:
- `action.yml` (new): composite Action, eight inputs (`version`, `kubeconfig`, `input-file`, `severity-threshold`, `output-dir`, `fail-on-critical`, `upload-sarif`, `compliance`), two outputs (`report-dir`, `sarif-file`), branding `icon: shield` / `color: blue`.
- `.github/workflows/action-smoke.yml` (new): runs the in-tree action via `uses: ./` against `testdata/snapshots/minimal-risky.json` on every PR touching the action, asserts `report.html` / `findings.json` / `findings.sarif` are produced.
- `README.md` (append-only): new "Use the GitHub Action" section right before Credits, copy-pasteable workflow snippet plus input/output reference table. No rewrite of the existing CI Integration section, which is owned by Slot #3.

## Design notes

- **Image tag pin**: the `version` input defaults to `main` because Slot #1 (GoReleaser + GHCR image publish) has not landed yet, so there is no `:v1` / `:latest` to pull. Once Slot #1 ships, update the README snippet and the smoke test to `version: v1` (or `latest`).
- **kubeconfig handling**: base64-decoded into `$RUNNER_TEMP`, mode-600, exposed via `KUBECONFIG` env, and removed in a `always()` cleanup step so credentials never leak into the workspace tarball.
- **SARIF upload**: gated on both the `upload-sarif` input and the presence of `findings.sarif`, using `github/codeql-action/upload-sarif@v3` with `category: kubesplaining` so multiple scanners co-exist in code scanning.
- **`fail-on-critical`**: forwards to the CLI's existing `--ci-mode --ci-max-critical 0` rather than re-implementing exit-code policy in shell; CI semantics stay anchored to `internal/cli/scan.go`.
- **Smoke test**: disables `upload-sarif` and `fail-on-critical` so the workflow stays green on forks and on the intentionally-risky fixture; the assertion is artifact presence, not zero-finding.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` parses.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/action-smoke.yml'))"` parses.
- [x] `make lint` clean.
- [x] `make test` green.
- [x] Action shell logic dry-run produces the expected `docker run ... ghcr.io/0hardik1/kubesplaining:main scan --input-file /workspace/testdata/snapshots/minimal-risky.json --output-dir /workspace/kubesplaining-report --output-format html,json,sarif --severity-threshold low` invocation.
- [x] Direct CLI invocation against the fixture produces the three artifacts the smoke test asserts on (`report.html`, `findings.json`, `findings.sarif`).
- [x] Image pull (`docker pull ghcr.io/0hardik1/kubesplaining:main`) fails with `not found` as expected (Slot #1 not yet shipped); documented as the only remaining manual verification.
- [ ] After Slot #1 lands and publishes `:main`, rerun the smoke workflow; bump default to `:v1` once `v1.0.0` is tagged.

## Equivalent local docker invocation (for reviewers)

The action's shell logic resolves to this, modulo workspace path:

```
docker run --rm \
  -v "$(pwd):/workspace" -w /workspace \
  ghcr.io/0hardik1/kubesplaining:main \
  scan \
  --output-dir /workspace/kubesplaining-report \
  --output-format html,json,sarif \
  --severity-threshold low \
  --input-file /workspace/testdata/snapshots/minimal-risky.json
```

Cannot be run end-to-end until the GHCR image is published by Slot #1; verified with the in-tree binary instead (`./bin/kubesplaining scan --input-file testdata/snapshots/minimal-risky.json --output-dir /tmp/out --output-format html,json,sarif --severity-threshold low` produces all three artifacts).

## Out of scope

- README rewrite (Slot #3).
- GHCR image publish pipeline (Slot #1).
- Bump the default `version` input from `main` to `v1` / `latest`; fast-follow after Slot #1.