### PR TITLE
feat(cli): diff command and scan --baseline for delta gates

### DIFF
--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -1,0 +1,134 @@
+package baseline
+
+import (
+	"sort"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// Result is the classification of two findings slices into three disjoint
+// buckets keyed on Finding.ID. Resolved findings carry the OLD finding
+// (so the caller can render its title/severity); Unchanged carries the NEW
+// finding (so the caller sees the freshest data when re-rendering).
+type Result struct {
+	Added     []models.Finding
+	Resolved  []models.Finding
+	Unchanged []models.Finding
+}
+
+// Diff partitions old and new findings into Added (in new, not in old),
+// Resolved (in old, not in new), and Unchanged (in both, keyed by ID).
+//
+// The result's three slices are sorted by (Severity rank desc, Score desc,
+// RuleID asc, ID asc) so the output order is deterministic across runs
+// regardless of input ordering. This matches the report writer's global
+// priority comparator and keeps `diff` output stable for diff-of-diffs
+// use cases (e.g. PR comments that get re-rendered on every push).
+//
+// When both slices are nil/empty the result is the zero value; when they
+// are identical (same ID set) Added and Resolved are both empty and
+// Unchanged carries every NEW finding.
+func Diff(oldFindings, newFindings []models.Finding) Result {
+	oldByID := indexByID(oldFindings)
+	newByID := indexByID(newFindings)
+
+	var result Result
+
+	for _, f := range newFindings {
+		if _, present := oldByID[f.ID]; present {
+			result.Unchanged = append(result.Unchanged, f)
+		} else {
+			result.Added = append(result.Added, f)
+		}
+	}
+
+	for _, f := range oldFindings {
+		if _, present := newByID[f.ID]; !present {
+			result.Resolved = append(result.Resolved, f)
+		}
+	}
+
+	sortFindings(result.Added)
+	sortFindings(result.Resolved)
+	sortFindings(result.Unchanged)
+
+	return result
+}
+
+// indexByID returns a presence-only map keyed on Finding.ID. We don't
+// need the value side for diff classification, only set membership.
+func indexByID(findings []models.Finding) map[string]struct{} {
+	out := make(map[string]struct{}, len(findings))
+	for _, f := range findings {
+		out[f.ID] = struct{}{}
+	}
+	return out
+}
+
+// sortFindings mirrors the global priority comparator used by the report
+// writer (severity rank desc, score desc, RuleID asc, ID asc). The final
+// ID tiebreaker makes the order fully deterministic even when two findings
+// share a rule and a score.
+func sortFindings(findings []models.Finding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		a, b := findings[i], findings[j]
+		if a.Severity.Rank() != b.Severity.Rank() {
+			return a.Severity.Rank() > b.Severity.Rank()
+		}
+		if a.Score != b.Score {
+			return a.Score > b.Score
+		}
+		if a.RuleID != b.RuleID {
+			return a.RuleID < b.RuleID
+		}
+		return a.ID < b.ID
+	})
+}
+
+// Summary is a small severity-tally view over a Result, used by the text
+// and markdown writers to compose the one-line headline. It mirrors the
+// shape of report.Summary so the rendered counts read the same in both
+// surfaces (and so a future migration to report.Summary stays mechanical).
+type Summary struct {
+	Critical int
+	High     int
+	Medium   int
+	Low      int
+	Info     int
+	Total    int
+}
+
+// SummarizeSeverities counts findings by severity bucket.
+func SummarizeSeverities(findings []models.Finding) Summary {
+	s := Summary{Total: len(findings)}
+	for _, f := range findings {
+		switch f.Severity {
+		case models.SeverityCritical:
+			s.Critical++
+		case models.SeverityHigh:
+			s.High++
+		case models.SeverityMedium:
+			s.Medium++
+		case models.SeverityLow:
+			s.Low++
+		default:
+			s.Info++
+		}
+	}
+	return s
+}
+
+// CountNewPrivescPaths returns the number of Added findings that look like
+// privilege-escalation graph paths (RuleID prefix "KUBE-PRIVESC-PATH-").
+// These get highlighted in the text/markdown summary because a new
+// privesc path is the highest-signal regression a diff can surface.
+func CountNewPrivescPaths(added []models.Finding) int {
+	const prefix = "KUBE-PRIVESC-PATH-"
+	n := 0
+	for _, f := range added {
+		if len(f.RuleID) >= len(prefix) && f.RuleID[:len(prefix)] == prefix {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/baseline/diff_test.go
+++ b/internal/baseline/diff_test.go
@@ -1,0 +1,218 @@
+package baseline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+func newFinding(id, ruleID string, severity models.Severity, score float64) models.Finding {
+	return models.Finding{
+		ID:       id,
+		RuleID:   ruleID,
+		Severity: severity,
+		Score:    score,
+		Title:    ruleID,
+	}
+}
+
+func ids(findings []models.Finding) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.ID)
+	}
+	return out
+}
+
+func TestDiff(t *testing.T) {
+	t.Parallel()
+
+	a := newFinding("KUBE-PODSEC-PRIV-001:default:a", "KUBE-PODSEC-PRIV-001", models.SeverityHigh, 8.0)
+	b := newFinding("KUBE-RBAC-OVERBROAD-001:cluster:b", "KUBE-RBAC-OVERBROAD-001", models.SeverityCritical, 9.5)
+	c := newFinding("KUBE-PRIVESC-PATH-CLUSTER-ADMIN:default:c", "KUBE-PRIVESC-PATH-CLUSTER-ADMIN", models.SeverityCritical, 9.8)
+	d := newFinding("KUBE-NETPOL-COVERAGE-001:default:d", "KUBE-NETPOL-COVERAGE-001", models.SeverityMedium, 5.0)
+
+	tests := []struct {
+		name              string
+		old               []models.Finding
+		new               []models.Finding
+		wantAdded         []string
+		wantResolved      []string
+		wantUnchanged     []string
+		wantPrivescPaths  int
+		wantAddedCritical int
+	}{
+		{
+			name:              "empty inputs",
+			old:               nil,
+			new:               nil,
+			wantAdded:         nil,
+			wantResolved:      nil,
+			wantUnchanged:     nil,
+			wantPrivescPaths:  0,
+			wantAddedCritical: 0,
+		},
+		{
+			name:              "identical inputs are all unchanged",
+			old:               []models.Finding{a, b},
+			new:               []models.Finding{a, b},
+			wantAdded:         nil,
+			wantResolved:      nil,
+			wantUnchanged:     []string{b.ID, a.ID}, // sorted by severity rank desc then score desc
+			wantPrivescPaths:  0,
+			wantAddedCritical: 0,
+		},
+		{
+			name:              "all added when old is empty",
+			old:               nil,
+			new:               []models.Finding{a, b, c},
+			wantAdded:         []string{c.ID, b.ID, a.ID}, // critical (9.8), critical (9.5), high (8.0)
+			wantResolved:      nil,
+			wantUnchanged:     nil,
+			wantPrivescPaths:  1,
+			wantAddedCritical: 2,
+		},
+		{
+			name:              "all resolved when new is empty",
+			old:               []models.Finding{a, b},
+			new:               nil,
+			wantAdded:         nil,
+			wantResolved:      []string{b.ID, a.ID},
+			wantUnchanged:     nil,
+			wantPrivescPaths:  0,
+			wantAddedCritical: 0,
+		},
+		{
+			name:              "mixed added resolved unchanged",
+			old:               []models.Finding{a, b, d}, // a, b, d
+			new:               []models.Finding{a, c},    // a unchanged, c added, b+d resolved
+			wantAdded:         []string{c.ID},
+			wantResolved:      []string{b.ID, d.ID}, // critical, medium
+			wantUnchanged:     []string{a.ID},
+			wantPrivescPaths:  1,
+			wantAddedCritical: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Diff(tc.old, tc.new)
+
+			if !equalIDs(ids(got.Added), tc.wantAdded) {
+				t.Errorf("Added IDs = %v, want %v", ids(got.Added), tc.wantAdded)
+			}
+			if !equalIDs(ids(got.Resolved), tc.wantResolved) {
+				t.Errorf("Resolved IDs = %v, want %v", ids(got.Resolved), tc.wantResolved)
+			}
+			if !equalIDs(ids(got.Unchanged), tc.wantUnchanged) {
+				t.Errorf("Unchanged IDs = %v, want %v", ids(got.Unchanged), tc.wantUnchanged)
+			}
+
+			if n := CountNewPrivescPaths(got.Added); n != tc.wantPrivescPaths {
+				t.Errorf("CountNewPrivescPaths = %d, want %d", n, tc.wantPrivescPaths)
+			}
+
+			if s := SummarizeSeverities(got.Added); s.Critical != tc.wantAddedCritical {
+				t.Errorf("Added Critical count = %d, want %d", s.Critical, tc.wantAddedCritical)
+			}
+		})
+	}
+}
+
+func TestDiff_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	// Two findings with identical severity/score must sort by RuleID asc, then ID asc.
+	f1 := newFinding("BBB", "KUBE-RBAC-OVERBROAD-001", models.SeverityHigh, 7.0)
+	f2 := newFinding("AAA", "KUBE-PODSEC-PRIV-001", models.SeverityHigh, 7.0)
+	f3 := newFinding("CCC", "KUBE-PODSEC-PRIV-001", models.SeverityHigh, 7.0)
+
+	got := Diff(nil, []models.Finding{f1, f2, f3})
+
+	// Expected order: PODSEC < RBAC (rule asc), then within PODSEC AAA < CCC (ID asc).
+	wantOrder := []string{"AAA", "CCC", "BBB"}
+	if !equalIDs(ids(got.Added), wantOrder) {
+		t.Errorf("Added order = %v, want %v", ids(got.Added), wantOrder)
+	}
+}
+
+func TestLoadFindings(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	f := newFinding("X:default:a", "KUBE-PODSEC-PRIV-001", models.SeverityHigh, 8.0)
+	arrayPayload, err := json.Marshal([]models.Finding{f})
+	if err != nil {
+		t.Fatalf("marshal array: %v", err)
+	}
+	arrayPath := filepath.Join(tmp, "array.json")
+	if err := os.WriteFile(arrayPath, arrayPayload, 0o600); err != nil {
+		t.Fatalf("write array: %v", err)
+	}
+
+	wrapped, err := json.Marshal(map[string]any{
+		"findings": []models.Finding{f},
+		"metadata": map[string]string{"cluster": "x"},
+	})
+	if err != nil {
+		t.Fatalf("marshal wrapped: %v", err)
+	}
+	wrappedPath := filepath.Join(tmp, "wrapped.json")
+	if err := os.WriteFile(wrappedPath, wrapped, 0o600); err != nil {
+		t.Fatalf("write wrapped: %v", err)
+	}
+
+	emptyPath := filepath.Join(tmp, "empty.json")
+	if err := os.WriteFile(emptyPath, []byte("   \n\t  "), 0o600); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+
+	bogusPath := filepath.Join(tmp, "bogus.json")
+	if err := os.WriteFile(bogusPath, []byte("\"not an object or array\""), 0o600); err != nil {
+		t.Fatalf("write bogus: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		wantLen int
+		wantErr bool
+	}{
+		{"bare array", arrayPath, 1, false},
+		{"object wrapper", wrappedPath, 1, false},
+		{"empty file", emptyPath, 0, true},
+		{"scalar JSON", bogusPath, 0, true},
+		{"missing file", filepath.Join(tmp, "missing.json"), 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := LoadFindings(tc.path)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("LoadFindings err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && len(got) != tc.wantLen {
+				t.Errorf("len(got) = %d, want %d", len(got), tc.wantLen)
+			}
+		})
+	}
+}
+
+// equalIDs compares two ID slices, treating a nil and an empty slice as equal.
+func equalIDs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/baseline/loader.go
+++ b/internal/baseline/loader.go
@@ -1,0 +1,67 @@
+// Package baseline loads previously emitted findings.json files and computes a
+// delta against a freshly produced findings slice. The diff is keyed on
+// Finding.ID, which the analyzer pipeline guarantees is deterministic per
+// instance ("RULE:ns:name"), so two scans of the same cluster surface the
+// same set of IDs and an Added / Resolved / Unchanged classification falls
+// out cleanly.
+//
+// The loader accepts either of two on-disk shapes so callers can point the
+// flag at whichever artifact they happen to have saved:
+//
+//	[ {...finding...}, {...finding...} ]                 // bare array  (writeJSON output)
+//	{ "findings": [ {...finding...}, ... ], ... }        // wrapper object (forward-compat)
+//
+// Detection is by first non-whitespace byte, not by filename suffix, so
+// renamed files (findings.json, report.json, baseline.json) all work.
+package baseline
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// wrappedFindings is the object-shape variant the loader accepts. The
+// `findings` key is the only required field; anything else in the wrapper
+// is ignored so future callers can stash metadata alongside without
+// breaking the loader.
+type wrappedFindings struct {
+	Findings []models.Finding `json:"findings"`
+}
+
+// LoadFindings reads a JSON file at path and returns its findings slice.
+// The file may be a bare JSON array (the shape written by the existing
+// report writer) or a wrapper object containing a `findings` array; the
+// shape is detected from the first non-whitespace byte. An empty file is
+// an error.
+func LoadFindings(path string) ([]models.Finding, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("open baseline file: %w", err)
+	}
+
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("baseline file %s is empty", path)
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var findings []models.Finding
+		if err := json.Unmarshal(raw, &findings); err != nil {
+			return nil, fmt.Errorf("decode baseline findings array: %w", err)
+		}
+		return findings, nil
+	case '{':
+		var wrapper wrappedFindings
+		if err := json.Unmarshal(raw, &wrapper); err != nil {
+			return nil, fmt.Errorf("decode baseline findings object: %w", err)
+		}
+		return wrapper.Findings, nil
+	default:
+		return nil, fmt.Errorf("baseline file %s: unrecognized JSON shape (expected array or object)", path)
+	}
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,0 +1,480 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/baseline"
+	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/spf13/cobra"
+)
+
+// NewDiffCmd returns the "diff" subcommand, which compares two findings JSON
+// files emitted by `scan` (or anything that produces the same shape) and
+// prints / writes a delta report classifying each finding as Added,
+// Resolved, or Unchanged. The diff is keyed on Finding.ID, which the
+// analyzer pipeline guarantees is deterministic across runs of the same
+// cluster ("RULE:ns:name").
+//
+// Output formats:
+//
+//	text     : default; summary headline + per-section bullet list
+//	markdown : same content as text but with ## headings and tables
+//	sarif    : SARIF 2.1.0 run containing only Added findings, with
+//	           level=warning and a properties.delta marker so downstream
+//	           tooling can distinguish a delta upload from a full scan
+//
+// When --output-dir is set the rendered diff is written to <dir>/diff.{txt,md,sarif}
+// instead of stdout. The diff command never re-runs analysis; it only
+// reads the two JSON files it's pointed at.
+func NewDiffCmd() *cobra.Command {
+	var (
+		outputFormat string
+		outputDir    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "diff <old.json> <new.json>",
+		Short: "Compare two findings JSON files and emit a delta report",
+		Long: "diff classifies findings as Added, Resolved, or Unchanged keyed on the deterministic Finding.ID. " +
+			"Use it in CI to surface only the findings that appeared since a baseline scan, or locally to see what changed between two snapshots.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := parseDiffFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+
+			oldFindings, err := baseline.LoadFindings(args[0])
+			if err != nil {
+				return fmt.Errorf("read old findings %s: %w", args[0], err)
+			}
+			newFindings, err := baseline.LoadFindings(args[1])
+			if err != nil {
+				return fmt.Errorf("read new findings %s: %w", args[1], err)
+			}
+
+			result := baseline.Diff(oldFindings, newFindings)
+
+			if outputDir != "" {
+				path, err := writeDiff(outputDir, format, result)
+				if err != nil {
+					return err
+				}
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", path)
+				return err
+			}
+
+			return renderDiff(cmd.OutOrStdout(), format, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&outputFormat, "output-format", "text", "Output format: text|markdown|sarif")
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Optional directory to write diff.{txt,md,sarif} into; stdout when unset")
+
+	return cmd
+}
+
+// diffFormat is the parsed --output-format value. Text and markdown share most
+// of their rendering pipeline (diffSummaryLine + bullet/table sections); sarif
+// is a distinct JSON document.
+type diffFormat string
+
+const (
+	diffFormatText     diffFormat = "text"
+	diffFormatMarkdown diffFormat = "markdown"
+	diffFormatSARIF    diffFormat = "sarif"
+)
+
+// parseDiffFormat normalizes and validates the --output-format flag.
+func parseDiffFormat(value string) (diffFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "text", "txt":
+		return diffFormatText, nil
+	case "markdown", "md":
+		return diffFormatMarkdown, nil
+	case "sarif":
+		return diffFormatSARIF, nil
+	default:
+		return "", fmt.Errorf("invalid --output-format %q (must be text, markdown, or sarif)", value)
+	}
+}
+
+// renderDiff writes the rendered output for format into w. The file-writing
+// path (writeDiff) reuses the same renderer so both code paths produce
+// identical bytes.
+func renderDiff(w io.Writer, format diffFormat, result baseline.Result) error {
+	switch format {
+	case diffFormatText:
+		return renderDiffText(w, result)
+	case diffFormatMarkdown:
+		return renderDiffMarkdown(w, result)
+	case diffFormatSARIF:
+		return renderDiffSARIF(w, result)
+	default:
+		return fmt.Errorf("unsupported diff format %q", format)
+	}
+}
+
+// writeDiff creates outputDir if needed and writes diff.{txt,md,sarif} into it.
+// Returns the absolute path of the written file so the caller can print it.
+func writeDiff(outputDir string, format diffFormat, result baseline.Result) (string, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return "", fmt.Errorf("create diff output directory: %w", err)
+	}
+
+	var filename string
+	switch format {
+	case diffFormatText:
+		filename = "diff.txt"
+	case diffFormatMarkdown:
+		filename = "diff.md"
+	case diffFormatSARIF:
+		filename = "diff.sarif"
+	default:
+		return "", fmt.Errorf("unsupported diff format %q", format)
+	}
+
+	path := filepath.Join(outputDir, filename)
+	file, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create diff file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if err := renderDiff(file, format, result); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// diffHeadline builds the single-line headline used by both text and markdown
+// renderers. It surfaces the four numbers a CI reviewer cares about first:
+// new criticals, total resolved, and any new privesc paths (the latter is
+// the highest-signal regression this tool can flag).
+func diffHeadline(result baseline.Result) string {
+	added := baseline.SummarizeSeverities(result.Added)
+	resolved := baseline.SummarizeSeverities(result.Resolved)
+	newPaths := baseline.CountNewPrivescPaths(result.Added)
+
+	var parts []string
+	if added.Critical > 0 {
+		parts = append(parts, fmt.Sprintf("%d new critical %s", added.Critical, pluralFindings(added.Critical)))
+	}
+	if added.High > 0 {
+		parts = append(parts, fmt.Sprintf("%d new high %s", added.High, pluralFindings(added.High)))
+	}
+	if added.Total-added.Critical-added.High > 0 {
+		other := added.Total - added.Critical - added.High
+		parts = append(parts, fmt.Sprintf("%d other new %s", other, pluralFindings(other)))
+	}
+	if resolved.Total > 0 {
+		parts = append(parts, fmt.Sprintf("%d resolved", resolved.Total))
+	}
+	if newPaths > 0 {
+		parts = append(parts, fmt.Sprintf("%d new privesc %s", newPaths, pluralPath(newPaths)))
+	}
+
+	if len(parts) == 0 {
+		return "no changes since baseline"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// pluralFindings returns "finding" or "findings" depending on n.
+func pluralFindings(n int) string {
+	if n == 1 {
+		return "finding"
+	}
+	return "findings"
+}
+
+// pluralPath returns "path" or "paths" depending on n.
+func pluralPath(n int) string {
+	if n == 1 {
+		return "path"
+	}
+	return "paths"
+}
+
+// renderDiffText writes a plain-text delta report: a one-line headline,
+// counts row, then per-section bullet lists with one bullet per finding.
+// Designed to read well on a terminal and inside a wrapped GitHub Action
+// log line.
+func renderDiffText(w io.Writer, result baseline.Result) error {
+	added := baseline.SummarizeSeverities(result.Added)
+	resolved := baseline.SummarizeSeverities(result.Resolved)
+	unchanged := baseline.SummarizeSeverities(result.Unchanged)
+
+	if _, err := fmt.Fprintf(w, "diff: %s\n", diffHeadline(result)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "counts: added=%d resolved=%d unchanged=%d\n", added.Total, resolved.Total, unchanged.Total); err != nil {
+		return err
+	}
+
+	if err := writeBulletSection(w, "Added", result.Added); err != nil {
+		return err
+	}
+	if err := writeBulletSection(w, "Resolved", result.Resolved); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeBulletSection writes a "Added (n):" / "Resolved (n):" heading and
+// a bullet per finding. Empty sections still render their header so readers
+// can confirm "zero resolved" rather than "section missing".
+func writeBulletSection(w io.Writer, label string, findings []models.Finding) error {
+	if _, err := fmt.Fprintf(w, "\n%s (%d):\n", label, len(findings)); err != nil {
+		return err
+	}
+	if len(findings) == 0 {
+		_, err := fmt.Fprintln(w, "  (none)")
+		return err
+	}
+	for _, f := range findings {
+		if _, err := fmt.Fprintf(w, "  - [%s] %s :: %s%s\n",
+			f.Severity, f.RuleID, f.Title, subjectSuffix(f)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// subjectSuffix returns a human-readable " (subject Kind/ns/name)" suffix
+// when the finding has a Subject or Resource, or "" otherwise.
+func subjectSuffix(f models.Finding) string {
+	switch {
+	case f.Subject != nil:
+		return " (subject " + f.Subject.Key() + ")"
+	case f.Resource != nil:
+		return " (resource " + f.Resource.Key() + ")"
+	default:
+		return ""
+	}
+}
+
+// renderDiffMarkdown writes a Markdown delta report. Sections use ## headings,
+// findings inside a section render as a pipe-separated table so the GitHub
+// Action's "Job summary" view tabulates them. The headline doubles as a
+// blockquote for visual emphasis.
+func renderDiffMarkdown(w io.Writer, result baseline.Result) error {
+	added := baseline.SummarizeSeverities(result.Added)
+	resolved := baseline.SummarizeSeverities(result.Resolved)
+	unchanged := baseline.SummarizeSeverities(result.Unchanged)
+
+	if _, err := fmt.Fprintf(w, "# kubesplaining diff\n\n> %s\n\n", diffHeadline(result)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "| | count |\n|---|---:|\n| Added | %d |\n| Resolved | %d |\n| Unchanged | %d |\n\n",
+		added.Total, resolved.Total, unchanged.Total); err != nil {
+		return err
+	}
+
+	if err := writeMarkdownSection(w, "Added", result.Added); err != nil {
+		return err
+	}
+	if err := writeMarkdownSection(w, "Resolved", result.Resolved); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeMarkdownSection writes a "## Added (n)" / "## Resolved (n)" heading
+// and either an empty-state line or a 4-column table. Severity column
+// values are wrapped in backticks so they retain their bucketed look in
+// a Markdown renderer that strips ANSI styling.
+func writeMarkdownSection(w io.Writer, label string, findings []models.Finding) error {
+	if _, err := fmt.Fprintf(w, "## %s (%d)\n\n", label, len(findings)); err != nil {
+		return err
+	}
+	if len(findings) == 0 {
+		_, err := fmt.Fprintln(w, "_None._")
+		_, _ = fmt.Fprintln(w)
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| Severity | Rule | Subject/Resource | Title |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "|---|---|---|---|"); err != nil {
+		return err
+	}
+	for _, f := range findings {
+		subject := "-"
+		if f.Subject != nil {
+			subject = f.Subject.Key()
+		} else if f.Resource != nil {
+			subject = f.Resource.Key()
+		}
+		if _, err := fmt.Fprintf(w, "| `%s` | `%s` | `%s` | %s |\n",
+			f.Severity, f.RuleID, subject, escapePipe(f.Title)); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
+}
+
+// escapePipe replaces literal `|` characters with `\|` so finding titles
+// containing pipes do not break the Markdown table column count.
+func escapePipe(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+// diffSARIFReport is the subset of SARIF 2.1.0 the diff command emits.
+// We intentionally do not re-use the report package's sarifReport types
+// to keep the diff command's surface independent of report internals;
+// the schema fields are small enough that duplication beats coupling.
+type diffSARIFReport struct {
+	Schema  string         `json:"$schema"`
+	Version string         `json:"version"`
+	Runs    []diffSARIFRun `json:"runs"`
+}
+
+type diffSARIFRun struct {
+	Tool       diffSARIFTool     `json:"tool"`
+	Results    []diffSARIFResult `json:"results"`
+	Properties map[string]any    `json:"properties,omitempty"`
+}
+
+type diffSARIFTool struct {
+	Driver diffSARIFDriver `json:"driver"`
+}
+
+type diffSARIFDriver struct {
+	Name           string          `json:"name"`
+	InformationURI string          `json:"informationUri,omitempty"`
+	Rules          []diffSARIFRule `json:"rules,omitempty"`
+}
+
+type diffSARIFRule struct {
+	ID               string                   `json:"id"`
+	Name             string                   `json:"name,omitempty"`
+	ShortDescription diffSARIFTextDescription `json:"shortDescription,omitempty"`
+}
+
+type diffSARIFTextDescription struct {
+	Text string `json:"text"`
+}
+
+type diffSARIFResult struct {
+	RuleID     string                   `json:"ruleId"`
+	Level      string                   `json:"level"`
+	Message    diffSARIFTextDescription `json:"message"`
+	Kind       string                   `json:"kind,omitempty"`
+	Properties map[string]any           `json:"properties,omitempty"`
+}
+
+// renderDiffSARIF writes a SARIF 2.1.0 document whose results are exactly
+// the Added findings (Resolved and Unchanged are intentionally omitted:
+// SARIF is consumed as "new issues" by GitHub code-scanning, so loading
+// resolved-finding entries would produce stale alerts).
+//
+// Every result is emitted at level=warning regardless of the underlying
+// severity. The rationale: a delta upload should not duplicate the full
+// scan's error-level results in code-scanning, but it still needs to be
+// visible. Consumers that care about the original severity can read it
+// from properties.severity.
+//
+// Each result and the enclosing run get a `properties.delta: true`
+// marker so downstream tooling can distinguish a diff upload from a
+// full scan.
+func renderDiffSARIF(w io.Writer, result baseline.Result) error {
+	rules := buildDiffSARIFRules(result.Added)
+	results := buildDiffSARIFResults(result.Added)
+
+	doc := diffSARIFReport{
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []diffSARIFRun{
+			{
+				Tool: diffSARIFTool{
+					Driver: diffSARIFDriver{
+						Name:           "kubesplaining-diff",
+						InformationURI: "https://github.com/0hardik1/kubesplaining",
+						Rules:          rules,
+					},
+				},
+				Results: results,
+				Properties: map[string]any{
+					"delta":           true,
+					"added_count":     len(result.Added),
+					"resolved_count":  len(result.Resolved),
+					"unchanged_count": len(result.Unchanged),
+				},
+			},
+		},
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(doc); err != nil {
+		return fmt.Errorf("encode diff sarif: %w", err)
+	}
+	return nil
+}
+
+// buildDiffSARIFRules projects unique RuleIDs from findings into rule
+// metadata entries, deduplicated by ID and emitted in ID-ascending order
+// so the SARIF document is byte-stable across runs.
+func buildDiffSARIFRules(findings []models.Finding) []diffSARIFRule {
+	seen := make(map[string]models.Finding)
+	for _, f := range findings {
+		if _, ok := seen[f.RuleID]; !ok {
+			seen[f.RuleID] = f
+		}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	out := make([]diffSARIFRule, 0, len(ids))
+	for _, id := range ids {
+		f := seen[id]
+		out = append(out, diffSARIFRule{
+			ID:               id,
+			Name:             f.Title,
+			ShortDescription: diffSARIFTextDescription{Text: f.Description},
+		})
+	}
+	return out
+}
+
+// buildDiffSARIFResults converts each Added finding into a SARIF result.
+// Level is fixed at "warning" (see renderDiffSARIF docstring).
+func buildDiffSARIFResults(findings []models.Finding) []diffSARIFResult {
+	out := make([]diffSARIFResult, 0, len(findings))
+	for _, f := range findings {
+		props := map[string]any{
+			"delta":    true,
+			"severity": f.Severity,
+			"score":    f.Score,
+			"category": f.Category,
+		}
+		if f.Namespace != "" {
+			props["namespace"] = f.Namespace
+		}
+		if f.Subject != nil {
+			props["subject"] = f.Subject
+		}
+		if f.Resource != nil {
+			props["resource"] = f.Resource
+		}
+		out = append(out, diffSARIFResult{
+			RuleID:     f.RuleID,
+			Level:      "warning",
+			Kind:       "fail",
+			Message:    diffSARIFTextDescription{Text: f.Title + ": " + f.Description},
+			Properties: props,
+		})
+	}
+	return out
+}

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// writeFindings is a small test helper that serializes findings as the bare
+// JSON array shape the report writer emits, so the diff command can ingest
+// it via baseline.LoadFindings.
+func writeFindings(t *testing.T, dir, name string, findings []models.Finding) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	payload, err := json.Marshal(findings)
+	if err != nil {
+		t.Fatalf("marshal findings: %v", err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write findings: %v", err)
+	}
+	return path
+}
+
+func TestDiffCmd_TextSummary(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	old := []models.Finding{
+		{ID: "A", RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0, Title: "privileged container"},
+		{ID: "B", RuleID: "KUBE-RBAC-OVERBROAD-001", Severity: models.SeverityCritical, Score: 9.5, Title: "wildcard role"},
+	}
+	newRun := []models.Finding{
+		{ID: "A", RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0, Title: "privileged container"},
+		{ID: "C", RuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN", Severity: models.SeverityCritical, Score: 9.8, Title: "default SA reaches cluster-admin"},
+	}
+	oldPath := writeFindings(t, tmp, "old.json", old)
+	newPath := writeFindings(t, tmp, "new.json", newRun)
+
+	cmd := NewDiffCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{oldPath, newPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	out := stdout.String()
+	// One added (C, critical), one resolved (B, critical), one unchanged (A, high).
+	if !strings.Contains(out, "1 new critical") {
+		t.Errorf("expected '1 new critical' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 resolved") {
+		t.Errorf("expected '1 resolved' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 new privesc path") {
+		t.Errorf("expected '1 new privesc path' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Added (1)") {
+		t.Errorf("expected 'Added (1)' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Resolved (1)") {
+		t.Errorf("expected 'Resolved (1)' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "KUBE-PRIVESC-PATH-CLUSTER-ADMIN") {
+		t.Errorf("expected new finding's RuleID in output, got:\n%s", out)
+	}
+}
+
+func TestDiffCmd_NoChangesIdenticalInputs(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	findings := []models.Finding{
+		{ID: "A", RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0, Title: "privileged container"},
+	}
+	oldPath := writeFindings(t, tmp, "old.json", findings)
+	newPath := writeFindings(t, tmp, "new.json", findings)
+
+	cmd := NewDiffCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{oldPath, newPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "no changes since baseline") {
+		t.Errorf("expected 'no changes since baseline' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "added=0 resolved=0 unchanged=1") {
+		t.Errorf("expected 'added=0 resolved=0 unchanged=1' counts, got:\n%s", out)
+	}
+}
+
+func TestDiffCmd_MarkdownOutput(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	old := []models.Finding{}
+	newRun := []models.Finding{
+		{ID: "X", RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0, Title: "privileged container | pipe"},
+	}
+	oldPath := writeFindings(t, tmp, "old.json", old)
+	newPath := writeFindings(t, tmp, "new.json", newRun)
+
+	cmd := NewDiffCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--output-format", "markdown", oldPath, newPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "# kubesplaining diff") {
+		t.Errorf("expected H1 title, got:\n%s", out)
+	}
+	if !strings.Contains(out, "## Added (1)") {
+		t.Errorf("expected '## Added (1)' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, `\|`) {
+		t.Errorf("expected pipe characters in titles to be escaped, got:\n%s", out)
+	}
+}
+
+func TestDiffCmd_SARIFOutputAddedOnly(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	old := []models.Finding{
+		{ID: "Resolved-1", RuleID: "KUBE-RBAC-OVERBROAD-001", Severity: models.SeverityCritical, Score: 9.5, Title: "resolved rule"},
+	}
+	newRun := []models.Finding{
+		{ID: "Added-1", RuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN", Severity: models.SeverityCritical, Score: 9.8, Title: "new privesc path", Description: "BFS from default SA"},
+	}
+	oldPath := writeFindings(t, tmp, "old.json", old)
+	newPath := writeFindings(t, tmp, "new.json", newRun)
+
+	cmd := NewDiffCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--output-format", "sarif", oldPath, newPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("decode sarif: %v\noutput:\n%s", err, stdout.String())
+	}
+	runs, ok := doc["runs"].([]any)
+	if !ok || len(runs) != 1 {
+		t.Fatalf("expected one run, got: %v", doc["runs"])
+	}
+	run := runs[0].(map[string]any)
+	props := run["properties"].(map[string]any)
+	if props["delta"] != true {
+		t.Errorf("expected properties.delta=true in run, got %v", props["delta"])
+	}
+	results := run["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 result (Added only), got %d", len(results))
+	}
+	res := results[0].(map[string]any)
+	if res["ruleId"] != "KUBE-PRIVESC-PATH-CLUSTER-ADMIN" {
+		t.Errorf("expected Added finding's ruleId in result, got %v", res["ruleId"])
+	}
+	if res["level"] != "warning" {
+		t.Errorf("expected level=warning for delta SARIF, got %v", res["level"])
+	}
+
+	// Resolved findings must not appear in SARIF.
+	if strings.Contains(stdout.String(), "KUBE-RBAC-OVERBROAD-001") {
+		t.Errorf("SARIF must omit Resolved findings; got:\n%s", stdout.String())
+	}
+}
+
+func TestDiffCmd_OutputDirWritesFile(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	findings := []models.Finding{
+		{ID: "A", RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0, Title: "x"},
+	}
+	oldPath := writeFindings(t, tmp, "old.json", findings)
+	newPath := writeFindings(t, tmp, "new.json", findings)
+
+	outDir := filepath.Join(tmp, "out")
+	cmd := NewDiffCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--output-dir", outDir, "--output-format", "markdown", oldPath, newPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	written := filepath.Join(outDir, "diff.md")
+	body, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("read written diff: %v", err)
+	}
+	if !strings.Contains(string(body), "# kubesplaining diff") {
+		t.Errorf("expected markdown content in %s, got:\n%s", written, string(body))
+	}
+	if !strings.Contains(stdout.String(), written) {
+		t.Errorf("expected stdout to mention %s, got:\n%s", written, stdout.String())
+	}
+}
+
+func TestDiffCmd_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	findings := []models.Finding{
+		{ID: "A", RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0, Title: "x"},
+	}
+	oldPath := writeFindings(t, tmp, "old.json", findings)
+	newPath := writeFindings(t, tmp, "new.json", findings)
+
+	cmd := NewDiffCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--output-format", "yaml", oldPath, newPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid output format")
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("expected error mentioning yaml, got: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,6 +19,7 @@ func NewRootCmd(build BuildInfo) *cobra.Command {
 		NewScanResourceCmd(),
 		NewCreateExclusionsCmd(),
 		NewReportCmd(),
+		NewDiffCmd(),
 		NewVersionCmd(build),
 	)
 

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0hardik1/kubesplaining/internal/analyzer"
 	"github.com/0hardik1/kubesplaining/internal/analyzer/leastprivilege"
+	"github.com/0hardik1/kubesplaining/internal/baseline"
 	"github.com/0hardik1/kubesplaining/internal/collector"
 	"github.com/0hardik1/kubesplaining/internal/connection"
 	"github.com/0hardik1/kubesplaining/internal/exclusions"
@@ -46,6 +47,8 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 		auditWindowDays      int
 		leastPrivilegeOnly   bool
 		complianceFilters    []string
+		baselineFile         string
+		baselineFormat       string
 	)
 
 	cmd := &cobra.Command{
@@ -159,12 +162,61 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 			}
 			printTruncationNotice(cmd.ErrOrStderr(), truncation)
 
-			if ciMode {
-				if summary.Critical > ciMaxCritical {
-					return fmt.Errorf("ci threshold exceeded: critical findings %d > %d", summary.Critical, ciMaxCritical)
+			// Baseline diff: when --baseline is set we always render and write
+			// the delta report alongside the main report so a reviewer can read
+			// "what changed since the last run" without invoking `kubesplaining diff`
+			// separately. In CI mode the diff also retargets the ci-max gates so
+			// they count Added findings only, not the absolute new-scan tally.
+			var diffResult *baseline.Result
+			if baselineFile != "" {
+				format, err := parseDiffFormat(baselineFormat)
+				if err != nil {
+					return err
 				}
-				if summary.High > ciMaxHigh {
-					return fmt.Errorf("ci threshold exceeded: high findings %d > %d", summary.High, ciMaxHigh)
+				oldFindings, err := baseline.LoadFindings(baselineFile)
+				if err != nil {
+					return fmt.Errorf("load baseline %s: %w", baselineFile, err)
+				}
+				r := baseline.Diff(oldFindings, findings)
+				diffResult = &r
+
+				diffPath, err := writeDiff(outputDir, format, r)
+				if err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "wrote %s (diff vs baseline: %s)\n", diffPath, diffHeadline(r)); err != nil {
+					return err
+				}
+			}
+
+			if ciMode {
+				// When a baseline is in play, the gate counts Added findings only:
+				// resolved findings cannot trip CI, and unchanged findings have
+				// already been accepted by a previous build. Without a baseline,
+				// the gate keeps its original full-scan semantics.
+				gateLabel := "ci threshold exceeded"
+				crit, high := summary.Critical, summary.High
+				if diffResult != nil {
+					addedSummary := baseline.SummarizeSeverities(diffResult.Added)
+					crit, high = addedSummary.Critical, addedSummary.High
+					gateLabel = "ci threshold exceeded (delta vs baseline)"
+				}
+
+				if crit > ciMaxCritical {
+					if diffResult != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+							":fire: regression: %d new critical findings vs baseline (max %d). Run `kubesplaining diff` for the per-finding breakdown.\n",
+							crit, ciMaxCritical)
+					}
+					return fmt.Errorf("%s: critical findings %d > %d", gateLabel, crit, ciMaxCritical)
+				}
+				if high > ciMaxHigh {
+					if diffResult != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+							":fire: regression: %d new high findings vs baseline (max %d). Run `kubesplaining diff` for the per-finding breakdown.\n",
+							high, ciMaxHigh)
+					}
+					return fmt.Errorf("%s: high findings %d > %d", gateLabel, high, ciMaxHigh)
 				}
 			}
 
@@ -197,6 +249,8 @@ func NewScanCmd(build BuildInfo) *cobra.Command {
 	cmd.Flags().IntVar(&auditWindowDays, "audit-window-days", 30, "How many days of audit history to consider when computing unused-permission findings")
 	cmd.Flags().BoolVar(&leastPrivilegeOnly, "least-privilege-only", false, "Focus mode: only emit least-privilege findings (UNUSED-*, WILDCARD-USED-PARTIAL-*, STALE-*) and open the Least Privilege tab by default. Requires --audit-log. Cluster-admin bindings are listed for review in the LP tab's inventory table instead of firing as findings.")
 	cmd.Flags().StringSliceVar(&complianceFilters, "compliance", nil, "Filter findings to those mapped to one or more frameworks (repeatable / comma-separated). Supported: cis, nsa. Empty = no filter; the Compliance tab still renders all controls.")
+	cmd.Flags().StringVar(&baselineFile, "baseline", "", "Path to a previous findings JSON file. When set, a diff.{txt,md,sarif} is written alongside the report and (in --ci-mode) ci-max-* gates count Added findings only, not the absolute scan tally.")
+	cmd.Flags().StringVar(&baselineFormat, "baseline-format", "text", "Format for the baseline diff sidecar: text|markdown|sarif")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Adds a `kubesplaining diff <old.json> <new.json>` subcommand and a `scan --baseline <old.json>` flag that turn the scanner into a continuous-monitoring tool. Implements Wave 1 slot #15 from the parallel-agent fan-out plan and ships Tier 2.7 of [STRATEGY.md:59-63](https://github.com/0hardik1/kubesplaining/blob/main/STRATEGY.md#L59-L63).

The diff is keyed on `Finding.ID`, which the analyzer pipeline already guarantees is deterministic per instance (`RULE:ns:name`), so re-scans of the same cluster surface stable Added / Resolved / Unchanged buckets without any extra glue.

## What lands

- **`internal/baseline/`** (new package)
  - `loader.go`: `LoadFindings(path)` accepts both a bare JSON array (the shape `writeJSON` already emits) and an object wrapper with a `findings` key. Format detected by first non-whitespace byte so renamed files (`findings.json`, `report.json`, ...) all work.
  - `diff.go`: `Diff(old, new) Result{Added, Resolved, Unchanged}`. Results sorted by severity rank desc, score desc, RuleID asc, ID asc for deterministic output.
  - `diff_test.go`: table-driven coverage of Added/Resolved/Unchanged classification, identical-input no-op, empty inputs, deterministic ordering, and loader format-detection.

- **`internal/cli/diff.go`** (new command, registered in `root.go`)
  - `kubesplaining diff <old.json> <new.json> [--output-format=text|markdown|sarif] [--output-dir=DIR]`.
  - Text (default): summary headline ("3 new critical findings, 2 resolved, 1 new privesc path") + per-section bullet lists.
  - Markdown: `##` headings + 4-column pipe table per section; pipe characters in titles are escaped.
  - SARIF: SARIF 2.1.0 run with Added findings only, level=warning, `properties.delta: true` on both run and result so downstream tooling distinguishes a delta upload from a full scan.

- **`internal/cli/scan.go`**: `--baseline <file>` + `--baseline-format` flags. When `--baseline` is set, a `diff.{txt,md,sarif}` is written next to the report. When combined with `--ci-mode`, the `--ci-max-critical` / `--ci-max-high` gates count Added findings only; failures print a `:fire: regression` line to stderr pointing at `kubesplaining diff`.

- **`internal/cli/diff_test.go`**: cobra-level smoke tests covering text, markdown, SARIF, `--output-dir`, identical inputs, and an invalid `--output-format`.

## Test plan

- [x] `make build` clean
- [x] `make test` clean (all packages green, new `internal/baseline` and CLI tests pass)
- [x] `make lint` clean
- [x] `./bin/golangci-lint run ./...` clean (CI gate per CLAUDE.md)
- [x] Smoke: `./bin/kubesplaining diff testdata/snapshots/minimal-risky.json testdata/snapshots/minimal-risky.json` reports `added=0 resolved=0`.
- [x] Functional smoke: ran scan twice against the same snapshot with `--severity-threshold low` vs `--severity-threshold critical`; `diff old.json new.json` correctly reported 18 resolved, 2 unchanged.
- [x] CI-gate smoke: `scan --baseline <hi_findings.json> --ci-mode --ci-max-critical 0 --ci-max-high 0` exits 1 with `:fire: regression` line; same command with the baseline matching the new scan exits 0 even though the absolute scan has 11 high findings.

Refs Wave 1 slot #15 of the parallel-agent fan-out plan; addresses STRATEGY.md:59-63.