### PR TITLE
feat(remediation): kubectl-patch generator for podsec rules

### DIFF
--- a/internal/analyzer/podsec/analyzer.go
+++ b/internal/analyzer/podsec/analyzer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/remediation"
 	"github.com/0hardik1/kubesplaining/internal/scoring"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -330,12 +331,17 @@ func newFindingFromContent(target target, ruleID string, severity models.Severit
 	})
 }
 
-// appendFinding deduplicates by Finding.ID before appending.
+// appendFinding deduplicates by Finding.ID before appending. The
+// RemediationHint is attached here (rather than at every call site) so the
+// analyzer's per-rule blocks stay focused on detection: the moment we know
+// we are emitting a finding, ask the remediation generator for the
+// matching kubectl patch.
 func appendFinding(findings []models.Finding, seen map[string]struct{}, finding models.Finding) []models.Finding {
 	if _, ok := seen[finding.ID]; ok {
 		return findings
 	}
 	seen[finding.ID] = struct{}{}
+	finding.RemediationHint = remediation.ForPodsec(finding.RuleID, finding)
 	return append(findings, finding)
 }
 

--- a/internal/remediation/common.go
+++ b/internal/remediation/common.go
@@ -1,0 +1,172 @@
+// Package remediation generates structured fix payloads (kubectl patches,
+// Kyverno / Gatekeeper policies, RBAC diffs) for findings emitted by the
+// analyzer modules. Each per-module entrypoint (e.g. ForPodsec) takes a rule ID
+// + a constructed Finding and returns a *models.RemediationHint, which the
+// analyzers attach to the Finding before emitting it. Every field on the hint
+// is optional, so generators that only know how to build one surface (a
+// kubectl patch, say) leave the others nil and the HTML / JSON / SARIF outputs
+// render only what was supplied.
+package remediation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// shellSingleQuote wraps body in POSIX single quotes, escaping any embedded
+// single quotes by closing-the-quote, inserting a backslash-escaped quote, and
+// reopening the quote. The result is safe to paste into a bash / zsh shell as
+// the argument to a flag like `kubectl patch ... -p '<this>'`. Single quotes
+// are used (not double) because shells do no expansion inside them, so the
+// JSON braces / dollar signs in patch bodies are passed through verbatim.
+func shellSingleQuote(body string) string {
+	return "'" + strings.ReplaceAll(body, "'", `'\''`) + "'"
+}
+
+// renderKubectlPatchCommand pre-renders the kubectl invocation that applies
+// the given patch. The result is a single-line string suitable for HTML
+// display with a copy button (e.g. `kubectl patch deployment foo -n bar
+// --type=strategic -p '{...}'`). For cluster-scoped objects (no Namespace),
+// the `-n` flag is omitted; for the default namespace it is still printed so
+// users do not paste the command without realising which namespace is
+// implicit.
+func renderKubectlPatchCommand(target models.PatchTarget, patchType string, body json.RawMessage) string {
+	kind := strings.ToLower(target.Kind)
+	parts := []string{"kubectl", "patch", kind, target.Name}
+	if target.Namespace != "" {
+		parts = append(parts, "-n", target.Namespace)
+	}
+	parts = append(parts, "--type="+patchType, "-p", shellSingleQuote(string(body)))
+	return strings.Join(parts, " ")
+}
+
+// patchTargetFromFinding pulls the kind / namespace / name off the Finding's
+// Resource pointer and resolves the apiVersion from the kind. Returns the
+// zero PatchTarget and false when Resource is nil — callers should skip the
+// remediation in that case rather than panic.
+func patchTargetFromFinding(finding models.Finding) (models.PatchTarget, bool) {
+	if finding.Resource == nil {
+		return models.PatchTarget{}, false
+	}
+	return models.PatchTarget{
+		Kind:       finding.Resource.Kind,
+		APIVersion: apiVersionForKind(finding.Resource.Kind),
+		Namespace:  finding.Resource.Namespace,
+		Name:       finding.Resource.Name,
+	}, true
+}
+
+// apiVersionForKind returns the apiVersion string we expect for each workload
+// kind the podsec analyzer emits findings against. Pods are core/v1; the apps
+// kinds are apps/v1; the batch kinds are batch/v1. Anything unknown returns
+// the empty string so JSON consumers can spot the gap.
+func apiVersionForKind(kind string) string {
+	switch kind {
+	case "Pod":
+		return "v1"
+	case "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet":
+		return "apps/v1"
+	case "Job", "CronJob":
+		return "batch/v1"
+	default:
+		return ""
+	}
+}
+
+// containerNameFromEvidence pulls the "container" key out of a finding's
+// Evidence JSON blob so the remediation generator knows which container in
+// the pod template to patch. The podsec analyzer always sets this for
+// container-scoped findings (privileged, runAsRoot, allowPrivilegeEscalation,
+// readOnlyRootFilesystem, seccomp, procMount, image-tag); returns the empty
+// string when the field is absent or the JSON is malformed (defensive — the
+// generator falls back to a no-container patch).
+func containerNameFromEvidence(evidence json.RawMessage) string {
+	if len(evidence) == 0 {
+		return ""
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(evidence, &decoded); err != nil {
+		return ""
+	}
+	name, _ := decoded["container"].(string)
+	return name
+}
+
+// volumeNameFromEvidence pulls the "volume" key out of a finding's Evidence
+// JSON blob. Used by hostPath-removal patches so the strategic-merge body
+// only deletes the offending volume and not the entire `volumes` slice.
+func volumeNameFromEvidence(evidence json.RawMessage) string {
+	if len(evidence) == 0 {
+		return ""
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(evidence, &decoded); err != nil {
+		return ""
+	}
+	name, _ := decoded["volume"].(string)
+	return name
+}
+
+// wrapPodPatch returns a strategic-merge patch body that places the given
+// pod-spec fragment (e.g. `{"hostNetwork": false}` or a containers list)
+// under the correct workload-kind wrapper. The wrapper depth is what changes:
+//
+//   - Pod                         spec.<fragment>
+//   - Deployment / DaemonSet /
+//     StatefulSet / Job           spec.template.spec.<fragment>
+//   - CronJob                     spec.jobTemplate.spec.template.spec.<fragment>
+//
+// Returns the raw JSON bytes and an error when marshalling fails (which
+// should never happen for the structured maps we build).
+func wrapPodPatch(kind string, podSpecFragment map[string]any) (json.RawMessage, error) {
+	var body any
+	switch kind {
+	case "Pod":
+		body = map[string]any{"spec": podSpecFragment}
+	case "CronJob":
+		body = map[string]any{
+			"spec": map[string]any{
+				"jobTemplate": map[string]any{
+					"spec": map[string]any{
+						"template": map[string]any{
+							"spec": podSpecFragment,
+						},
+					},
+				},
+			},
+		}
+	default:
+		// Deployment / DaemonSet / StatefulSet / Job all use spec.template.spec.
+		body = map[string]any{
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": podSpecFragment,
+				},
+			},
+		}
+	}
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pod patch: %w", err)
+	}
+	return bytes, nil
+}
+
+// containerSecurityContextPatch builds a strategic-merge patch fragment that
+// targets one container by name and overlays its securityContext with the
+// given fields. `containers` is a strategic-merge "named list" keyed by
+// `name`, so kubectl will merge the patch into the existing container with
+// that name without disturbing any other containers in the pod template.
+func containerSecurityContextPatch(containerName string, securityContext map[string]any) map[string]any {
+	return map[string]any{
+		"containers": []map[string]any{
+			{
+				"name":            containerName,
+				"securityContext": securityContext,
+			},
+		},
+	}
+}

--- a/internal/remediation/podsec.go
+++ b/internal/remediation/podsec.go
@@ -1,0 +1,261 @@
+package remediation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// ForPodsec returns the structured remediation hint for a podsec finding, or
+// nil when no patch can be generated for the rule (e.g. mutable image tags,
+// where the right answer requires knowing the desired digest). The Finding's
+// Resource pointer must be non-nil; container-scoped rules also expect
+// "container" / "volume" entries inside Finding.Evidence (the podsec
+// analyzer always populates them).
+//
+// The returned RemediationHint always carries a *KubectlPatch with a
+// pre-rendered Command string, except for KUBE-IMAGE-LATEST-001 where the
+// patch is comment-only because there is no safe automated rewrite.
+//
+// Coverage: privileged, runAsNonRoot, hostNetwork / hostPID / hostIPC,
+// hostPath family (KUBE-HOSTPATH-001 + KUBE-ESCAPE-005/006/008 +
+// KUBE-CONTAINERD-SOCKET-001), allowPrivilegeEscalation,
+// readOnlyRootFilesystem, seccomp profile, procMount.
+func ForPodsec(ruleID string, finding models.Finding) *models.RemediationHint {
+	target, ok := patchTargetFromFinding(finding)
+	if !ok {
+		return nil
+	}
+
+	switch ruleID {
+	case "KUBE-ESCAPE-001":
+		return privilegedPatch(target, finding)
+	case "KUBE-PODSEC-ROOT-001":
+		return runAsNonRootPatch(target, finding)
+	case "KUBE-PODSEC-APE-001":
+		return allowPrivilegeEscalationPatch(target, finding)
+	case "KUBE-PODSEC-READONLY-001":
+		return readOnlyRootFilesystemPatch(target, finding)
+	case "KUBE-PODSEC-SECCOMP-001":
+		return seccompProfilePatch(target, finding)
+	case "KUBE-PODSEC-PROCMOUNT-001":
+		return procMountPatch(target, finding)
+	case "KUBE-ESCAPE-003":
+		return hostBoolPatch(target, "hostNetwork")
+	case "KUBE-ESCAPE-002":
+		return hostBoolPatch(target, "hostPID")
+	case "KUBE-ESCAPE-004":
+		return hostBoolPatch(target, "hostIPC")
+	case "KUBE-HOSTPATH-001",
+		"KUBE-ESCAPE-005",
+		"KUBE-ESCAPE-006",
+		"KUBE-ESCAPE-008",
+		"KUBE-CONTAINERD-SOCKET-001":
+		return hostPathRemovalPatch(target, finding)
+	case "KUBE-IMAGE-LATEST-001":
+		return imageLatestSuggestion(target, finding)
+	}
+	return nil
+}
+
+// privilegedPatch returns a strategic-merge patch that flips the offending
+// container's securityContext.privileged to false. The rule fires only when
+// privileged was explicitly true, so this is the minimal change that brings
+// the workload back to the safe default without otherwise rewriting the
+// container's securityContext.
+func privilegedPatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	fragment := containerSecurityContextPatch(container, map[string]any{
+		"privileged": false,
+	})
+	return strategicHint(target, fragment)
+}
+
+// runAsNonRootPatch sets the offending container's securityContext to enforce
+// non-root execution: runAsNonRoot=true plus a sentinel runAsUser=1000 so the
+// kubelet has a UID to actually use when no explicit user exists in the
+// image. Operators should treat the 1000 as a placeholder and replace it
+// with a project-appropriate UID.
+func runAsNonRootPatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	fragment := containerSecurityContextPatch(container, map[string]any{
+		"runAsNonRoot": true,
+		"runAsUser":    1000,
+	})
+	return strategicHint(target, fragment)
+}
+
+// allowPrivilegeEscalationPatch sets the container's securityContext field
+// to false, blocking the no_new_privs bypass that lets a process gain extra
+// capabilities via setuid binaries after exec.
+func allowPrivilegeEscalationPatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	fragment := containerSecurityContextPatch(container, map[string]any{
+		"allowPrivilegeEscalation": false,
+	})
+	return strategicHint(target, fragment)
+}
+
+// readOnlyRootFilesystemPatch flips the offending container's
+// securityContext.readOnlyRootFilesystem to true. Workloads that legitimately
+// need a writable path should mount an emptyDir for that path; that is out of
+// scope for an automated patch and is documented in the prose remediation.
+func readOnlyRootFilesystemPatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	fragment := containerSecurityContextPatch(container, map[string]any{
+		"readOnlyRootFilesystem": true,
+	})
+	return strategicHint(target, fragment)
+}
+
+// seccompProfilePatch sets seccompProfile.type to RuntimeDefault on the
+// offending container, which applies the container runtime's stock seccomp
+// profile (cri-o, containerd, docker all ship one). RuntimeDefault is what
+// PSS Restricted requires; teams that need a stricter Localhost profile
+// should follow up manually.
+func seccompProfilePatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	fragment := containerSecurityContextPatch(container, map[string]any{
+		"seccompProfile": map[string]any{
+			"type": "RuntimeDefault",
+		},
+	})
+	return strategicHint(target, fragment)
+}
+
+// procMountPatch sets procMount back to the safe Default. We deliberately do
+// not use a JSON 6902 `remove` op here: setting it to Default is byte-equal
+// to the K8s default behaviour, easier to apply (works against either
+// strategic-merge or merge), and reads as an explicit refusal of the
+// Unmasked opt-in rather than a silent unset.
+func procMountPatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	fragment := containerSecurityContextPatch(container, map[string]any{
+		"procMount": "Default",
+	})
+	return strategicHint(target, fragment)
+}
+
+// hostBoolPatch returns a strategic-merge patch that flips a top-level
+// pod-spec boolean (hostNetwork, hostPID, hostIPC) to false. The K8s default
+// for all three is false, so this is the minimal "undo the explicit opt-in"
+// change.
+func hostBoolPatch(target models.PatchTarget, field string) *models.RemediationHint {
+	fragment := map[string]any{field: false}
+	return strategicHint(target, fragment)
+}
+
+// hostPathRemovalPatch deletes the offending hostPath volume from the pod
+// template using a strategic-merge `$patch: delete` directive on the named
+// list. We do not also strip volumeMounts referencing the volume — kubectl's
+// strategic-merge handling of named lists tolerates a dangling reference at
+// patch time and surfaces the validation error at admission, which gives the
+// operator a clear pointer to the second edit they need to make. (A full
+// fix that also strips matching volumeMounts would require knowing every
+// container that mounts the volume, which the analyzer does not currently
+// thread through Finding.Evidence.)
+func hostPathRemovalPatch(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	volume := volumeNameFromEvidence(finding.Evidence)
+	if volume == "" {
+		return nil
+	}
+	fragment := map[string]any{
+		"volumes": []map[string]any{
+			{
+				"name":   volume,
+				"$patch": "delete",
+			},
+		},
+	}
+	return strategicHint(target, fragment)
+}
+
+// imageLatestSuggestion returns a Patch with no Body (no automated rewrite is
+// possible without knowing the desired digest) but with a Command string
+// carrying a `# TODO:` comment that documents the manual fix. The HTML report
+// renders the Command verbatim, so users see actionable guidance even though
+// no patch can be applied.
+func imageLatestSuggestion(target models.PatchTarget, finding models.Finding) *models.RemediationHint {
+	container := containerNameFromEvidence(finding.Evidence)
+	if container == "" {
+		return nil
+	}
+	command := fmt.Sprintf(
+		"# TODO: pin image to an immutable digest, e.g.\n"+
+			"# kubectl set image %s/%s %s=%s@sha256:<digest> -n %s",
+		strings.ToLower(target.Kind), target.Name, container, imageRepoFromEvidence(finding.Evidence), target.Namespace,
+	)
+	return &models.RemediationHint{
+		Patch: &models.KubectlPatch{
+			Type:    "merge",
+			Target:  target,
+			Body:    json.RawMessage("{}"),
+			Command: command,
+		},
+	}
+}
+
+// imageRepoFromEvidence pulls the "image" key off the finding evidence and
+// strips the `:tag` (or `@digest`) suffix so the TODO command points at the
+// repository the user should re-pin. Falls back to an obvious placeholder
+// when the field is missing or unparseable.
+func imageRepoFromEvidence(evidence json.RawMessage) string {
+	const fallback = "<repo>"
+	if len(evidence) == 0 {
+		return fallback
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(evidence, &decoded); err != nil {
+		return fallback
+	}
+	image, _ := decoded["image"].(string)
+	if image == "" {
+		return fallback
+	}
+	if idx := strings.LastIndex(image, "@"); idx > 0 {
+		return image[:idx]
+	}
+	if idx := strings.LastIndex(image, ":"); idx > 0 {
+		return image[:idx]
+	}
+	return image
+}
+
+// strategicHint is the shared tail end of every podsec generator: wrap the
+// pod-spec fragment in the workload-kind envelope, attach the rendered
+// kubectl command, and return the populated RemediationHint. Returns nil
+// when wrapping fails (which would only happen on an unrepresentable map).
+func strategicHint(target models.PatchTarget, podSpecFragment map[string]any) *models.RemediationHint {
+	body, err := wrapPodPatch(target.Kind, podSpecFragment)
+	if err != nil {
+		return nil
+	}
+	return &models.RemediationHint{
+		Patch: &models.KubectlPatch{
+			Type:    "strategic",
+			Target:  target,
+			Body:    body,
+			Command: renderKubectlPatchCommand(target, "strategic", body),
+		},
+	}
+}

--- a/internal/remediation/podsec_test.go
+++ b/internal/remediation/podsec_test.go
@@ -1,0 +1,400 @@
+package remediation
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// makeFinding builds a minimal podsec-style Finding suitable for feeding into
+// ForPodsec. The Resource pointer is mandatory for every covered rule; the
+// evidence map is marshalled to JSON so the generator's evidence accessors
+// see exactly the shape the podsec analyzer produces in production.
+func makeFinding(t *testing.T, ruleID, kind, namespace, name string, evidence map[string]any) models.Finding {
+	t.Helper()
+	body, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatalf("marshal evidence: %v", err)
+	}
+	return models.Finding{
+		ID:       ruleID + ":" + kind + ":" + namespace + ":" + name,
+		RuleID:   ruleID,
+		Severity: models.SeverityHigh,
+		Resource: &models.ResourceRef{
+			Kind:      kind,
+			Namespace: namespace,
+			Name:      name,
+		},
+		Evidence: body,
+	}
+}
+
+// expectStrategicPatch is a shared assertion that runs the same shape checks
+// against every strategic-merge generator: the hint must be non-nil, the
+// patch type must be "strategic", the target fields must match the input,
+// the body must be parseable JSON, and the command string must include
+// `kubectl patch`, the kind, the name, and the body. Each rule-specific
+// test then layers on its own assertion against the parsed body.
+func expectStrategicPatch(t *testing.T, hint *models.RemediationHint, kind, namespace, name string) map[string]any {
+	t.Helper()
+	if hint == nil || hint.Patch == nil {
+		t.Fatalf("expected non-nil RemediationHint and Patch, got %+v", hint)
+	}
+	if hint.Patch.Type != "strategic" {
+		t.Errorf("Patch.Type = %q, want strategic", hint.Patch.Type)
+	}
+	if hint.Patch.Target.Kind != kind || hint.Patch.Target.Namespace != namespace || hint.Patch.Target.Name != name {
+		t.Errorf("Patch.Target = %+v, want kind=%q ns=%q name=%q",
+			hint.Patch.Target, kind, namespace, name)
+	}
+	if hint.Patch.Target.APIVersion == "" {
+		t.Errorf("Patch.Target.APIVersion is empty for kind %q", kind)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(hint.Patch.Body, &decoded); err != nil {
+		t.Fatalf("Patch.Body is not valid JSON: %v\nbody: %s", err, string(hint.Patch.Body))
+	}
+	if hint.Patch.Command == "" {
+		t.Fatalf("Patch.Command is empty")
+	}
+	for _, want := range []string{"kubectl patch", strings.ToLower(kind), name} {
+		if !strings.Contains(hint.Patch.Command, want) {
+			t.Errorf("Patch.Command missing %q\ncommand: %s", want, hint.Patch.Command)
+		}
+	}
+	if namespace != "" && !strings.Contains(hint.Patch.Command, "-n "+namespace) {
+		t.Errorf("Patch.Command missing namespace flag %q\ncommand: %s", "-n "+namespace, hint.Patch.Command)
+	}
+	return decoded
+}
+
+// containerSecCtx walks the wrapped strategic-merge body down to the named
+// container's securityContext and returns it. Helper exists to make
+// per-rule tests assert exactly the field they care about without
+// re-traversing the same template envelope every time.
+func containerSecCtx(t *testing.T, decoded map[string]any, kind, container string) map[string]any {
+	t.Helper()
+	containers := podSpecField(t, decoded, kind, "containers")
+	containerList, ok := containers.([]any)
+	if !ok {
+		t.Fatalf("containers is %T, want []any", containers)
+	}
+	for _, raw := range containerList {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entry["name"] != container {
+			continue
+		}
+		sc, ok := entry["securityContext"].(map[string]any)
+		if !ok {
+			t.Fatalf("container %q has no securityContext map: %+v", container, entry)
+		}
+		return sc
+	}
+	t.Fatalf("container %q not found in patch body", container)
+	return nil
+}
+
+// podSpecField unwraps the workload-kind envelope (Pod vs Deployment vs
+// CronJob) and returns the requested field from the embedded pod spec.
+// Mirrors the logic in wrapPodPatch in reverse so the tests stay in sync if
+// the wrapping ever changes.
+func podSpecField(t *testing.T, decoded map[string]any, kind, field string) any {
+	t.Helper()
+	spec, ok := decoded["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("decoded.spec is %T, want map", decoded["spec"])
+	}
+	switch kind {
+	case "Pod":
+		return spec[field]
+	case "CronJob":
+		jobTemplate, _ := spec["jobTemplate"].(map[string]any)
+		jobSpec, _ := jobTemplate["spec"].(map[string]any)
+		template, _ := jobSpec["template"].(map[string]any)
+		podSpec, _ := template["spec"].(map[string]any)
+		return podSpec[field]
+	default:
+		template, _ := spec["template"].(map[string]any)
+		podSpec, _ := template["spec"].(map[string]any)
+		return podSpec[field]
+	}
+}
+
+func TestForPodsecPrivileged(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-ESCAPE-001", "Deployment", "default", "risky", map[string]any{
+		"container": "app",
+	})
+	hint := ForPodsec("KUBE-ESCAPE-001", finding)
+	body := expectStrategicPatch(t, hint, "Deployment", "default", "risky")
+	sc := containerSecCtx(t, body, "Deployment", "app")
+	if sc["privileged"] != false {
+		t.Errorf("securityContext.privileged = %v, want false", sc["privileged"])
+	}
+}
+
+func TestForPodsecRunAsNonRoot(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-PODSEC-ROOT-001", "Deployment", "default", "rooty", map[string]any{
+		"container": "app",
+	})
+	hint := ForPodsec("KUBE-PODSEC-ROOT-001", finding)
+	body := expectStrategicPatch(t, hint, "Deployment", "default", "rooty")
+	sc := containerSecCtx(t, body, "Deployment", "app")
+	if sc["runAsNonRoot"] != true {
+		t.Errorf("securityContext.runAsNonRoot = %v, want true", sc["runAsNonRoot"])
+	}
+}
+
+func TestForPodsecAllowPrivilegeEscalation(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-PODSEC-APE-001", "DaemonSet", "kube-system", "ds", map[string]any{
+		"container": "agent",
+	})
+	hint := ForPodsec("KUBE-PODSEC-APE-001", finding)
+	body := expectStrategicPatch(t, hint, "DaemonSet", "kube-system", "ds")
+	sc := containerSecCtx(t, body, "DaemonSet", "agent")
+	if sc["allowPrivilegeEscalation"] != false {
+		t.Errorf("securityContext.allowPrivilegeEscalation = %v, want false", sc["allowPrivilegeEscalation"])
+	}
+}
+
+func TestForPodsecReadOnlyRootFilesystem(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-PODSEC-READONLY-001", "Pod", "default", "p", map[string]any{
+		"container": "c",
+	})
+	hint := ForPodsec("KUBE-PODSEC-READONLY-001", finding)
+	body := expectStrategicPatch(t, hint, "Pod", "default", "p")
+	sc := containerSecCtx(t, body, "Pod", "c")
+	if sc["readOnlyRootFilesystem"] != true {
+		t.Errorf("securityContext.readOnlyRootFilesystem = %v, want true", sc["readOnlyRootFilesystem"])
+	}
+}
+
+func TestForPodsecSeccompProfile(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-PODSEC-SECCOMP-001", "StatefulSet", "default", "sts", map[string]any{
+		"container": "main",
+	})
+	hint := ForPodsec("KUBE-PODSEC-SECCOMP-001", finding)
+	body := expectStrategicPatch(t, hint, "StatefulSet", "default", "sts")
+	sc := containerSecCtx(t, body, "StatefulSet", "main")
+	profile, ok := sc["seccompProfile"].(map[string]any)
+	if !ok {
+		t.Fatalf("securityContext.seccompProfile = %v, want map", sc["seccompProfile"])
+	}
+	if profile["type"] != "RuntimeDefault" {
+		t.Errorf("seccompProfile.type = %v, want RuntimeDefault", profile["type"])
+	}
+}
+
+func TestForPodsecProcMount(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-PODSEC-PROCMOUNT-001", "Job", "batch", "j", map[string]any{
+		"container": "worker",
+	})
+	hint := ForPodsec("KUBE-PODSEC-PROCMOUNT-001", finding)
+	body := expectStrategicPatch(t, hint, "Job", "batch", "j")
+	sc := containerSecCtx(t, body, "Job", "worker")
+	if sc["procMount"] != "Default" {
+		t.Errorf("securityContext.procMount = %v, want Default", sc["procMount"])
+	}
+}
+
+func TestForPodsecHostNetwork(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-ESCAPE-003", "Deployment", "default", "host-net", nil)
+	hint := ForPodsec("KUBE-ESCAPE-003", finding)
+	body := expectStrategicPatch(t, hint, "Deployment", "default", "host-net")
+	if got := podSpecField(t, body, "Deployment", "hostNetwork"); got != false {
+		t.Errorf("hostNetwork = %v, want false", got)
+	}
+}
+
+func TestForPodsecHostPID(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-ESCAPE-002", "Deployment", "default", "host-pid", nil)
+	hint := ForPodsec("KUBE-ESCAPE-002", finding)
+	body := expectStrategicPatch(t, hint, "Deployment", "default", "host-pid")
+	if got := podSpecField(t, body, "Deployment", "hostPID"); got != false {
+		t.Errorf("hostPID = %v, want false", got)
+	}
+}
+
+func TestForPodsecHostIPC(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-ESCAPE-004", "Deployment", "default", "host-ipc", nil)
+	hint := ForPodsec("KUBE-ESCAPE-004", finding)
+	body := expectStrategicPatch(t, hint, "Deployment", "default", "host-ipc")
+	if got := podSpecField(t, body, "Deployment", "hostIPC"); got != false {
+		t.Errorf("hostIPC = %v, want false", got)
+	}
+}
+
+// TestForPodsecHostPathVariants exercises every rule the hostPath family can
+// emit so the volume-removal patch wires up consistently for the generic
+// hostPath, the docker socket, the rootfs mount, the log directory, and the
+// containerd socket.
+func TestForPodsecHostPathVariants(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		ruleID string
+		volume string
+	}{
+		{"KUBE-HOSTPATH-001", "data"},
+		{"KUBE-ESCAPE-005", "docker-sock"},
+		{"KUBE-ESCAPE-006", "rootfs"},
+		{"KUBE-ESCAPE-008", "varlog"},
+		{"KUBE-CONTAINERD-SOCKET-001", "containerd-sock"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.ruleID, func(t *testing.T) {
+			t.Parallel()
+			finding := makeFinding(t, tc.ruleID, "Deployment", "default", "hp", map[string]any{
+				"volume": tc.volume,
+				"path":   "/some/path",
+			})
+			hint := ForPodsec(tc.ruleID, finding)
+			body := expectStrategicPatch(t, hint, "Deployment", "default", "hp")
+			volumes, ok := podSpecField(t, body, "Deployment", "volumes").([]any)
+			if !ok || len(volumes) == 0 {
+				t.Fatalf("volumes is %v (%T), want non-empty slice", podSpecField(t, body, "Deployment", "volumes"), podSpecField(t, body, "Deployment", "volumes"))
+			}
+			entry, _ := volumes[0].(map[string]any)
+			if entry["name"] != tc.volume {
+				t.Errorf("volumes[0].name = %v, want %q", entry["name"], tc.volume)
+			}
+			if entry["$patch"] != "delete" {
+				t.Errorf(`volumes[0]["$patch"] = %v, want "delete"`, entry["$patch"])
+			}
+		})
+	}
+}
+
+// TestForPodsecImageLatest verifies the comment-only TODO patch still
+// renders a runnable shape: a non-nil hint, an empty JSON body, and a
+// Command string carrying the placeholder repo.
+func TestForPodsecImageLatest(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-IMAGE-LATEST-001", "Deployment", "default", "imgapp", map[string]any{
+		"container": "app",
+		"image":     "nginx:latest",
+	})
+	hint := ForPodsec("KUBE-IMAGE-LATEST-001", finding)
+	if hint == nil || hint.Patch == nil {
+		t.Fatalf("expected non-nil hint, got %+v", hint)
+	}
+	if hint.Patch.Type != "merge" {
+		t.Errorf("Patch.Type = %q, want merge", hint.Patch.Type)
+	}
+	if string(hint.Patch.Body) != "{}" {
+		t.Errorf("Patch.Body = %s, want empty object", string(hint.Patch.Body))
+	}
+	if !strings.Contains(hint.Patch.Command, "# TODO:") {
+		t.Errorf("Patch.Command missing TODO marker: %s", hint.Patch.Command)
+	}
+	if !strings.Contains(hint.Patch.Command, "nginx") {
+		t.Errorf("Patch.Command missing image repo: %s", hint.Patch.Command)
+	}
+}
+
+// TestForPodsecCronJobWrapping checks that CronJob targets get the deeper
+// envelope (spec.jobTemplate.spec.template.spec) instead of the generic
+// spec.template.spec.
+func TestForPodsecCronJobWrapping(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-PODSEC-APE-001", "CronJob", "default", "nightly", map[string]any{
+		"container": "app",
+	})
+	hint := ForPodsec("KUBE-PODSEC-APE-001", finding)
+	if hint == nil || hint.Patch == nil {
+		t.Fatalf("expected non-nil hint")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(hint.Patch.Body, &decoded); err != nil {
+		t.Fatalf("body parse: %v", err)
+	}
+	spec, _ := decoded["spec"].(map[string]any)
+	if _, ok := spec["jobTemplate"]; !ok {
+		t.Errorf("CronJob patch missing spec.jobTemplate envelope: %s", string(hint.Patch.Body))
+	}
+}
+
+// TestForPodsecPodWrapping checks that Pod targets get the shallow envelope
+// (spec.<fragment>) rather than the workload spec.template.spec.
+func TestForPodsecPodWrapping(t *testing.T) {
+	t.Parallel()
+	finding := makeFinding(t, "KUBE-ESCAPE-003", "Pod", "default", "p", nil)
+	hint := ForPodsec("KUBE-ESCAPE-003", finding)
+	if hint == nil || hint.Patch == nil {
+		t.Fatalf("expected non-nil hint")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(hint.Patch.Body, &decoded); err != nil {
+		t.Fatalf("body parse: %v", err)
+	}
+	spec, _ := decoded["spec"].(map[string]any)
+	if _, ok := spec["template"]; ok {
+		t.Errorf("Pod patch should not have spec.template envelope: %s", string(hint.Patch.Body))
+	}
+	if spec["hostNetwork"] != false {
+		t.Errorf("spec.hostNetwork = %v, want false", spec["hostNetwork"])
+	}
+}
+
+// TestForPodsecNilResourceReturnsNil guards the defensive branch in
+// patchTargetFromFinding: callers that hand us a Finding with no Resource
+// should get nil back rather than a panic.
+func TestForPodsecNilResourceReturnsNil(t *testing.T) {
+	t.Parallel()
+	f := models.Finding{RuleID: "KUBE-ESCAPE-001"}
+	if hint := ForPodsec("KUBE-ESCAPE-001", f); hint != nil {
+		t.Errorf("expected nil hint for finding without Resource, got %+v", hint)
+	}
+}
+
+// TestForPodsecUnknownRuleReturnsNil documents that the table is closed:
+// rules outside the covered set get nil rather than a default patch, so
+// callers know to fall back to the prose Remediation field.
+func TestForPodsecUnknownRuleReturnsNil(t *testing.T) {
+	t.Parallel()
+	f := makeFinding(t, "KUBE-RBAC-OVERBROAD-001", "ClusterRole", "", "admin", nil)
+	if hint := ForPodsec("KUBE-RBAC-OVERBROAD-001", f); hint != nil {
+		t.Errorf("expected nil hint for non-podsec rule, got %+v", hint)
+	}
+}
+
+// TestForPodsecMissingContainerReturnsNil checks the defensive branch in
+// container-scoped generators: when Evidence.container is missing we cannot
+// produce a sensible patch, so we return nil instead of a patch that targets
+// the wrong (empty) container name.
+func TestForPodsecMissingContainerReturnsNil(t *testing.T) {
+	t.Parallel()
+	f := makeFinding(t, "KUBE-ESCAPE-001", "Deployment", "default", "x", map[string]any{
+		// no container key
+	})
+	if hint := ForPodsec("KUBE-ESCAPE-001", f); hint != nil {
+		t.Errorf("expected nil hint when container missing from evidence, got %+v", hint)
+	}
+}
+
+// TestForPodsecCommandShellSafe forces a single-quote into a target name to
+// confirm shellSingleQuote escapes it correctly so the rendered Command can
+// still be pasted into a POSIX shell without breaking out of the body
+// argument. Real K8s names cannot contain quotes, but the function should
+// still degrade safely if the contract is ever violated upstream.
+func TestForPodsecCommandShellSafe(t *testing.T) {
+	t.Parallel()
+	body := json.RawMessage(`{"key":"o'malley"}`)
+	got := renderKubectlPatchCommand(models.PatchTarget{Kind: "Pod", Name: "p", Namespace: "ns"}, "merge", body)
+	if !strings.Contains(got, `'{"key":"o'\''malley"}'`) {
+		t.Errorf("command did not escape single quote correctly: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/remediation/` package exposing `ForPodsec(ruleID, finding) *RemediationHint`. Returns a `KubectlPatch` (strategic-merge by default) plus a pre-rendered, shell-safe `Command` string ready for copy-paste.
- Covers 14 podsec rule IDs: privileged, runAsNonRoot, host{Network,PID,IPC}, the hostPath family (`KUBE-HOSTPATH-001`, `KUBE-ESCAPE-005/006/008`, `KUBE-CONTAINERD-SOCKET-001`), `allowPrivilegeEscalation`, `readOnlyRootFilesystem`, `seccompProfile`, and `procMount`. Mutable image tags emit a `# TODO:` Command-only suggestion with no patch body, since the desired digest is not knowable from a static scan.
- Wired in via a one-line addition to `appendFinding` in `internal/analyzer/podsec/analyzer.go`, so detection logic stays focused on detection.
- Patches account for workload-kind envelope depth: `Pod` -> `spec.<>`; Deployment / DaemonSet / StatefulSet / Job -> `spec.template.spec.<>`; CronJob -> `spec.jobTemplate.spec.template.spec.<>`. hostPath removal uses strategic-merge `$patch: delete` keyed by volume name (the cleanest no-index removal).
- Tests in `internal/remediation/podsec_test.go` assert (per rule) that the hint is non-nil, the body parses as JSON, the target fields are populated, and the rendered Command contains the expected verbs/flags. A separate test feeds a single quote through `renderKubectlPatchCommand` to confirm the shell escaping holds.

Plan slot #16; STRATEGY.md:52-57.

## Test plan

- [x] `make build` clean
- [x] `make test` clean (new package: `internal/remediation` ok)
- [x] `make lint` clean (gofmt + go vet)
- [x] `./bin/golangci-lint run ./...` clean (CI gate)
- [x] `make e2e` green: 50 expected rule IDs present, 56 of 65 podsec findings carry `remediation_hint` (the 9 without are `KUBE-SA-DEFAULT-001`, intentionally outside scope)
- [x] Sample command parses cleanly when pasted into a POSIX shell:
  ```
  kubectl patch deployment risky -n default --type=strategic -p '{"spec":{"template":{"spec":{"containers":[{"name":"app","securityContext":{"privileged":false}}]}}}}'
  ```