### PR TITLE
fix(report): gate JS-only interactivity copy in static export

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -660,6 +660,15 @@
     .graph-intro { color: var(--text-mut); font-size: 14px; max-width: 820px; flex: 1 1 420px; margin: 0 0 4px; }
     .graph-intro strong { color: var(--text); }
     .graph-intro .kp-hint { display: inline-block; margin-left: 4px; color: var(--accent); font-size: 12.5px; }
+    /* JS-gated visibility for graph hints. The "hover / click any node" copy only makes
+       sense once graph.js has wired up tooltips and popovers, and tab navigation also
+       requires JS, so the interactive hint is hidden by default and revealed by an
+       inline <script> in <head> that adds `js` to the <html> element. The static
+       fallback shows in its place when JS is disabled and points readers to the
+       findings.json companion file (always written alongside report.html). */
+    .kp-js-only { display: none; }
+    html.js .kp-js-only { display: inline-block; }
+    html.js .kp-static-fallback { display: none; }
     .graph-truncated-notice { color: var(--text-mut); font-size: 12.5px; flex: 1 1 360px; min-width: 280px; padding: 8px 12px; background: rgba(255,154,60,0.06); border-left: 2px solid rgba(255,154,60,0.55); border-radius: 4px; line-height: 1.5; }
     .graph-truncated-notice strong { color: var(--text); }
     .graph-truncated-badge { display: inline-block; font-weight: 600; color: var(--text); margin-right: 6px; padding: 1px 2px; background: rgba(255,154,60,0.18); border-radius: 3px; font-size: 11.5px; letter-spacing: 0.02em; }
@@ -1340,6 +1349,12 @@
       h1 { font-size: 24px; }
     }
   </style>
+  <script>
+    // Mark JS as live before paint so kp-js-only copy (interactive-graph hints) appears
+    // and kp-static-fallback copy stays hidden. Runs synchronously in <head> to avoid a
+    // flash of the static-mode hint when JS is enabled.
+    document.documentElement.classList.add('js');
+  </script>
 </head>
 <body data-active-tab="{{ if .DefaultTab }}{{ .DefaultTab }}{{ else }}attack{{ end }}">
   <header class="topbar">
@@ -1654,7 +1669,7 @@
           </div>
         </div>
         <div class="graph-header-row">
-          <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves, so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint">Hover for context · click any node for a plain-language explainer.</span></p>
+          <p class="graph-intro">Defenders look at findings as a list. <strong>Attackers chain them</strong>. This graph walks each entry point through the capability it grants to the impact it achieves, so a finding's real danger is the <em>path</em> it joins, not its individual score. <span class="kp-hint kp-js-only">Hover for context · click any node for a plain-language explainer.</span><span class="kp-hint kp-static-fallback">Tab navigation, hover tooltips, and click popovers need JavaScript. Open this report in a browser with JS enabled, or see the per-node explainers in the <code>findings.json</code> companion file.</span></p>
           {{ if .Graph.Truncated }}
           <p class="graph-truncated-notice"><span class="graph-truncated-badge">Showing {{ .Graph.Shown }} of {{ .Graph.TotalCaps }}</span>To keep the diagram readable, capabilities are capped at 10. The slate first guarantees one cap per impact category present in the cluster, then fills remaining slots by severity and score. The <strong>Findings</strong> tab has the complete list.</p>
           {{ end }}


### PR DESCRIPTION
## Summary

- The Attack Graph card's "Hover for context, click any node for a plain-language explainer" copy looked broken in JS-disabled viewers (privacy browsers, RSS/preview renderers, screenshot tooling) because the inline `graph.js` was never executed to wire up the tooltips and popovers.
- Wrap the interactive hint in a `kp-js-only` span hidden by default and revealed by a small inline script that adds a `js` class to `<html>`. Add a `kp-static-fallback` sibling that surfaces the JS dependency and points readers to the `findings.json` companion file (always written next to `report.html`).
- Single template-only change in `internal/report/assets/report.html.tmpl`. No Go edits, no schema changes, no other behavior touched.

Slot #8 of the parallel-worktree fan-out (plan: Track B, slot 8). Addresses STRATEGY.md:152.

## Test plan

- [x] `make build` clean.
- [x] `make test` green (full repo, including `internal/report`).
- [x] `make lint` clean (`gofmt -l` + `go vet`).
- [x] `./bin/golangci-lint run ./...` clean (`0 issues.`).
- [x] `make e2e` green.
- [x] Regenerated report against `testdata/snapshots/minimal-risky.json`: verified the new `kp-js-only` hint, `kp-static-fallback` complement, CSS rules, and inline `<head>` script are all present in `report.html`.
- [ ] (Optional manual check, not blocking) open the generated `report.html` in a browser with JS disabled and confirm the static fallback appears in place of the interactive hint.