### PR TITLE
ci(release): multi-stage Dockerfile + tighten release tag pattern

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Keep the build context tiny. Anything not needed by `go build` is excluded
+# so layer caching kicks in on go.mod / go.sum changes only.
+.git/
+.github/
+.githooks/
+.tmp/
+.claude/
+bin/
+dist/
+kubesplaining-report/
+tmp-*/
+
+# Editor / OS noise
+.idea/
+.vscode/
+*.swp
+.DS_Store
+
+# Generated output / docs that don't affect the binary
+*.md
+!README.md
+CHANGELOG.md
+docs/
+examples/
+
+# Test data isn't needed inside the image
+testdata/
+scripts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 permissions:
   contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,7 +96,7 @@ dockers:
     image_templates:
       - "ghcr.io/0hardik1/kubesplaining:{{ .Version }}-amd64"
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
@@ -113,7 +113,7 @@ dockers:
     image_templates:
       - "ghcr.io/0hardik1/kubesplaining:{{ .Version }}-arm64"
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,43 @@
-# Distroless static + nonroot keeps the attack surface minimal — no shell,
-# no package manager, runs as UID 65532. The binary is built and copied in
-# by GoReleaser, so this Dockerfile is intentionally a copy-only stage.
-FROM gcr.io/distroless/static:nonroot
+# Multi-stage build so `docker build -t kubesplaining:dev .` works from a
+# fresh clone (no prebuilt binary needed in context). For tagged releases,
+# GoReleaser uses Dockerfile.goreleaser instead, which copies the binary
+# it already built and skips the compile step.
+#
+# Stage 1: compile a static binary with the same ldflags the Makefile uses
+# so `kubesplaining version` reports something useful even from a dev image.
+FROM golang:1.26-alpine AS build
 
-COPY kubesplaining /usr/local/bin/kubesplaining
+WORKDIR /src
+
+# Cache module downloads in a separate layer.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# VERSION/COMMIT/DATE may be passed in via --build-arg; the defaults keep the
+# image buildable from a clean source tarball with no .git directory.
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+
+RUN CGO_ENABLED=0 go build \
+      -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+      -o /out/kubesplaining \
+      ./cmd/kubesplaining
+
+# Stage 2: distroless static + nonroot. No shell, no package manager,
+# runs as UID 65532. The image only contains the binary plus CA certs
+# pulled in by the base.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.source=https://github.com/0hardik1/kubesplaining
+LABEL org.opencontainers.image.title=kubesplaining
+LABEL org.opencontainers.image.description="Kubernetes security CLI: RBAC privesc graph, offline snapshot scanning"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
+COPY --from=build /out/kubesplaining /usr/local/bin/kubesplaining
 
 USER nonroot:nonroot
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,17 @@
+# Used by GoReleaser only. GoReleaser drops the already-built binary into
+# the build context as `kubesplaining`, so this stage is intentionally a
+# copy-only Dockerfile (no go toolchain needed in the release pipeline).
+# For ad-hoc `docker build .` from a fresh clone, use the top-level
+# multi-stage Dockerfile instead.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.source=https://github.com/0hardik1/kubesplaining
+LABEL org.opencontainers.image.title=kubesplaining
+LABEL org.opencontainers.image.description="Kubernetes security CLI: RBAC privesc graph, offline snapshot scanning"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
+COPY kubesplaining /usr/local/bin/kubesplaining
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/kubesplaining"]


### PR DESCRIPTION
## Summary

Wave 1 Slot #1 of the parallel-agent fan-out plan (`~/.claude/plans/use-plan-md-strategy-md-and-think-frolicking-waffle.md`, Track A).

The GoReleaser + GHCR pipeline was already in place from PR #?? (`0c62d3b`), but a fresh-clone `docker build .` was broken: the existing `Dockerfile` was a copy-only stage that expected a prebuilt binary in the build context, which only GoReleaser produces. This PR restores a buildable-from-source image without sacrificing the existing release path.

- **`Dockerfile`** is now multi-stage: `golang:1.26-alpine` builder to `gcr.io/distroless/static-debian12:nonroot` runtime. Static binary, non-root, no shell, no package manager. Build args `VERSION` / `COMMIT` / `DATE` flow into the same `-ldflags "-X main.version=... -X main.commit=... -X main.date=..."` the Makefile uses, so `kubesplaining version` reports something sensible even from an ad-hoc image. `LABEL org.opencontainers.image.source=...` set per spec.
- **`Dockerfile.goreleaser`** preserves the fast copy-only path for tagged releases. `.goreleaser.yaml` now points its `dockers:` entries at the new file, so release-pipeline image builds do not pay the compile cost twice.
- **`.dockerignore`** prunes `.git`, `.tmp`, `dist`, `testdata`, `bin`, generated reports, and other context that does not affect the binary. Keeps layer caching focused on `go.mod`/`go.sum` changes.
- **`.github/workflows/release.yml`** tag trigger tightened from `'v*'` to `'v*.*.*'` to match the slot spec. Semver pre-releases like `v1.2.3-rc1` still match.

No Go source edits.

## Plan reference

`Wave 1 / Track A / Slot #1: GoReleaser + Dockerfile + GHCR push`
(see `~/.claude/plans/use-plan-md-strategy-md-and-think-frolicking-waffle.md`).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses cleanly.
- [x] `./bin/goreleaser check` validates `.goreleaser.yaml` (only deprecation notice is the pre-existing `dockers` warning).
- [x] `docker build -t kubesplaining:dev .` succeeds against a fresh clone (multi-arch buildx, distroless, non-root).
- [x] `docker run --rm kubesplaining:dev --help` prints CLI usage.
- [x] `docker run --rm kubesplaining:dev version` prints `version=dev commit=unknown date=unknown` (defaults; tagged releases will inject real values via GoReleaser ldflags).
- [x] `./bin/goreleaser release --snapshot --clean --skip=publish,docker` builds all 5 archives (linux/{amd64,arm64}, darwin/{amd64,arm64}, windows/amd64) + `checksums.txt`.
- [x] `make test`, `make lint`, `./bin/golangci-lint run ./...` all green.
- [ ] Cutting a real `v*.*.*` tag is intentionally **not** part of this PR; the workflow only fires on tag push.

## Deferred

- **Cosign signing** of artifacts and images: not in slot scope; a follow-up can wire `sigstore/cosign-installer` and add `signs:` / `docker_signs:` to `.goreleaser.yaml`.
- **SBOM**: skipped per slot guidance ("unless trivial"). Trivy/syft integration is a small follow-up if/when distribution stories need attestations.
- **Slot #2 (Action wrapper)** and **Slot #3 (README rewrite)** are sibling worktrees; this PR does not touch their files.