### PR TITLE
feat(report): wire Top 5 fixes panel grouped by subject and resource

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -1339,6 +1339,20 @@
       .topbar-meta .sep { display: none; }
       h1 { font-size: 24px; }
     }
+
+    /* Top fixes panel: ranked, single-edit recommendations. Mirrors the visual
+       weight of .narrative cards (severity-tinted strip on the left, monospace
+       rule chips) while staying compact enough to keep five rows above the fold. */
+    .top-fixes-intro { color: var(--text-mut); font-size: 13px; margin: 4px 0 14px; }
+    .top-fixes-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 10px; }
+    .top-fix-row { display: grid; grid-template-columns: 36px minmax(0, 1fr); gap: 12px; align-items: start; background: rgba(255,255,255,0.02); border: 1px solid var(--border-soft); border-radius: 10px; padding: 12px 14px; }
+    .top-fix-rank { font-family: "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 14px; font-weight: 700; color: var(--accent); text-align: center; padding-top: 2px; }
+    .top-fix-body { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+    .top-fix-action { color: var(--text); font-size: 14px; line-height: 1.45; }
+    .top-fix-action code { font-size: 12.5px; }
+    .top-fix-impact { color: var(--text-mut); font-size: 12px; font-variant-numeric: tabular-nums; }
+    .top-fix-rules { color: var(--text-mut); font-size: 11.5px; word-break: break-word; }
+    .top-fix-rules code { font-size: 11px; padding: 1px 4px; }
   </style>
 </head>
 <body data-active-tab="{{ if .DefaultTab }}{{ .DefaultTab }}{{ else }}attack{{ end }}">
@@ -1603,12 +1617,16 @@
       <div class="card soft">
         <div class="kicker">Top fixes</div>
         <h2>Highest-impact remediations</h2>
+        <p class="top-fixes-intro">Each row collapses every finding sharing the same owning principal or workload into a single edit. Tackle them top-down: the score-reduction column shows how much your cluster risk index drops once the fix lands.</p>
         <ol class="top-fixes-list">
           {{ range .TopFixes }}
           <li class="top-fix-row">
-            <span class="top-fix-rank">{{ .Rank }}</span>
-            <span class="top-fix-action">{{ .Action }}</span>
-            <span class="top-fix-impact">resolves {{ .FindingsCount }} {{ pluralize .FindingsCount "finding" "findings" }} (&minus;{{ score .ScoreImpact }})</span>
+            <span class="top-fix-rank">#{{ .Rank }}</span>
+            <div class="top-fix-body">
+              <span class="top-fix-action">{{ inlineHTML .Action }}</span>
+              <span class="top-fix-impact">Clears {{ .FindingsCount }} {{ pluralize .FindingsCount "rule" "rules" }} &middot; score impact &minus;{{ score .ScoreImpact }}</span>
+              {{ if .RuleIDs }}<span class="top-fix-rules">Rules: {{ range $i, $r := .RuleIDs }}{{ if $i }}, {{ end }}<code>{{ $r }}</code>{{ end }}</span>{{ end }}
+            </div>
           </li>
           {{ end }}
         </ol>

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -244,14 +244,9 @@ func buildHeroChains(_ []models.Finding) []HeroChainCard {
 	return nil
 }
 
-// buildTopFixes is the Wave 0 stub for the "Top 5 fixes" panel
-// (STRATEGY.md:162, plan slot W1 #5). Wave 1 will group findings by Subject,
-// sum scores, and surface the top binding / role deletions ranked by
-// score-reduction. Returns nil for now so the {{ if .TopFixes }} template gate
-// suppresses the section.
-func buildTopFixes(_ []models.Finding) []TopFix {
-	return nil
-}
+// buildTopFixes is implemented in topfixes.go. The stub originally lived here;
+// the call site stays so the BuildHTMLData hot path keeps a single line per
+// section builder. See topfixes.go for the grouping + ranking algorithm.
 
 // buildPerSubjectCapabilities is the Wave 0 stub for the per-ServiceAccount
 // "what can this principal actually do" capability cards

--- a/internal/report/topfixes.go
+++ b/internal/report/topfixes.go
@@ -1,0 +1,357 @@
+// Package report - "Top 5 fixes" panel builder. Groups findings by the principal or
+// resource that owns them, sums per-group scores, and ranks the resulting buckets so
+// the operator sees the single highest-leverage cleanup at the top of the report.
+// One ServiceAccount with overbroad RBAC plus a privesc path will typically dominate
+// the cluster's risk index; collapsing those rows into a single "delete this binding"
+// recommendation turns the report from a 200-row triage list into a five-step plan.
+package report
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+// maxTopFixes caps the panel at the highest-leverage five buckets so the hero
+// section stays scannable. Keeping it as a package-level constant lets the test
+// file pin the cap without re-deriving it.
+const maxTopFixes = 5
+
+// buildTopFixes groups findings by Subject (or, when Subject is nil, by Resource)
+// and surfaces the five buckets whose collective score would drop most if the
+// underlying object were removed or pared back. The ranking key is the sum of
+// per-finding scores within a bucket: a single ServiceAccount carrying eight
+// medium findings plus one critical privesc path beats a single critical finding
+// elsewhere because deleting that one binding clears all nine rows at once.
+//
+// The returned slice carries pre-rendered presentation fields (Rank, Action,
+// FindingsCount, ScoreImpact, Subjects, RuleIDs). The template consumes these
+// directly; no further formatting happens at render time. Returns nil when no
+// findings have a Subject or Resource (so the {{ if .TopFixes }} template gate
+// keeps the section absent for empty inputs).
+func buildTopFixes(findings []models.Finding) []TopFix {
+	if len(findings) == 0 {
+		return nil
+	}
+
+	// bucket aggregates the findings that share an owning Subject (preferred) or
+	// Resource (fallback). targetKind / targetLabel drive the suggested action
+	// string; subjects retains the original display key so the row can list it
+	// even when grouping fell back to Resource.
+	type bucket struct {
+		key         string
+		targetKind  string // "Subject" | "Resource"
+		targetLabel string // pre-rendered "Kind/[ns/]name" string
+		subjectRef  *models.SubjectRef
+		resourceRef *models.ResourceRef
+		score       float64
+		ruleIDs     []string
+		ruleSeen    map[string]bool
+		subjects    []string
+		subjSeen    map[string]bool
+		order       int // first-seen index, used as a stable tiebreaker
+	}
+
+	buckets := make(map[string]*bucket)
+	order := 0
+	for _, f := range findings {
+		var key, kind, label string
+		var subjRef *models.SubjectRef
+		var resRef *models.ResourceRef
+		switch {
+		case f.Subject != nil:
+			label = subjectDisplay(f.Subject)
+			if label == "" || label == "-" {
+				// subjectDisplay returns "-" only when Subject is nil; this branch
+				// guards the Kind="" Name="" degenerate case that some hand-built
+				// fixtures expose.
+				if f.Resource != nil {
+					label = resourceDisplay(f.Resource)
+					kind = "Resource"
+					resRef = f.Resource
+				} else {
+					continue
+				}
+			} else {
+				kind = "Subject"
+				subjRef = f.Subject
+			}
+			key = kind + "::" + label
+		case f.Resource != nil:
+			label = resourceDisplay(f.Resource)
+			if label == "" || label == "-" {
+				continue
+			}
+			kind = "Resource"
+			resRef = f.Resource
+			key = kind + "::" + label
+		default:
+			// No owner to fix: a cluster-wide observation (e.g. missing admission
+			// policy engine) belongs in the cluster-level section rather than a
+			// per-target top-fix row, so we skip it.
+			continue
+		}
+
+		b, ok := buckets[key]
+		if !ok {
+			b = &bucket{
+				key:         key,
+				targetKind:  kind,
+				targetLabel: label,
+				subjectRef:  subjRef,
+				resourceRef: resRef,
+				ruleSeen:    map[string]bool{},
+				subjSeen:    map[string]bool{},
+				order:       order,
+			}
+			buckets[key] = b
+			order++
+		}
+		b.score += f.Score
+		if f.RuleID != "" && !b.ruleSeen[f.RuleID] {
+			b.ruleSeen[f.RuleID] = true
+			b.ruleIDs = append(b.ruleIDs, f.RuleID)
+		}
+		// Track the subject display even when grouping is by Resource so the
+		// rendered row can disambiguate "Resource Deployment/api" with the
+		// affected principal when one exists.
+		if f.Subject != nil {
+			subjLabel := subjectDisplay(f.Subject)
+			if subjLabel != "" && subjLabel != "-" && !b.subjSeen[subjLabel] {
+				b.subjSeen[subjLabel] = true
+				b.subjects = append(b.subjects, subjLabel)
+			}
+		}
+	}
+
+	if len(buckets) == 0 {
+		return nil
+	}
+
+	ranked := make([]*bucket, 0, len(buckets))
+	for _, b := range buckets {
+		ranked = append(ranked, b)
+	}
+	// Sort by total score desc, then count desc, then first-seen order so the
+	// rendering stays deterministic across runs against the same snapshot.
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].score != ranked[j].score {
+			return ranked[i].score > ranked[j].score
+		}
+		if len(ranked[i].ruleIDs) != len(ranked[j].ruleIDs) {
+			return len(ranked[i].ruleIDs) > len(ranked[j].ruleIDs)
+		}
+		return ranked[i].order < ranked[j].order
+	})
+	if len(ranked) > maxTopFixes {
+		ranked = ranked[:maxTopFixes]
+	}
+
+	out := make([]TopFix, 0, len(ranked))
+	for i, b := range ranked {
+		// Keep the per-row rule list stable so two runs produce byte-identical
+		// HTML: sort the deduped slice alphabetically before emitting.
+		sort.Strings(b.ruleIDs)
+		sort.Strings(b.subjects)
+		out = append(out, TopFix{
+			Rank:          i + 1,
+			Action:        suggestedFixAction(b.targetKind, b.targetLabel, b.subjectRef, b.resourceRef, b.ruleIDs),
+			ScoreImpact:   b.score,
+			FindingsCount: len(b.ruleIDs),
+			Subjects:      append([]string(nil), b.subjects...),
+			RuleIDs:       append([]string(nil), b.ruleIDs...),
+		})
+	}
+	return out
+}
+
+// suggestedFixAction renders a one-line "what to do" string for a TopFix row.
+// The wording matches the kind of object the operator actually edits: a binding
+// is deleted, an overbroad Role gets its wildcard verb pared back, a workload's
+// hostPath volume is removed. The rule-prefix hints below cover the common
+// dominant-rule cases; everything else falls back to a generic "review" so the
+// row is still actionable.
+func suggestedFixAction(targetKind, targetLabel string, subj *models.SubjectRef, res *models.ResourceRef, ruleIDs []string) string {
+	dominant := dominantRulePrefix(ruleIDs)
+
+	switch targetKind {
+	case "Subject":
+		// Subject is the most common owner: an over-privileged ServiceAccount or
+		// a User/Group bound to cluster-admin. The dominant-prefix branches
+		// surface the specific binding-level edit; the default is generic.
+		who := subjectFriendly(subj, targetLabel)
+		switch dominant {
+		case "KUBE-PRIVESC-PATH":
+			return fmt.Sprintf("Sever privilege-escalation paths from %s by dropping the offending RoleBinding or pruning the bound Role's verbs", who)
+		case "KUBE-PRIVESC":
+			return fmt.Sprintf("Drop the dangerous RBAC verbs (impersonate / bind / escalate / token-create / pod-exec) granted to %s", who)
+		case "KUBE-RBAC-OVERBROAD":
+			return fmt.Sprintf("Pare back the overbroad Role bound to %s by replacing `*` verbs / resources with an explicit allowlist", who)
+		case "KUBE-RBAC-STALE":
+			return fmt.Sprintf("Delete the stale (Cluster)RoleBindings granting %s, the principal or referenced role no longer exists", who)
+		case "KUBE-SA-DEFAULT":
+			return fmt.Sprintf("Set `automountServiceAccountToken: false` on workloads still using %s, or replace it with a least-privileged ServiceAccount", who)
+		case "KUBE-SA-PRIVILEGED":
+			return fmt.Sprintf("Remove cluster-admin (or equivalent) bindings from %s and grant the minimum verbs the workload actually uses", who)
+		case "KUBE-LP-UNUSED", "KUBE-LP-WILDCARD-USED-PARTIAL":
+			return fmt.Sprintf("Apply the Least Privilege tab's suggested Role for %s (drop unused verbs / resources observed via audit)", who)
+		}
+		return fmt.Sprintf("Review every (Cluster)RoleBinding targeting %s and trim it to the minimum verbs the workload requires", who)
+
+	case "Resource":
+		// Resource is the fallback owner: typically a workload (Deployment,
+		// Pod, DaemonSet) that triggers pod-security findings even though no
+		// RBAC subject is attached.
+		what := resourceFriendly(res, targetLabel)
+		switch dominant {
+		case "KUBE-PODSEC-ROOT":
+			return fmt.Sprintf("Drop `securityContext.runAsRoot` / `privileged: true` from %s and pin a non-root UID", what)
+		case "KUBE-PODSEC-APE":
+			return fmt.Sprintf("Set `allowPrivilegeEscalation: false` and drop dangerous capabilities on every container in %s", what)
+		case "KUBE-PODSEC-READONLY":
+			return fmt.Sprintf("Set `readOnlyRootFilesystem: true` on every container in %s and mount writable paths explicitly via emptyDir or PV", what)
+		case "KUBE-PODSEC-SECCOMP":
+			return fmt.Sprintf("Apply `seccompProfile: { type: RuntimeDefault }` to every container in %s to block uncommon syscalls", what)
+		case "KUBE-HOSTPATH":
+			return fmt.Sprintf("Remove the hostPath volume mount from %s and replace it with a PersistentVolume or emptyDir", what)
+		case "KUBE-IMAGE-LATEST":
+			return fmt.Sprintf("Replace the `:latest` image tag in %s with a pinned digest (e.g. `image@sha256:...`)", what)
+		case "KUBE-CONTAINERD-SOCKET":
+			return fmt.Sprintf("Unmount the container-runtime socket from %s; it is functionally equivalent to root on the node", what)
+		case "KUBE-ESCAPE":
+			return fmt.Sprintf("Tighten the Pod Security context on %s to deny host namespaces, hostPath, and privileged containers", what)
+		case "KUBE-NETPOL-COVERAGE":
+			return fmt.Sprintf("Add a default-deny NetworkPolicy to %s and explicitly allow only the ingress / egress flows the workloads need", what)
+		case "KUBE-NETPOL-WEAKNESS":
+			return fmt.Sprintf("Tighten %s by replacing wildcard selectors and `0.0.0.0/0` egress with narrow pod / namespace selectors", what)
+		case "KUBE-SECRETS":
+			return fmt.Sprintf("Rotate and narrow the Secret referenced by %s, restricting the consuming workloads via RBAC and pod-level mounts", what)
+		case "KUBE-CONFIGMAP":
+			return fmt.Sprintf("Move credential-shaped keys out of the ConfigMap referenced by %s into a Secret with tight RBAC", what)
+		case "KUBE-ADMISSION":
+			return fmt.Sprintf("Replace `failurePolicy: Ignore` on the admission webhook attached to %s with `Fail`, or scope it down via namespaceSelector", what)
+		}
+		return fmt.Sprintf("Review %s and apply the per-finding remediation steps listed under the matching rule cards", what)
+	}
+	return fmt.Sprintf("Review %s and apply the per-finding remediation steps", targetLabel)
+}
+
+// dominantRulePrefix returns the most frequent "KUBE-AREA" stem across the
+// supplied rule IDs. Ties prefer the longest (most specific) prefix, then the
+// alphabetically-first prefix, so two runs produce identical wording. A single
+// KUBE-PRIVESC-PATH-CLUSTER-ADMIN finding alongside a KUBE-PRIVESC-005 finding
+// resolves to KUBE-PRIVESC-PATH (length: 17) rather than the more generic
+// KUBE-PRIVESC (length: 12). Returns an empty string when no rule IDs follow
+// the KUBE-AREA- naming convention.
+func dominantRulePrefix(ruleIDs []string) string {
+	if len(ruleIDs) == 0 {
+		return ""
+	}
+	counts := map[string]int{}
+	for _, id := range ruleIDs {
+		prefix := rulePrefix(id)
+		if prefix == "" {
+			continue
+		}
+		counts[prefix]++
+	}
+	if len(counts) == 0 {
+		return ""
+	}
+	best := ""
+	bestCount := -1
+	for prefix, n := range counts {
+		switch {
+		case n > bestCount:
+			best, bestCount = prefix, n
+		case n == bestCount && len(prefix) > len(best):
+			best = prefix
+		case n == bestCount && len(prefix) == len(best) && prefix < best:
+			best = prefix
+		}
+	}
+	return best
+}
+
+// rulePrefix extracts the "KUBE-<AREA>" stem from a rule ID. For privesc graph
+// rules the area is the multi-segment "PRIVESC-PATH" since the suffix is the
+// sink name, not a number; that's why the helper looks at the third dash too.
+// Returns an empty string when the input does not follow the convention.
+func rulePrefix(ruleID string) string {
+	parts := strings.Split(ruleID, "-")
+	if len(parts) < 3 {
+		return ""
+	}
+	// KUBE-PRIVESC-PATH-CLUSTER-ADMIN → keep "KUBE-PRIVESC-PATH" so the topfix
+	// suggestion can distinguish graph paths from the static KUBE-PRIVESC-001
+	// style rules.
+	if len(parts) >= 4 && parts[0] == "KUBE" && parts[1] == "PRIVESC" && parts[2] == "PATH" {
+		return "KUBE-PRIVESC-PATH"
+	}
+	// KUBE-LP-UNUSED-VERB-001 → "KUBE-LP-UNUSED"; KUBE-LP-WILDCARD-USED-PARTIAL-001 → "KUBE-LP-WILDCARD-USED-PARTIAL".
+	if len(parts) >= 4 && parts[0] == "KUBE" && parts[1] == "LP" {
+		// Strip the trailing numeric component if present so suffixes group together.
+		stem := parts[:len(parts)-1]
+		if !isNumericSegment(parts[len(parts)-1]) {
+			stem = parts
+		}
+		return strings.Join(stem, "-")
+	}
+	// Fallback: keep KUBE-AREA without the trailing numeric / sub-numeric suffix.
+	// Multi-segment areas like KUBE-PODSEC-APE-001 collapse to "KUBE-PODSEC-APE".
+	stem := parts[:len(parts)-1]
+	if !isNumericSegment(parts[len(parts)-1]) {
+		stem = parts
+	}
+	return strings.Join(stem, "-")
+}
+
+// isNumericSegment reports whether a rule-ID segment is a pure numeric tail
+// (e.g. "001"). Used by rulePrefix to know whether the trailing segment is the
+// rule's instance counter or part of its area.
+func isNumericSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// subjectFriendly returns a slightly humanized label for a Subject. The bare
+// "Kind/[ns/]name" string is fine for code spans but the topfix action reads
+// better when the kind is spelled out as "ServiceAccount default/builder"
+// rather than "ServiceAccount/default/builder".
+func subjectFriendly(subj *models.SubjectRef, fallback string) string {
+	if subj == nil {
+		return fallback
+	}
+	name := subj.Name
+	if name == "" {
+		name = fallback
+	}
+	if subj.Namespace != "" {
+		return fmt.Sprintf("%s `%s/%s`", subj.Kind, subj.Namespace, name)
+	}
+	return fmt.Sprintf("%s `%s`", subj.Kind, name)
+}
+
+// resourceFriendly mirrors subjectFriendly for ResourceRef.
+func resourceFriendly(res *models.ResourceRef, fallback string) string {
+	if res == nil {
+		return fallback
+	}
+	name := res.Name
+	if name == "" {
+		name = fallback
+	}
+	if res.Namespace != "" {
+		return fmt.Sprintf("%s `%s/%s`", res.Kind, res.Namespace, name)
+	}
+	return fmt.Sprintf("%s `%s`", res.Kind, name)
+}

--- a/internal/report/topfixes_test.go
+++ b/internal/report/topfixes_test.go
@@ -1,0 +1,249 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+)
+
+func TestBuildTopFixes_EmptyAndOwnerless(t *testing.T) {
+	t.Parallel()
+
+	if got := buildTopFixes(nil); got != nil {
+		t.Errorf("nil input should produce nil slice, got %#v", got)
+	}
+
+	// Findings with neither Subject nor Resource have no owner to fix, so they
+	// belong in the cluster-level section and should be skipped here.
+	if got := buildTopFixes([]models.Finding{
+		{ID: "f1", RuleID: "KUBE-ADMISSION-001", Score: 7.0},
+	}); got != nil {
+		t.Errorf("ownerless findings should produce nil slice, got %#v", got)
+	}
+}
+
+func TestBuildTopFixes_GroupsBySubjectAndSumsScores(t *testing.T) {
+	t.Parallel()
+
+	subjA := &models.SubjectRef{Kind: "ServiceAccount", Name: "builder", Namespace: "default"}
+	subjB := &models.SubjectRef{Kind: "ServiceAccount", Name: "reader", Namespace: "default"}
+
+	findings := []models.Finding{
+		// subjA: dominant prefix KUBE-PRIVESC-PATH, sum 9.5 + 7.5 = 17.0
+		{ID: "1", RuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN", Score: 9.5, Subject: subjA},
+		{ID: "2", RuleID: "KUBE-PRIVESC-005", Score: 7.5, Subject: subjA},
+		// subjB: dominant prefix KUBE-RBAC-OVERBROAD, sum 8.0
+		{ID: "3", RuleID: "KUBE-RBAC-OVERBROAD-001", Score: 8.0, Subject: subjB},
+	}
+
+	got := buildTopFixes(findings)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 top-fix rows, got %d: %+v", len(got), got)
+	}
+
+	if got[0].Rank != 1 {
+		t.Errorf("first row Rank = %d, want 1", got[0].Rank)
+	}
+	if got[1].Rank != 2 {
+		t.Errorf("second row Rank = %d, want 2", got[1].Rank)
+	}
+
+	// subjA wins on summed score.
+	if got[0].ScoreImpact != 17.0 {
+		t.Errorf("top score = %v, want 17.0", got[0].ScoreImpact)
+	}
+	if got[0].FindingsCount != 2 {
+		t.Errorf("top FindingsCount = %d, want 2", got[0].FindingsCount)
+	}
+	// The action should reference the dominant rule prefix (privesc-path) for subjA.
+	if !strings.Contains(got[0].Action, "privilege-escalation") {
+		t.Errorf("top action should mention privilege escalation for subjA, got: %q", got[0].Action)
+	}
+	if !strings.Contains(got[0].Action, "builder") {
+		t.Errorf("top action should name the subject (builder), got: %q", got[0].Action)
+	}
+
+	// subjB shows up second with the overbroad-role messaging.
+	if got[1].ScoreImpact != 8.0 {
+		t.Errorf("second score = %v, want 8.0", got[1].ScoreImpact)
+	}
+	if !strings.Contains(got[1].Action, "overbroad") {
+		t.Errorf("second action should mention overbroad role for subjB, got: %q", got[1].Action)
+	}
+}
+
+func TestBuildTopFixes_FallsBackToResourceWhenSubjectMissing(t *testing.T) {
+	t.Parallel()
+
+	res := &models.ResourceRef{Kind: "Deployment", Name: "risky", Namespace: "default"}
+	findings := []models.Finding{
+		{ID: "1", RuleID: "KUBE-PODSEC-ROOT-001", Score: 7.0, Resource: res},
+		{ID: "2", RuleID: "KUBE-HOSTPATH-001", Score: 6.5, Resource: res},
+	}
+
+	got := buildTopFixes(findings)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row from a single Resource bucket, got %d", len(got))
+	}
+	if got[0].ScoreImpact != 13.5 {
+		t.Errorf("ScoreImpact = %v, want 13.5", got[0].ScoreImpact)
+	}
+	// Dominant prefix is podsec-root (alphabetically lower than hostpath); the
+	// action should reference the deployment by name.
+	if !strings.Contains(got[0].Action, "risky") {
+		t.Errorf("action should name the resource (risky), got: %q", got[0].Action)
+	}
+	if len(got[0].RuleIDs) != 2 {
+		t.Errorf("expected both unique rule IDs, got %v", got[0].RuleIDs)
+	}
+}
+
+func TestBuildTopFixes_CapsAtFive(t *testing.T) {
+	t.Parallel()
+
+	findings := make([]models.Finding, 0, 7)
+	for i := 0; i < 7; i++ {
+		subj := &models.SubjectRef{Kind: "ServiceAccount", Name: string(rune('a' + i)), Namespace: "ns"}
+		// Use decreasing scores so the ranking is stable and the row order is
+		// trivially verifiable.
+		findings = append(findings, models.Finding{
+			ID:      string(rune('1' + i)),
+			RuleID:  "KUBE-RBAC-OVERBROAD-001",
+			Score:   float64(7 - i),
+			Subject: subj,
+		})
+	}
+
+	got := buildTopFixes(findings)
+	if len(got) != maxTopFixes {
+		t.Fatalf("expected %d rows (cap), got %d", maxTopFixes, len(got))
+	}
+	if got[0].ScoreImpact != 7.0 || got[len(got)-1].ScoreImpact != 3.0 {
+		t.Errorf("rows out of order: first=%v last=%v", got[0].ScoreImpact, got[len(got)-1].ScoreImpact)
+	}
+}
+
+func TestBuildTopFixes_DeterministicRuleIDOrder(t *testing.T) {
+	t.Parallel()
+
+	subj := &models.SubjectRef{Kind: "ServiceAccount", Name: "builder", Namespace: "default"}
+	findings := []models.Finding{
+		{ID: "1", RuleID: "KUBE-RBAC-OVERBROAD-001", Score: 5.0, Subject: subj},
+		{ID: "2", RuleID: "KUBE-PRIVESC-005", Score: 5.0, Subject: subj},
+		{ID: "3", RuleID: "KUBE-SA-DEFAULT-001", Score: 5.0, Subject: subj},
+	}
+
+	got := buildTopFixes(findings)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	want := []string{"KUBE-PRIVESC-005", "KUBE-RBAC-OVERBROAD-001", "KUBE-SA-DEFAULT-001"}
+	if len(got[0].RuleIDs) != len(want) {
+		t.Fatalf("expected %d rule IDs, got %d", len(want), len(got[0].RuleIDs))
+	}
+	for i, w := range want {
+		if got[0].RuleIDs[i] != w {
+			t.Errorf("RuleIDs[%d] = %q, want %q", i, got[0].RuleIDs[i], w)
+		}
+	}
+}
+
+func TestBuildTopFixes_DeduplicatesRuleIDsAcrossInstances(t *testing.T) {
+	t.Parallel()
+
+	subj := &models.SubjectRef{Kind: "ServiceAccount", Name: "builder", Namespace: "default"}
+	// Same rule fires three times against three distinct resources owned by the
+	// same subject. The topfix row should sum every score but list the rule once.
+	findings := []models.Finding{
+		{ID: "1", RuleID: "KUBE-RBAC-OVERBROAD-001", Score: 8.0, Subject: subj},
+		{ID: "2", RuleID: "KUBE-RBAC-OVERBROAD-001", Score: 7.0, Subject: subj},
+		{ID: "3", RuleID: "KUBE-RBAC-OVERBROAD-001", Score: 6.0, Subject: subj},
+	}
+
+	got := buildTopFixes(findings)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	if got[0].ScoreImpact != 21.0 {
+		t.Errorf("ScoreImpact = %v, want 21.0", got[0].ScoreImpact)
+	}
+	if got[0].FindingsCount != 1 {
+		t.Errorf("FindingsCount = %d, want 1 (deduped)", got[0].FindingsCount)
+	}
+	if len(got[0].RuleIDs) != 1 {
+		t.Errorf("RuleIDs should be deduped to 1 entry, got %v", got[0].RuleIDs)
+	}
+}
+
+func TestBuildTopFixes_TracksSubjectsWhenResourceBucket(t *testing.T) {
+	t.Parallel()
+
+	subjA := &models.SubjectRef{Kind: "ServiceAccount", Name: "alpha", Namespace: "ns"}
+	subjB := &models.SubjectRef{Kind: "ServiceAccount", Name: "beta", Namespace: "ns"}
+	resource := &models.ResourceRef{Kind: "Deployment", Name: "shared", Namespace: "ns"}
+
+	findings := []models.Finding{
+		{ID: "1", RuleID: "KUBE-PODSEC-ROOT-001", Score: 6.0, Resource: resource, Subject: subjA},
+		{ID: "2", RuleID: "KUBE-PODSEC-ROOT-001", Score: 5.0, Resource: resource, Subject: subjB},
+	}
+
+	got := buildTopFixes(findings)
+	// Both findings have a Subject so they group by subject (alpha and beta),
+	// producing two separate rows. The Subjects slice on each row carries the
+	// subject display string for context.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 subject rows, got %d", len(got))
+	}
+	foundAlpha, foundBeta := false, false
+	for _, row := range got {
+		for _, s := range row.Subjects {
+			switch {
+			case strings.Contains(s, "alpha"):
+				foundAlpha = true
+			case strings.Contains(s, "beta"):
+				foundBeta = true
+			}
+		}
+	}
+	if !foundAlpha || !foundBeta {
+		t.Errorf("expected both subjects to appear across rows, got alpha=%v beta=%v: %+v", foundAlpha, foundBeta, got)
+	}
+}
+
+func TestRulePrefix_Variants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{"KUBE-PRIVESC-PATH-CLUSTER-ADMIN", "KUBE-PRIVESC-PATH"},
+		{"KUBE-PRIVESC-PATH-NODE-ESCAPE", "KUBE-PRIVESC-PATH"},
+		{"KUBE-PRIVESC-005", "KUBE-PRIVESC"},
+		{"KUBE-RBAC-OVERBROAD-001", "KUBE-RBAC-OVERBROAD"},
+		{"KUBE-PODSEC-APE-001", "KUBE-PODSEC-APE"},
+		{"KUBE-LP-UNUSED-VERB-001", "KUBE-LP-UNUSED-VERB"},
+		{"KUBE-LP-WILDCARD-USED-PARTIAL-001", "KUBE-LP-WILDCARD-USED-PARTIAL"},
+		{"too-short", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := rulePrefix(tc.in); got != tc.want {
+			t.Errorf("rulePrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDominantRulePrefix_TiebreakPrefersLongerThenAlphabetical(t *testing.T) {
+	t.Parallel()
+
+	// Longer prefix wins on a length tie because it's strictly more specific:
+	// KUBE-PRIVESC-PATH (17 chars) beats KUBE-PRIVESC (12 chars) at equal count.
+	if got := dominantRulePrefix([]string{"KUBE-PRIVESC-005", "KUBE-PRIVESC-PATH-CLUSTER-ADMIN"}); got != "KUBE-PRIVESC-PATH" {
+		t.Errorf("longer-prefix tiebreak: got %q, want KUBE-PRIVESC-PATH", got)
+	}
+	// Equal-length tie falls through to alphabetical.
+	if got := dominantRulePrefix([]string{"KUBE-RBAC-STALE-001", "KUBE-RBAC-OVERBROAD-001"}); got != "KUBE-RBAC-OVERBROAD" {
+		t.Errorf("alphabetical-tiebreak: got %q, want KUBE-RBAC-OVERBROAD", got)
+	}
+}


### PR DESCRIPTION
## Summary

Wave 1, plan slot **#5** ([STRATEGY.md:162](../blob/main/STRATEGY.md#L162)). Fills the W0 `buildTopFixes` stub so the hero "Top fixes" section now renders five actionable, ranked cleanup recommendations.

- New `internal/report/topfixes.go`: groups findings by `Subject` (falling back to `Resource` when Subject is nil), sums per-bucket scores, ranks by total score-reduction, and renders a one-line action string tailored to the dominant rule prefix in the bucket (e.g. "Sever privilege-escalation paths from ServiceAccount X" for KUBE-PRIVESC-PATH-heavy buckets, "Tighten the Pod Security context on Deployment Y" for KUBE-ESCAPE-heavy buckets, etc.).
- `internal/report/summary.go`: keeps the `buildTopFixes(findings)` call site, replaces the stub body with a one-line redirect comment pointing at the new file.
- `internal/report/assets/report.html.tmpl`: expanded the existing `{{ if .TopFixes }}` block to render the rank chip + action sentence + impact line + per-row rule-ID list; small CSS additions inline.
- `internal/report/topfixes_test.go`: 9 table-driven tests covering empty / ownerless input, subject grouping with score summing, fallback to Resource, the 5-row cap, deterministic rule-ID ordering, rule-ID dedup, subject tracking on Resource buckets, the rule-prefix extractor variants (KUBE-PRIVESC-PATH-* multi-segment, KUBE-LP-*, numeric tails), and the longest-then-alphabetical tiebreak.

## Sample rows against `testdata/snapshots/minimal-risky.json`

| Rank | Action | Impact |
|---:|---|---:|
| #1 | Tighten the Pod Security context on Deployment `default/risky` to deny host namespaces, hostPath, and privileged containers | -54.7 (8 rules) |
| #2 | Drop the dangerous RBAC verbs (impersonate / bind / escalate / token-create / pod-exec) granted to ServiceAccount `default/reader` | -42.4 (5 rules) |
| #3 | Set `readOnlyRootFilesystem: true` on every container in Deployment `flat-network/api` and mount writable paths explicitly via emptyDir or PV | -24.2 (4 rules) |
| #4 | Replace `failurePolicy: Ignore` on the admission webhook attached to MutatingWebhookConfiguration `risky-ignore-webhook` with `Fail`, or scope it down via namespaceSelector | -20.4 (3 rules) |
| #5 | Tighten NetworkPolicy `flat-network/allow-broad` by replacing wildcard selectors and `0.0.0.0/0` egress with narrow pod / namespace selectors | -13.1 (2 rules) |

Same five-row panel renders cleanly on the kind e2e cluster too (top row `ServiceAccount rbac-fixtures/sa-pod-create` clears 10 rules at -83.4).

## Test plan

- [x] `make build`
- [x] `make test` (full suite green; new `topfixes_test.go` covers 9 cases)
- [x] `make lint` (`gofmt -l` + `go vet`)
- [x] `./bin/golangci-lint run ./...` (0 issues)
- [x] `make e2e` (kind cluster boots, all 50 expected rule IDs present)
- [x] Visual: re-rendered HTML report against `testdata/snapshots/minimal-risky.json`, five rows visible with realistic deltas, monospace rule chips and code spans render correctly under the existing `.card.soft` look