### PR TITLE
feat(report): hero panel for critical attack chains

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -536,6 +536,43 @@
     .truncation-banner strong { color: var(--text); font-weight: 600; }
     .truncation-banner code { color: var(--accent); background: rgba(106,183,255,0.10); padding: 1px 4px; border-radius: 4px; }
 
+    /* Hero "Critical attack chains" panel (W1 #4, STRATEGY.md:151). Sits directly
+       under the executive-summary card so the most dangerous chains are the first
+       artefact a reader sees, with the full hop list rendered inline (no
+       click-through). The visual treatment mirrors the .tldr critical accent so
+       cluster-takeover paths read as the report's loudest signal. */
+    .hero-chains { margin-top: 16px; }
+    .hero-chains h2 { margin: 4px 0 6px; font-size: 18px; }
+    .hero-chains-intro { color: var(--text-mut); font-size: 13.5px; line-height: 1.55; margin: 0 0 14px; }
+    .hero-chain-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
+    .hero-chain-card { padding: 14px 16px 12px; border-radius: 10px;
+      border: 1px solid var(--border); background: rgba(21,28,44,0.55);
+      border-left: 3px solid var(--text-mut); }
+    .hero-chain-card.sev-crit { border-left-color: var(--critical);
+      background: linear-gradient(90deg, var(--critical-soft), rgba(21,28,44,0.55) 70%); }
+    .hero-chain-card.sev-high { border-left-color: #ff9a3c;
+      background: linear-gradient(90deg, rgba(255,154,60,0.13), rgba(21,28,44,0.55) 70%); }
+    .hero-chain-card.sev-med { border-left-color: #f5d76e;
+      background: linear-gradient(90deg, rgba(245,215,110,0.10), rgba(21,28,44,0.55) 70%); }
+    .hero-chain-title { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px;
+      font-size: 14.5px; font-weight: 600; color: var(--text); }
+    .hero-chain-title a { color: var(--text); text-decoration: none; border-bottom: 1px dashed transparent; }
+    .hero-chain-title a:hover { border-bottom-color: var(--accent); color: var(--accent); }
+    .hero-chain-score { font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+      color: var(--text-mut); padding: 2px 6px; border-radius: 999px;
+      background: rgba(255,255,255,0.05); border: 1px solid var(--border); }
+    .hero-chain-card.sev-crit .hero-chain-score { color: #ffb4be; background: var(--critical-soft); border-color: var(--critical-edge); }
+    .hero-chain-card.sev-high .hero-chain-score { color: #ffd6a8; background: rgba(255,154,60,0.13); border-color: rgba(255,154,60,0.35); }
+    .hero-chain-summary { margin: 8px 0 10px; font-size: 13.5px; line-height: 1.55; color: var(--text-mut); }
+    .hero-chain-summary code { color: var(--accent); background: rgba(106,183,255,0.10); padding: 1px 4px; border-radius: 4px; font-size: 12.5px; }
+    .hero-chain-hops { list-style: decimal; margin: 6px 0 0; padding-left: 22px;
+      display: flex; flex-direction: column; gap: 4px; font-size: 12.5px; color: var(--text-mut); }
+    .hero-chain-hops li { line-height: 1.5; }
+    .hero-chain-hops strong { color: var(--text); font-weight: 600; text-transform: lowercase; letter-spacing: 0; }
+    .hero-chain-hops code { color: var(--accent); background: rgba(106,183,255,0.08); padding: 1px 4px; border-radius: 4px; font-size: 12px; }
+    .hero-chain-hops code.hero-chain-sink { color: #ffb4be; background: var(--critical-soft); border: 1px solid var(--critical-edge); text-transform: lowercase; letter-spacing: 0.04em; }
+    .hero-chain-hops em { color: var(--text-mut); font-style: italic; font-size: 11.5px; }
+
     /* Cluster reconnaissance - collapsible top-of-report panel surfacing
        pentester-relevant snapshot facts. Sits as the first card inside <main>
        (above the executive-summary hero) so the recon view is the first thing
@@ -1579,15 +1616,16 @@
       <div class="card soft">
         <div class="kicker">Critical attack chains</div>
         <h2>Cluster-takeover paths</h2>
+        <p class="hero-chains-intro">{{ if eq (len .HeroChains) 1 }}The chain below is the most direct route{{ else }}The {{ len .HeroChains }} chains below are the most direct routes{{ end }} from a non-system identity to a sensitive sink in this cluster. Each step is annotated with the RBAC permission that enables it; jump to the rule card for full remediation.</p>
         <ol class="hero-chain-list">
-          {{ range .HeroChains }}
-          <li class="hero-chain-card sev-{{ sevClass .Severity }}">
-            <div class="hero-chain-title"><a href="#{{ .Anchor }}">{{ .Title }}</a> <span class="hero-chain-score">{{ score .Score }}</span></div>
-            {{ if .Summary }}<p class="hero-chain-summary">{{ .Summary }}</p>{{ end }}
-            {{ if .Hops }}
+          {{ range $card := .HeroChains }}
+          <li class="hero-chain-card sev-{{ sevClass $card.Severity }}">
+            <div class="hero-chain-title"><a href="#{{ $card.Anchor }}">{{ inlineHTML $card.Title }}</a> <span class="hero-chain-score">score {{ score $card.Score }}</span></div>
+            {{ if $card.Summary }}<p class="hero-chain-summary">{{ inlineHTML $card.Summary }}</p>{{ end }}
+            {{ if $card.Hops }}
             <ol class="hero-chain-hops">
-              {{ range .Hops }}
-              <li><strong>{{ .Action }}</strong>: <code>{{ .FromSubject.Kind }}/{{ if .FromSubject.Namespace }}{{ .FromSubject.Namespace }}/{{ end }}{{ .FromSubject.Name }}</code> &rarr; <code>{{ .ToSubject.Kind }}/{{ if .ToSubject.Namespace }}{{ .ToSubject.Namespace }}/{{ end }}{{ .ToSubject.Name }}</code>{{ if .Permission }} <em>({{ .Permission }})</em>{{ end }}</li>
+              {{ range $i, $hop := $card.Hops }}
+              <li><strong>{{ $hop.Action }}</strong>: <code>{{ $hop.FromSubject.Kind }}/{{ if $hop.FromSubject.Namespace }}{{ $hop.FromSubject.Namespace }}/{{ end }}{{ $hop.FromSubject.Name }}</code> &rarr; {{ if and $hop.ToSubject.Kind $hop.ToSubject.Name }}<code>{{ $hop.ToSubject.Kind }}/{{ if $hop.ToSubject.Namespace }}{{ $hop.ToSubject.Namespace }}/{{ end }}{{ $hop.ToSubject.Name }}</code>{{ else }}<code class="hero-chain-sink">{{ $card.Sink }}</code>{{ end }}{{ if $hop.Permission }} <em>({{ $hop.Permission }})</em>{{ end }}</li>
               {{ end }}
             </ol>
             {{ end }}

--- a/internal/report/narratives.go
+++ b/internal/report/narratives.go
@@ -143,6 +143,229 @@ func buildNarratives(findings []models.Finding) []NarrativeCard {
 	return narratives
 }
 
+// buildHeroChains computes the 1-3 most severe attack chains to surface above-the-fold
+// in the HTML report (STRATEGY.md:151, plan slot W1 #4). It filters findings to the
+// privesc graph paths (RuleID prefix "KUBE-PRIVESC-PATH-"), ranks them so cluster-takeover
+// paths sit at the top, and renders each as a HeroChainCard with the full hop list inline
+// (no click-through). Returns nil when no privesc paths exist; the
+// `{{ if .HeroChains }}` template gate then suppresses the whole section.
+//
+// Ranking: sink-priority bucket (cluster_admin / system_masters first, then the other
+// sensitive sinks), then severity rank desc, then score desc, then hop count asc, then
+// stable on RuleID + source subject so two runs against the same snapshot produce the
+// same hero slate.
+func buildHeroChains(findings []models.Finding) []HeroChainCard {
+	const heroCap = 3
+	var paths []models.Finding
+	for _, f := range findings {
+		if !strings.HasPrefix(f.RuleID, "KUBE-PRIVESC-PATH-") {
+			continue
+		}
+		paths = append(paths, f)
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	sort.SliceStable(paths, func(i, j int) bool {
+		pi := heroSinkPriority(heroSinkSlug(paths[i]))
+		pj := heroSinkPriority(heroSinkSlug(paths[j]))
+		if pi != pj {
+			return pi < pj
+		}
+		ri := paths[i].Severity.Rank()
+		rj := paths[j].Severity.Rank()
+		if ri != rj {
+			return ri > rj
+		}
+		if paths[i].Score != paths[j].Score {
+			return paths[i].Score > paths[j].Score
+		}
+		hi := len(paths[i].EscalationPath)
+		hj := len(paths[j].EscalationPath)
+		if hi != hj {
+			return hi < hj
+		}
+		if paths[i].RuleID != paths[j].RuleID {
+			return paths[i].RuleID < paths[j].RuleID
+		}
+		return paths[i].ID < paths[j].ID
+	})
+	if len(paths) > heroCap {
+		paths = paths[:heroCap]
+	}
+	out := make([]HeroChainCard, 0, len(paths))
+	for _, f := range paths {
+		sink := heroSinkSlug(f)
+		out = append(out, HeroChainCard{
+			Title:    f.Title,
+			Severity: f.Severity,
+			Score:    f.Score,
+			Sink:     sink,
+			Summary:  heroChainSummary(f, sink),
+			Hops:     f.EscalationPath,
+			RuleID:   f.RuleID,
+			Anchor:   "finding-" + f.RuleID,
+		})
+	}
+	return out
+}
+
+// heroSinkSlug pulls the "target:<sink>" tag (set by the privesc analyzer) off a finding,
+// falling back to the last hop's destination subject name when the tag is absent. The slug
+// stays in lower_snake form ("cluster_admin", "kube_system_secrets") so callers can switch
+// on it without normalizing case.
+func heroSinkSlug(f models.Finding) string {
+	for _, tag := range f.Tags {
+		if v, ok := strings.CutPrefix(tag, "target:"); ok {
+			return v
+		}
+	}
+	if n := len(f.EscalationPath); n > 0 {
+		return f.EscalationPath[n-1].ToSubject.Name
+	}
+	return ""
+}
+
+// heroSinkPriority returns the sort weight of an escalation sink for the hero slate. Lower
+// = surfaced first. cluster_admin and system_masters are full cluster takeover, so they sit
+// at the top; kube_system_secrets and node_escape are the next tier (control-plane-blast
+// radius); namespace_admin and token_mint round out the list.
+func heroSinkPriority(sink string) int {
+	switch sink {
+	case string(models.TargetClusterAdmin), "cluster_admin":
+		return 0
+	case string(models.TargetSystemMasters):
+		return 1
+	case string(models.TargetKubeSystemSecrets):
+		return 2
+	case string(models.TargetNodeEscape):
+		return 3
+	case string(models.TargetNamespaceAdmin):
+		return 4
+	case string(models.TargetTokenMint):
+		return 5
+	default:
+		return 6
+	}
+}
+
+// heroSinkLabel renders a sink slug as a human-readable phrase used inside the
+// one-line plain-English summary on each HeroChainCard.
+func heroSinkLabel(sink string) string {
+	switch sink {
+	case string(models.TargetClusterAdmin), "cluster_admin":
+		return "cluster-admin"
+	case string(models.TargetSystemMasters):
+		return "the system:masters group"
+	case string(models.TargetKubeSystemSecrets):
+		return "kube-system secrets"
+	case string(models.TargetNodeEscape):
+		return "node root (container escape)"
+	case string(models.TargetNamespaceAdmin):
+		return "namespace-admin"
+	case string(models.TargetTokenMint):
+		return "minted service-account tokens"
+	default:
+		if sink == "" {
+			return "a sensitive sink"
+		}
+		return strings.ReplaceAll(sink, "_", " ")
+	}
+}
+
+// heroChainSummary returns the one-line plain-English narrative shown on a hero card
+// ("ServiceAccount foo in namespace bar reaches cluster-admin in 2 hops via Pod Exec
+// → Token Theft."). Falls back gracefully when the chain has no hops or the subject
+// is missing, because both fields are nominally optional on Finding.
+//
+// The hop verbs are pulled from the Techniques glossary so they read as proper titles
+// ("Pod Exec") rather than internal slugs ("pod_exec"); when no glossary entry exists
+// we fall back to humanizing the slug in place. The sentence is intentionally short
+// because the hero panel already lists every hop in detail directly below it.
+func heroChainSummary(f models.Finding, sink string) string {
+	hops := len(f.EscalationPath)
+	subject := "An unknown subject"
+	if f.Subject != nil {
+		subject = subjectChainPhrase(*f.Subject)
+	}
+	target := heroSinkLabel(sink)
+	if hops == 0 {
+		return fmt.Sprintf("%s reaches %s.", subject, target)
+	}
+	via := chainViaPhrase(f.EscalationPath)
+	if hops == 1 {
+		if via != "" {
+			return fmt.Sprintf("%s reaches %s in 1 hop via %s.", subject, target, via)
+		}
+		return fmt.Sprintf("%s reaches %s in 1 hop.", subject, target)
+	}
+	if via != "" {
+		return fmt.Sprintf("%s reaches %s in %d hops via %s.", subject, target, hops, via)
+	}
+	return fmt.Sprintf("%s reaches %s in %d hops.", subject, target, hops)
+}
+
+// chainViaPhrase joins the per-hop technique titles with arrows ("Pod Exec → Token
+// Theft"). It caps the rendered chain at three steps and appends an ellipsis so a
+// 5-hop chain never blows out the hero card's single-line summary. Returns "" when
+// no hop has any usable label.
+func chainViaPhrase(hops []models.EscalationHop) string {
+	const maxParts = 3
+	titles := make([]string, 0, len(hops))
+	for _, hop := range hops {
+		title := actionTitle(hop.Action)
+		if title == "" {
+			continue
+		}
+		titles = append(titles, title)
+	}
+	if len(titles) == 0 {
+		return ""
+	}
+	if len(titles) > maxParts {
+		titles = append(titles[:maxParts], "…")
+	}
+	return strings.Join(titles, " → ")
+}
+
+// actionTitle returns the human-readable name for an EscalationHop.Action: the
+// Techniques-glossary Title when one is registered, otherwise a humanized version
+// of the slug ("pod_exec" → "Pod exec"). Empty input returns "".
+func actionTitle(slug string) string {
+	if slug == "" {
+		return ""
+	}
+	if entry, ok := Techniques[slug]; ok && entry.Title != "" {
+		return entry.Title
+	}
+	parts := strings.Split(slug, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		runes := []rune(p)
+		if i == 0 {
+			runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		}
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, " ")
+}
+
+// subjectChainPhrase returns a "<Kind> X in ns Y" phrase for use inside the
+// hero-chain narrative. ServiceAccount/User/Group all read naturally with this
+// pattern; cluster-scoped subjects (no namespace) omit the trailing clause.
+func subjectChainPhrase(s models.SubjectRef) string {
+	kind := s.Kind
+	if kind == "" {
+		kind = "Subject"
+	}
+	if s.Namespace == "" {
+		return fmt.Sprintf("%s `%s`", kind, s.Name)
+	}
+	return fmt.Sprintf("%s `%s` in namespace `%s`", kind, s.Name, s.Namespace)
+}
+
 // buildHeadline returns a data-driven h1 string and the short prose that sits under it.
 // The prose is returned as template.HTML because it contains safe, pre-escaped <strong> and <code> markup.
 func buildHeadline(s Summary, narratives []NarrativeCard, ns []Hotspot) (string, template.HTML) {

--- a/internal/report/narratives_test.go
+++ b/internal/report/narratives_test.go
@@ -1,0 +1,159 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// TestBuildHeroChainsEmpty asserts the section disappears when no privesc paths exist.
+func TestBuildHeroChainsEmpty(t *testing.T) {
+	t.Parallel()
+	out := buildHeroChains([]models.Finding{
+		{RuleID: "KUBE-PODSEC-PRIV-001", Severity: models.SeverityHigh, Score: 8.0},
+		{RuleID: "KUBE-RBAC-OVERBROAD-001", Severity: models.SeverityMedium, Score: 6.0},
+	})
+	if out != nil {
+		t.Fatalf("expected nil for non-privesc findings, got %d cards", len(out))
+	}
+}
+
+// TestBuildHeroChainsRanksClusterAdminFirst confirms the sink-priority bucket
+// pushes a cluster-admin path above a kube-system-secrets path even when the
+// secrets path scores higher numerically.
+func TestBuildHeroChainsRanksClusterAdminFirst(t *testing.T) {
+	t.Parallel()
+	findings := []models.Finding{
+		{
+			ID:       "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS:ServiceAccount/default/reader:kube_system_secrets",
+			RuleID:   "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS",
+			Severity: models.SeverityHigh,
+			Score:    9.5,
+			Title:    "ServiceAccount/default/reader can read kube-system secrets",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "reader", Namespace: "default"},
+			Tags:     []string{"module:privesc", "target:kube_system_secrets"},
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "read_secrets", FromSubject: models.SubjectRef{Kind: "ServiceAccount", Name: "reader", Namespace: "default"}, ToSubject: models.SubjectRef{Kind: "Sink", Name: "kube-system-secrets"}, Permission: "get,list secrets"},
+			},
+		},
+		{
+			ID:       "KUBE-PRIVESC-PATH-CLUSTER-ADMIN:ServiceAccount/default/builder:cluster_admin_equivalent",
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Score:    8.0,
+			Title:    "ServiceAccount/default/builder can reach cluster-admin",
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "builder", Namespace: "default"},
+			Tags:     []string{"module:privesc", "target:cluster_admin_equivalent"},
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "bind_escalate", FromSubject: models.SubjectRef{Kind: "ServiceAccount", Name: "builder", Namespace: "default"}, ToSubject: models.SubjectRef{Kind: "ClusterRole", Name: "cluster-admin"}, Permission: "rbac/clusterrolebindings:create"},
+				{Step: 2, Action: "use_role", FromSubject: models.SubjectRef{Kind: "ClusterRole", Name: "cluster-admin"}, ToSubject: models.SubjectRef{Kind: "Sink", Name: "cluster-admin"}, Permission: "*"},
+			},
+		},
+	}
+	out := buildHeroChains(findings)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 hero cards, got %d", len(out))
+	}
+	if out[0].RuleID != "KUBE-PRIVESC-PATH-CLUSTER-ADMIN" {
+		t.Fatalf("expected cluster-admin path first, got %s", out[0].RuleID)
+	}
+	if out[0].Sink != string(models.TargetClusterAdmin) {
+		t.Fatalf("expected first sink %s, got %s", models.TargetClusterAdmin, out[0].Sink)
+	}
+	if out[0].Anchor != "finding-KUBE-PRIVESC-PATH-CLUSTER-ADMIN" {
+		t.Fatalf("anchor mismatch: %s", out[0].Anchor)
+	}
+	if len(out[0].Hops) != 2 {
+		t.Fatalf("expected 2 hops on first card, got %d", len(out[0].Hops))
+	}
+	if !strings.Contains(out[0].Summary, "cluster-admin") {
+		t.Fatalf("expected cluster-admin in summary, got %q", out[0].Summary)
+	}
+	if !strings.Contains(out[0].Summary, "builder") {
+		t.Fatalf("expected subject name in summary, got %q", out[0].Summary)
+	}
+}
+
+// TestBuildHeroChainsCapsAtThree confirms the slate is bounded so the panel never
+// pushes the rest of the report off-screen.
+func TestBuildHeroChainsCapsAtThree(t *testing.T) {
+	t.Parallel()
+	var findings []models.Finding
+	for i := 0; i < 8; i++ {
+		findings = append(findings, models.Finding{
+			ID:       "KUBE-PRIVESC-PATH-CLUSTER-ADMIN:ServiceAccount/default/sa-" + string(rune('a'+i)) + ":cluster_admin_equivalent",
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Score:    9.5,
+			Title:    "Path " + string(rune('a'+i)),
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "sa-" + string(rune('a'+i)), Namespace: "default"},
+			Tags:     []string{"module:privesc", "target:cluster_admin_equivalent"},
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "bind_escalate"},
+			},
+		})
+	}
+	out := buildHeroChains(findings)
+	if len(out) != 3 {
+		t.Fatalf("expected hero cap at 3, got %d", len(out))
+	}
+}
+
+// TestBuildHeroChainsFavorsShorterChains: at the same sink and severity, a 1-hop
+// path should be ranked above a 4-hop path because shorter chains are more
+// directly exploitable.
+func TestBuildHeroChainsFavorsShorterChains(t *testing.T) {
+	t.Parallel()
+	long := models.Finding{
+		ID:       "long",
+		RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+		Severity: models.SeverityCritical,
+		Score:    8.5,
+		Title:    "Long chain",
+		Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "long", Namespace: "default"},
+		Tags:     []string{"module:privesc", "target:cluster_admin_equivalent"},
+		EscalationPath: []models.EscalationHop{
+			{Step: 1}, {Step: 2}, {Step: 3}, {Step: 4},
+		},
+	}
+	short := models.Finding{
+		ID:       "short",
+		RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+		Severity: models.SeverityCritical,
+		Score:    8.5,
+		Title:    "Short chain",
+		Subject:  &models.SubjectRef{Kind: "ServiceAccount", Name: "short", Namespace: "default"},
+		Tags:     []string{"module:privesc", "target:cluster_admin_equivalent"},
+		EscalationPath: []models.EscalationHop{
+			{Step: 1, Action: "impersonate"},
+		},
+	}
+	out := buildHeroChains([]models.Finding{long, short})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 hero cards, got %d", len(out))
+	}
+	if out[0].Title != "Short chain" {
+		t.Fatalf("expected short chain ranked first, got %q", out[0].Title)
+	}
+}
+
+// TestHeroSinkLabel renders a few sink slugs into the human-readable phrase used
+// inside HeroChainCard.Summary, so a regression in the labeling table is caught
+// without re-running the whole hero builder.
+func TestHeroSinkLabel(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		string(models.TargetClusterAdmin):      "cluster-admin",
+		string(models.TargetSystemMasters):     "the system:masters group",
+		string(models.TargetKubeSystemSecrets): "kube-system secrets",
+		string(models.TargetNodeEscape):        "node root (container escape)",
+		string(models.TargetNamespaceAdmin):    "namespace-admin",
+		"":                                     "a sensitive sink",
+	}
+	for slug, want := range cases {
+		if got := heroSinkLabel(slug); got != want {
+			t.Errorf("heroSinkLabel(%q) = %q, want %q", slug, got, want)
+		}
+	}
+}

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -236,13 +236,9 @@ func moduleLabel(key string) string {
 	}
 }
 
-// buildHeroChains is the Wave 0 stub for the "Critical attack chains" hero
-// panel at the top of the HTML report (STRATEGY.md:151, plan slot W1 #4).
-// Returns nil so the {{ if .HeroChains }} template gate suppresses the section
-// until Wave 1 populates it.
-func buildHeroChains(_ []models.Finding) []HeroChainCard {
-	return nil
-}
+// buildHeroChains lives in narratives.go alongside the related chain-detection /
+// headline helpers (W1 slot #4). The stub is intentionally absent here so the
+// implementation has a single home.
 
 // buildTopFixes is the Wave 0 stub for the "Top 5 fixes" panel
 // (STRATEGY.md:162, plan slot W1 #5). Wave 1 will group findings by Subject,


### PR DESCRIPTION
## Summary
- Fills the Wave 0 `buildHeroChains` stub (plan slot W1 #4, STRATEGY.md:151) so the 1-3 most severe attack chains render above the fold in the HTML report, with the full hop list inline (no click-through).
- Ranking: sink-priority bucket first (cluster_admin / system_masters as full takeover, then kube_system_secrets / node_escape, then namespace_admin / token_mint), then severity rank, score, shorter chains, then stable on RuleID / ID so the slate is deterministic between runs.
- Each card surfaces the chain title (with backtick code spans and bold rendered as HTML), a one-line plain-English narrative pulled from Techniques glossary titles, a deep link to the Findings-tab anchor, and a per-hop list that labels the synthetic sink when the terminal hop's ToSubject is empty.
- New CSS treats critical cards with the same accent gradient as the existing `.tldr` callout so the panel reads as the report's loudest signal; sink chips render in critical-soft palette to keep the terminal node visually distinct from intermediate subjects.

## Files changed
- `internal/report/narratives.go` (new `buildHeroChains` + sink-priority / sink-label / chain-summary helpers, alongside the existing chain detection)
- `internal/report/summary.go` (stub comment replaced; implementation moved to narratives.go for cohesion)
- `internal/report/assets/report.html.tmpl` (CSS for `.hero-chains` + the template block body, including sink-fallback rendering and pluralized intro copy)
- `internal/report/narratives_test.go` (new: ranks-cluster-admin-first, caps-at-three, favors-shorter-chains, empty-input, sink-label table)

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make lint`
- [x] `./bin/golangci-lint run ./...` (0 issues)
- [x] Regenerated HTML against `testdata/snapshots/minimal-risky.json` — 1-hop kube-system-secrets path renders as a single high-severity hero card with the sink labelled `kube_system_secrets`.
- [x] Regenerated HTML against `testdata/snapshots/leastprivilege-demo.json` — both cluster-admin paths render as critical hero cards, 1-hop direct binding ranked above the 2-hop pod-create-token-theft chain.
- [x] `make e2e` unchanged (no new rules, no expectation file updates).

## Notes
- Title and Summary are rendered through `inlineHTML` so the existing backtick code spans and `**bold**` markdown that already live in the privesc finding titles render correctly inside the hero card link.
- The chain "via" phrase is pulled from `report.Techniques[Action].Title`, falling back to a humanized slug when no glossary entry exists. This keeps the summary readable when a new privesc Action ships without a Techniques entry.
- Slot scope: this PR does not touch any of the files Wave 0 reserved for other Wave 1 slots (engine.go, modules.go, types.go, glossary.go, etc.). Only the `buildHeroChains` builder, the existing template block, the new test file, and CSS-only template additions.