### PR TITLE
feat(report): add per-finding scoring formula tooltip

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -1064,7 +1064,7 @@
     .rule-hd .rule-title code { background: rgba(255,255,255,0.10); padding: 1px 2px; border-radius: 4px; font-size: 12.5px; }
     .rule-meta-pills { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-left: auto; }
     .rule-group .rule { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; background: rgba(255,255,255,0.02); letter-spacing: 0.02em; }
-    .rule-group .score-lbl { font-size: 12px; color: var(--text-mut); }
+    .rule-group .score-lbl { font-size: 12px; color: var(--text-mut); cursor: help; }
     .rule-group .score-lbl strong { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
     .rule-instance-count { font-size: 11.5px; color: var(--text-mut); padding: 3px 8px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.02); }
     .rule-shared { padding: 10px 0 4px; border-top: 1px solid var(--border-soft); margin-top: 12px; }
@@ -1118,7 +1118,7 @@
     .topbar-meta code,
     code.gloss { overflow-wrap: anywhere; word-break: break-word; min-width: 0; }
     .instance-scope { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-mut); padding: 2px 7px; border: 1px solid var(--border-soft); border-radius: 999px; background: rgba(255,255,255,0.02); }
-    .instance-score { font-size: 12px; color: var(--text-mut); font-variant-numeric: tabular-nums; }
+    .instance-score { font-size: 12px; color: var(--text-mut); font-variant-numeric: tabular-nums; cursor: help; border-bottom: 1px dotted rgba(255,255,255,0.18); }
     .instance-body { padding: 4px 16px 14px; border-top: 1px solid var(--border-soft); }
     .instance-body .finding-hd-inner { margin: 8px 0 4px; }
     .instance-body .finding-title-inner { font-size: 13.5px; font-weight: 600; color: var(--text); margin: 0; }
@@ -1953,7 +1953,7 @@
             <span class="rule-meta-pills">
               <span class="rule">{{ .RuleID }}</span>
               <span class="rule-instance-count">{{ .InstanceCount }} {{ pluralize .InstanceCount "subject" "subjects" }}</span>
-              <span class="score-lbl">Score <strong>{{ score .MaxScore }}{{ if ne .MaxScore .MinScore }}–{{ score .MinScore }}{{ end }}</strong></span>
+              <span class="score-lbl" title="Composite score: base × exploitability × blast_radius + chain_modifier (clamped 0-10). Hover an instance score below for its per-finding breakdown.">Score <strong>{{ score .MaxScore }}{{ if ne .MaxScore .MinScore }}–{{ score .MinScore }}{{ end }}</strong></span>
             </span>
           </header>
           {{ if .MitreTechniques }}
@@ -1973,7 +1973,7 @@
                 <span class="badge-sev {{ sevClass $f.Severity }}">{{ sevShort $f.Severity }}</span>
                 <span class="instance-title">{{ if $f.Subject }}{{ subjectCode $f.Subject }}{{ else if $f.Resource }}{{ resourceCode $f.Resource }}{{ else }}{{ inlineHTML $f.Title }}{{ end }}</span>
                 {{ if $f.Scope.Level }}<span class="instance-scope" title="Blast-radius level">{{ scopeLabel $f.Scope.Level }}</span>{{ end }}
-                <span class="instance-score">{{ score $f.Score }}</span>
+                <span class="instance-score" title="{{ scoringTooltipText $f }}">{{ score $f.Score }}</span>
               </summary>
               <div class="instance-body">
                 <div class="finding-hd-inner">

--- a/internal/report/evidence_render.go
+++ b/internal/report/evidence_render.go
@@ -877,3 +877,44 @@ func sourceBindingCmd(name string, obj map[string]any) string {
 	}
 	return "kubectl get rolebinding " + name + " -n " + ns + " -o yaml"
 }
+
+// renderScoringTooltip formats a one-line breakdown of how a finding's score was
+// produced, suitable for a `title="…"` attribute on the score badge in the HTML
+// report (STRATEGY.md:155, plan slot W1 #6). The composite formula is
+// `base × exploitability × blast_radius + chain_modifier = score`; when an
+// analyzer has populated Finding.ScoreFactors the breakdown is rendered in full,
+// otherwise the helper degrades gracefully to "Score 7.4" so legacy
+// hand-picked-score findings still get a (minimal) hoverable label.
+//
+// The output is plain text (no HTML), since browsers render `title` attributes
+// as text-only tooltips. Backed by BuildScoringTooltip from summary.go so the
+// struct shape stays canonical for any future expandable-row UI.
+func renderScoringTooltip(f models.Finding) string {
+	bd := BuildScoringTooltip(f)
+	if !bd.HasFactors {
+		return fmt.Sprintf("Score %s", formatScoreNum(bd.Score))
+	}
+	// Show "+ chain N.N" only when ChainModifier is non-zero, so simple findings
+	// with no chain amplification read as "base × exploit × blast = score".
+	if bd.ChainModifier == 0 {
+		return fmt.Sprintf("Score %s = base %s × exploit %s × blast %s",
+			formatScoreNum(bd.Score),
+			formatScoreNum(bd.Base),
+			formatScoreNum(bd.Exploitability),
+			formatScoreNum(bd.BlastRadius),
+		)
+	}
+	return fmt.Sprintf("Score %s = base %s × exploit %s × blast %s + chain %s",
+		formatScoreNum(bd.Score),
+		formatScoreNum(bd.Base),
+		formatScoreNum(bd.Exploitability),
+		formatScoreNum(bd.BlastRadius),
+		formatScoreNum(bd.ChainModifier),
+	)
+}
+
+// formatScoreNum renders a score / factor with one decimal place, matching the
+// `score` template helper used elsewhere in the report.
+func formatScoreNum(v float64) string {
+	return fmt.Sprintf("%.1f", v)
+}

--- a/internal/report/evidence_render_test.go
+++ b/internal/report/evidence_render_test.go
@@ -280,6 +280,64 @@ func TestCIDRHintContainment(t *testing.T) {
 	}
 }
 
+func TestRenderScoringTooltipNilFactors(t *testing.T) {
+	// Hand-picked-score path: ScoreFactors is nil, so the tooltip degrades to
+	// just the final score with no formula.
+	f := models.Finding{Score: 7.4}
+	got := renderScoringTooltip(f)
+	want := "Score 7.4"
+	if got != want {
+		t.Errorf("renderScoringTooltip(nil factors) = %q, want %q", got, want)
+	}
+}
+
+func TestRenderScoringTooltipWithFactorsNoChain(t *testing.T) {
+	// Factor-driven path with no chain amplification: omits the "+ chain" suffix
+	// to keep the tooltip compact.
+	f := models.Finding{
+		Score: 7.2,
+		ScoreFactors: &models.ScoreFactors{
+			Base:           6.0,
+			Exploitability: 1.2,
+			BlastRadius:    1.0,
+			ChainModifier:  0.0,
+		},
+	}
+	got := renderScoringTooltip(f)
+	want := "Score 7.2 = base 6.0 × exploit 1.2 × blast 1.0"
+	if got != want {
+		t.Errorf("renderScoringTooltip(no chain) = %q, want %q", got, want)
+	}
+}
+
+func TestRenderScoringTooltipWithChain(t *testing.T) {
+	// Chain-amplified path: the "+ chain N.N" suffix appears.
+	f := models.Finding{
+		Score: 8.4,
+		ScoreFactors: &models.ScoreFactors{
+			Base:           6.0,
+			Exploitability: 1.2,
+			BlastRadius:    1.0,
+			ChainModifier:  1.2,
+		},
+	}
+	got := renderScoringTooltip(f)
+	want := "Score 8.4 = base 6.0 × exploit 1.2 × blast 1.0 + chain 1.2"
+	if got != want {
+		t.Errorf("renderScoringTooltip(with chain) = %q, want %q", got, want)
+	}
+}
+
+func TestRenderScoringTooltipZeroScore(t *testing.T) {
+	// Edge case: nil factors and zero score still produce a usable tooltip.
+	f := models.Finding{}
+	got := renderScoringTooltip(f)
+	want := "Score 0.0"
+	if got != want {
+		t.Errorf("renderScoringTooltip(zero) = %q, want %q", got, want)
+	}
+}
+
 func TestMutableImageHint(t *testing.T) {
 	cases := map[string]string{
 		"nginx:latest": ":latest is mutable",

--- a/internal/report/writers.go
+++ b/internal/report/writers.go
@@ -265,14 +265,20 @@ func writeHTMLWithOptions(path string, snapshot models.Snapshot, findings []mode
 		"findingEducationHTML": func(f models.Finding) template.HTML {
 			return renderFindingEducation(f)
 		},
-		// scoringTooltip is the Wave 0 stub helper registered for the W1 #6
-		// scoring-formula tooltip. Templates can call {{ scoringTooltip .Finding }}
-		// today; the returned struct's HasFactors is false on every finding because
-		// no analyzer populates ScoreFactors yet, so the template path that would
-		// render the breakdown stays gated on .HasFactors and contributes nothing
-		// to the rendered HTML until Wave 1 wires it in.
+		// scoringTooltip exposes the structured ScoringBreakdown for templates that
+		// want to drive an expandable row instead of a `title` tooltip. When an
+		// analyzer has populated Finding.ScoreFactors the breakdown carries the
+		// per-factor values; otherwise HasFactors is false and only Score is set.
 		"scoringTooltip": func(f models.Finding) ScoringBreakdown {
 			return BuildScoringTooltip(f)
+		},
+		// scoringTooltipText returns the plain-text "Score 7.4 = base 6.0 × exploit 1.2
+		// × blast 1.0 + chain 0.2" string the HTML template attaches to the score
+		// badge as a `title="…"` attribute (STRATEGY.md:155, plan slot W1 #6). Falls
+		// back to "Score 7.4" when ScoreFactors is nil so the tooltip degrades
+		// gracefully on hand-picked-score findings.
+		"scoringTooltipText": func(f models.Finding) string {
+			return renderScoringTooltip(f)
 		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {


### PR DESCRIPTION
## Summary

- Renders the composite formula \`Score X.X = base × exploit × blast + chain\` as a \`title=\"…\"\` attribute on each per-instance score badge in the HTML report.
- Degrades to \`Score X.X\` when \`Finding.ScoreFactors\` is nil so legacy hand-picked-score findings still get a (minimal) hoverable label.
- Adds a generic explainer tooltip to the rule-group \`.score-lbl\` pointing operators at the per-instance breakdowns below.
- Visual affordance: subtle dotted underline + \`cursor: help\` on \`.instance-score\` so the hover hint is discoverable.

Per-analyzer migration to populate \`ScoreFactors\` is intentionally out of scope for this slot (called out by the plan); the helper is wired so the day an analyzer starts populating factors, the tooltip lights up automatically.

References plan slot **W1 #6** (\`/Users/hardik/.claude/plans/use-plan-md-strategy-md-and-think-frolicking-waffle.md\`) and **STRATEGY.md:155** (\"Score opacity. … surface it in a tooltip or expandable row\").

## Files

- \`internal/report/evidence_render.go\` – new \`renderScoringTooltip\` helper + \`formatScoreNum\`.
- \`internal/report/writers.go\` – registers \`scoringTooltipText\` template helper alongside the existing \`scoringTooltip\` (struct).
- \`internal/report/assets/report.html.tmpl\` – \`title=\"…\"\` on the score spans, \`cursor: help\` + dotted underline CSS.
- \`internal/report/evidence_render_test.go\` – four focused tests covering nil factors, no-chain factors, with-chain factors, and zero-score edge case.

## Sample tooltip text

For a hand-picked-score finding (today): \`Score 9.8\`
For a factor-populated finding with chain amplification: \`Score 8.4 = base 6.0 × exploit 1.2 × blast 1.0 + chain 1.2\`
For a factor-populated finding with no chain bump: \`Score 7.2 = base 6.0 × exploit 1.2 × blast 1.0\`

## Test plan

- [x] \`make build\` clean
- [x] \`make test\` clean (new tests pass)
- [x] \`make lint\` + \`./bin/golangci-lint run ./...\` clean
- [x] \`make e2e\` green
- [x] Generated HTML report against \`testdata/snapshots/minimal-risky.json\`: \`title\` attribute appears on every \`.instance-score\` and \`.score-lbl\` span; tooltip text matches \`Score X.X\` (no formula yet because no analyzer populates \`ScoreFactors\`)