### PR TITLE
feat(report): per-subject capability cards in LP tab

### DIFF
--- a/internal/report/assets/report.html.tmpl
+++ b/internal/report/assets/report.html.tmpl
@@ -1616,30 +1616,6 @@
     </section>
     {{ end }}
 
-    {{ if .SubjectCapCards }}
-    <section class="subject-caps" data-tab="leastprivilege">
-      <div class="card soft">
-        <div class="kicker">Per-subject capabilities</div>
-        <h2>What each principal can actually do</h2>
-        <div class="subject-cap-grid">
-          {{ range .SubjectCapCards }}
-          <article class="subject-cap-card sev-{{ sevClass .HighestSeverity }}">
-            <header><h3>{{ .SubjectLabel }}</h3></header>
-            {{ if .EffectiveVerbs }}<p class="cap-verbs"><strong>Verbs:</strong> {{ range .EffectiveVerbs }}<code>{{ . }}</code> {{ end }}</p>{{ end }}
-            {{ if .EffectiveRules }}<ul class="cap-rules">{{ range .EffectiveRules }}<li>{{ . }}</li>{{ end }}</ul>{{ end }}
-            {{ if .PrivescPaths }}
-            <div class="cap-paths">
-              <strong>Privesc paths:</strong>
-              <ul>{{ range .PrivescPaths }}<li>{{ . }}</li>{{ end }}</ul>
-            </div>
-            {{ end }}
-          </article>
-          {{ end }}
-        </div>
-      </div>
-    </section>
-    {{ end }}
-
     {{ if .Graph.Nodes }}
     <section data-tab="attack">
       <div class="card kp-graph-card">
@@ -2250,6 +2226,53 @@
           </tbody>
         </table>
       </details>
+      {{ end }}
+
+      {{ if .SubjectCapCards }}
+      <section class="subject-caps">
+        <div class="lp-caps-hd">
+          <h2>What each principal can actually do</h2>
+          <p class="lp-caps-sub">
+            The Cloudsplaining-style per-subject view: every RBAC subject that fires a finding or
+            holds a cluster-admin-equivalent grant gets one card. <strong>Bindings</strong> lists the
+            (Cluster)RoleBindings that grant the subject its permissions; <strong>Effective verbs</strong>
+            is the deduped verb set across all bound roles; <strong>Effective rules</strong> collapses
+            the granular RBAC rules into one row per resource so the operator can scan them. When the
+            engine detected a privesc chain from this subject the card is tagged
+            <span class="badge-chain">chain-amplified</span> and the chain summaries appear at the
+            bottom — those are the principals to prune first.
+          </p>
+        </div>
+        <div class="subject-cap-grid">
+          {{ range .SubjectCapCards }}
+          <article class="subject-cap-card sev-{{ sevClass .HighestSeverity }}">
+            <header class="subject-cap-hd">
+              <h3>{{ .SubjectLabel }}</h3>
+              {{ if .ChainAmplified }}<span class="badge-chain" title="A privesc chain originates from this subject">chain-amplified</span>{{ end }}
+            </header>
+            {{ if .Bindings }}
+            <div class="cap-bindings">
+              <strong>Bindings:</strong>
+              <ul>{{ range .Bindings }}<li><code>{{ . }}</code></li>{{ end }}</ul>
+            </div>
+            {{ end }}
+            {{ if .EffectiveVerbs }}<p class="cap-verbs"><strong>Effective verbs:</strong> {{ range .EffectiveVerbs }}<code>{{ . }}</code> {{ end }}</p>{{ end }}
+            {{ if .EffectiveRules }}
+            <div class="cap-rules-wrap">
+              <strong>Effective rules:</strong>
+              <ul class="cap-rules">{{ range .EffectiveRules }}<li><code>{{ . }}</code></li>{{ end }}</ul>
+            </div>
+            {{ end }}
+            {{ if .PrivescPaths }}
+            <div class="cap-paths">
+              <strong>Privesc paths originating here:</strong>
+              <ul>{{ range .PrivescPaths }}<li>{{ . }}</li>{{ end }}</ul>
+            </div>
+            {{ end }}
+          </article>
+          {{ end }}
+        </div>
+      </section>
       {{ end }}
 
       {{ range .LeastPrivilege.Groups }}

--- a/internal/report/leastprivilege_section.go
+++ b/internal/report/leastprivilege_section.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/0hardik1/kubesplaining/internal/analyzer/leastprivilege"
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
 )
 
 // buildLeastPrivilegeSection filters findings to the LP rule set, populates two top-of-
@@ -581,6 +582,272 @@ func dedupeStrings(in []string) []string {
 // out of evidence. Kept as a thin wrapper so the row builder reads cleanly.
 func formatVerbList(triples []map[string]string) template.HTML {
 	return renderVerbsGrouped(triplesToVR(triples))
+}
+
+// buildPerSubjectCapabilities composes one SubjectCapabilityCard per RBAC subject
+// (STRATEGY.md:32, plan slot W1 #7). The card answers "what can this principal
+// actually do AND where does it lead": aggregated EffectiveRules from
+// permissions.Aggregate (collapsed by resource for readability), the bindings the
+// subject is granted via, and any privesc paths the analyzer detected as
+// originating from this subject. ChainAmplified mirrors the engine's chain-modifier
+// signal so the template can surface a badge for subjects whose grants compose
+// into an exploitable path.
+//
+// Filter: we only emit a card for subjects that appear in at least one finding OR
+// hold a "cluster-admin equivalent" grant (cluster-scoped wildcard verb, or direct
+// binding to the built-in cluster-admin ClusterRole). This keeps the section
+// focused on the principals an operator should review without flooding the tab
+// with every default ServiceAccount in every namespace.
+func buildPerSubjectCapabilities(snapshot models.Snapshot, findings []models.Finding) []SubjectCapabilityCard {
+	if len(snapshot.Resources.RoleBindings)+len(snapshot.Resources.ClusterRoleBindings) == 0 {
+		return nil
+	}
+	effective := permissions.Aggregate(snapshot)
+	if len(effective) == 0 {
+		return nil
+	}
+
+	// Index findings by subject key so each card carries only the findings about
+	// its own principal. Build the privesc summary + highest severity in the same
+	// pass — both views are derived from the same finding slice.
+	type subjectIndex struct {
+		highest   models.Severity
+		hasFind   bool
+		privescs  []string
+		amplified bool
+	}
+	idx := map[string]*subjectIndex{}
+	for _, f := range findings {
+		if f.Subject == nil {
+			continue
+		}
+		key := f.Subject.Key()
+		entry := idx[key]
+		if entry == nil {
+			entry = &subjectIndex{}
+			idx[key] = entry
+		}
+		entry.hasFind = true
+		if f.Severity.Rank() > entry.highest.Rank() {
+			entry.highest = f.Severity
+		}
+		if strings.HasPrefix(f.RuleID, "KUBE-PRIVESC-PATH-") {
+			entry.privescs = append(entry.privescs, summarizePrivescPath(f))
+			entry.amplified = true
+		}
+		for _, tag := range f.Tags {
+			if tag == "chain:amplified" {
+				entry.amplified = true
+				break
+			}
+		}
+	}
+
+	// Build the per-subject binding list once so each card can pull from it. The
+	// permissions package already gave us source bindings via EffectiveRule, but
+	// re-walking bindings here lets us include bindings whose Role has no rules
+	// (still visible to operators as "bound to <Role>") and preserves the
+	// distinction between RoleBinding and ClusterRoleBinding.
+	bindingsBySubject := map[string][]string{}
+	for _, rb := range snapshot.Resources.RoleBindings {
+		for _, s := range rb.Subjects {
+			ref := permissions.SubjectRef(s, rb.Namespace)
+			label := fmt.Sprintf("RoleBinding/%s/%s -> %s/%s", rb.Namespace, rb.Name, rb.RoleRef.Kind, rb.RoleRef.Name)
+			bindingsBySubject[ref.Key()] = append(bindingsBySubject[ref.Key()], label)
+		}
+	}
+	for _, crb := range snapshot.Resources.ClusterRoleBindings {
+		for _, s := range crb.Subjects {
+			ref := permissions.SubjectRef(s, "")
+			label := fmt.Sprintf("ClusterRoleBinding/%s -> %s/%s", crb.Name, crb.RoleRef.Kind, crb.RoleRef.Name)
+			bindingsBySubject[ref.Key()] = append(bindingsBySubject[ref.Key()], label)
+		}
+	}
+
+	cards := make([]SubjectCapabilityCard, 0, len(effective))
+	for key, perms := range effective {
+		entry := idx[key]
+		hasFinding := entry != nil && entry.hasFind
+		hasClusterAdmin := subjectHoldsClusterAdmin(perms, bindingsBySubject[key])
+		if !hasFinding && !hasClusterAdmin {
+			continue
+		}
+
+		card := SubjectCapabilityCard{
+			SubjectKind:  perms.Subject.Kind,
+			SubjectName:  perms.Subject.Name,
+			SubjectNs:    perms.Subject.Namespace,
+			SubjectLabel: subjectGroupLabel(&perms.Subject),
+		}
+		card.EffectiveVerbs, card.EffectiveRules = collapseEffectiveRules(perms.Rules)
+		card.Bindings = dedupeStrings(bindingsBySubject[key])
+		sort.Strings(card.Bindings)
+		if entry != nil {
+			card.PrivescPaths = entry.privescs
+			card.ChainAmplified = entry.amplified
+			card.HighestSeverity = entry.highest
+		}
+		cards = append(cards, card)
+	}
+
+	// Cards with privesc paths first (they're the actionable ones), then by
+	// highest severity, then by subject label for stable output.
+	sort.SliceStable(cards, func(i, j int) bool {
+		if cards[i].ChainAmplified != cards[j].ChainAmplified {
+			return cards[i].ChainAmplified
+		}
+		if cards[i].HighestSeverity.Rank() != cards[j].HighestSeverity.Rank() {
+			return cards[i].HighestSeverity.Rank() > cards[j].HighestSeverity.Rank()
+		}
+		return cards[i].SubjectLabel < cards[j].SubjectLabel
+	})
+
+	return cards
+}
+
+// summarizePrivescPath turns a KUBE-PRIVESC-PATH-* finding into the one-line chain
+// summary shown on the card. Falls back to a sink-only summary when EscalationPath
+// is empty (the privesc analyzer sometimes emits paths with no hop slice for
+// degenerate sink edges); the sink label is always derivable from the RuleID.
+func summarizePrivescPath(f models.Finding) string {
+	hops := len(f.EscalationPath)
+	sink := strings.TrimPrefix(f.RuleID, "KUBE-PRIVESC-PATH-")
+	sink = strings.ToLower(strings.ReplaceAll(sink, "-", "_"))
+	suffix := fmt.Sprintf("%s (%s, %d %s)", sink, f.Severity, hops, pluralizeHops(hops))
+	if hops == 0 {
+		return suffix
+	}
+	first := f.EscalationPath[0]
+	last := f.EscalationPath[hops-1]
+	// Some sinks ("kube_system_secrets", "node_escape") are synthetic and the
+	// privesc analyzer leaves their ToSubject Kind/Name empty. Falling back to
+	// the rule's sink slug keeps the chain summary readable in those cases.
+	toLabel := subjectGroupLabel(&last.ToSubject)
+	if last.ToSubject.Kind == "" && last.ToSubject.Name == "" {
+		toLabel = sink
+	}
+	return fmt.Sprintf("%s -> %s via %s -> %s",
+		subjectGroupLabel(&first.FromSubject),
+		toLabel,
+		first.Action,
+		suffix,
+	)
+}
+
+// pluralizeHops returns "hop" or "hops" based on count.
+func pluralizeHops(n int) string {
+	if n == 1 {
+		return "hop"
+	}
+	return "hops"
+}
+
+// collapseEffectiveRules turns the granular permissions.EffectiveRule list into
+// (uniqueVerbs, perResourceRows). Each row reads "verb,verb,... on resource@apiGroup"
+// so the card stays scannable: operators want to know "this SA can delete pods" not
+// "this SA has 13 separate rules". Wildcards stay verbatim ("*") so the threat is
+// obvious. Empty inputs yield nil for both, keeping the template gates honest.
+func collapseEffectiveRules(rules []permissions.EffectiveRule) ([]string, []string) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	type bucket struct {
+		apiGroup string
+		resource string
+		verbs    map[string]struct{}
+	}
+	buckets := map[string]*bucket{}
+	order := []string{}
+	verbsAll := map[string]struct{}{}
+	for _, r := range rules {
+		for _, ag := range zeroOrSelf(r.APIGroups) {
+			for _, res := range zeroOrSelf(r.Resources) {
+				key := ag + "|" + res
+				b, ok := buckets[key]
+				if !ok {
+					b = &bucket{apiGroup: ag, resource: res, verbs: map[string]struct{}{}}
+					buckets[key] = b
+					order = append(order, key)
+				}
+				for _, v := range r.Verbs {
+					b.verbs[v] = struct{}{}
+					verbsAll[v] = struct{}{}
+				}
+			}
+		}
+	}
+
+	verbs := make([]string, 0, len(verbsAll))
+	for v := range verbsAll {
+		verbs = append(verbs, v)
+	}
+	sort.Strings(verbs)
+
+	rows := make([]string, 0, len(order))
+	for _, k := range order {
+		b := buckets[k]
+		verbList := make([]string, 0, len(b.verbs))
+		for v := range b.verbs {
+			verbList = append(verbList, v)
+		}
+		sort.Strings(verbList)
+		ag := b.apiGroup
+		if ag == "" {
+			ag = "core"
+		}
+		rows = append(rows, fmt.Sprintf("%s on %s@%s", strings.Join(verbList, ","), b.resource, ag))
+	}
+	sort.Strings(rows)
+	return verbs, rows
+}
+
+// zeroOrSelf returns a single empty-string slice when the input is empty so the
+// "core" apiGroup or untyped resource still produces one bucket. Otherwise it
+// returns the input verbatim.
+func zeroOrSelf(in []string) []string {
+	if len(in) == 0 {
+		return []string{""}
+	}
+	return in
+}
+
+// subjectHoldsClusterAdmin returns true when the subject either holds a wildcard
+// grant (`*` verbs on `*` resources in `*` apiGroups) or is directly bound to the
+// built-in cluster-admin ClusterRole. Either case means "this principal is one
+// kubectl command from total cluster control"; we surface the card unconditionally
+// so the operator sees it. The bindings slice is pre-computed in
+// buildPerSubjectCapabilities to avoid a second walk.
+func subjectHoldsClusterAdmin(perms *permissions.EffectivePermissions, bindings []string) bool {
+	for _, b := range bindings {
+		if strings.Contains(b, "ClusterRole/cluster-admin") {
+			return true
+		}
+	}
+	for _, r := range perms.Rules {
+		if hasWildcard(r.Verbs) && hasWildcard(r.Resources) && hasWildcardOrEmpty(r.APIGroups) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasWildcard returns true when the slice contains "*".
+func hasWildcard(in []string) bool {
+	for _, s := range in {
+		if s == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasWildcardOrEmpty returns true when the slice is empty (some RBAC authors treat
+// `apiGroups: []` as "all") or contains "*".
+func hasWildcardOrEmpty(in []string) bool {
+	if len(in) == 0 {
+		return true
+	}
+	return hasWildcard(in)
 }
 
 // wildcardTriples decodes a WILDCARD-USED-PARTIAL evidence payload into used/unused

--- a/internal/report/leastprivilege_section_test.go
+++ b/internal/report/leastprivilege_section_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -152,4 +153,194 @@ func TestBuildClusterAdminInventoryEmpty(t *testing.T) {
 	if rows := buildClusterAdminInventory(models.Snapshot{}); rows != nil {
 		t.Fatalf("empty snapshot should produce no rows, got: %+v", rows)
 	}
+}
+
+// snapshotWithReaderSA is a small fixture used by the per-subject capability
+// tests: one ServiceAccount bound to a ClusterRole that grants get/list on
+// secrets and create on pods, plus a User bound to cluster-admin so we can
+// assert the "holds cluster-admin equivalent" filter fires for that case too.
+func snapshotWithReaderSA() models.Snapshot {
+	return models.Snapshot{
+		Resources: models.SnapshotResources{
+			ClusterRoles: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "reader-role"},
+					Rules: []rbacv1.PolicyRule{
+						{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}},
+						{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"create"}},
+					},
+				},
+			},
+			ClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "reader-binding"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "reader-role"},
+					Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "default", Name: "reader"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "ops-admin"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+					Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice@example.com"}},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildPerSubjectCapabilitiesIncludesFindingSubject(t *testing.T) {
+	snap := snapshotWithReaderSA()
+	findings := []models.Finding{
+		{
+			ID:       "X:1",
+			RuleID:   "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS",
+			Severity: models.SeverityHigh,
+			Subject:  &models.SubjectRef{Kind: "ServiceAccount", Namespace: "default", Name: "reader"},
+			EscalationPath: []models.EscalationHop{
+				{
+					Step:        1,
+					Action:      "read_secrets",
+					FromSubject: models.SubjectRef{Kind: "ServiceAccount", Namespace: "default", Name: "reader"},
+					ToSubject:   models.SubjectRef{}, // sink — empty by design
+					Permission:  "get,list secrets",
+				},
+			},
+		},
+	}
+	cards := buildPerSubjectCapabilities(snap, findings)
+	if len(cards) == 0 {
+		t.Fatalf("expected at least one card, got 0")
+	}
+	// Reader SA (chain-amplified) must come first because of the privesc finding.
+	if cards[0].SubjectName != "reader" || cards[0].SubjectKind != "ServiceAccount" {
+		t.Fatalf("expected reader SA card first, got %+v", cards[0])
+	}
+	if !cards[0].ChainAmplified {
+		t.Fatalf("expected reader card to be chain-amplified, got %+v", cards[0])
+	}
+	if len(cards[0].PrivescPaths) != 1 {
+		t.Fatalf("expected 1 privesc summary, got %d: %+v", len(cards[0].PrivescPaths), cards[0].PrivescPaths)
+	}
+	if !strings.Contains(cards[0].PrivescPaths[0], "kube_system_secrets") {
+		t.Fatalf("expected privesc summary to mention sink, got %q", cards[0].PrivescPaths[0])
+	}
+	if len(cards[0].EffectiveRules) != 2 {
+		t.Fatalf("expected 2 collapsed effective-rule rows, got %d: %+v", len(cards[0].EffectiveRules), cards[0].EffectiveRules)
+	}
+	// Effective rules collapse verb-by-resource: "create on pods" and "get,list on secrets".
+	gotRules := strings.Join(cards[0].EffectiveRules, "|")
+	if !strings.Contains(gotRules, "create on pods@core") || !strings.Contains(gotRules, "get,list on secrets@core") {
+		t.Fatalf("expected collapsed rules, got %q", gotRules)
+	}
+	if len(cards[0].Bindings) != 1 || !strings.Contains(cards[0].Bindings[0], "ClusterRoleBinding/reader-binding") {
+		t.Fatalf("expected reader binding label, got %+v", cards[0].Bindings)
+	}
+}
+
+func TestBuildPerSubjectCapabilitiesIncludesClusterAdminWithoutFinding(t *testing.T) {
+	snap := snapshotWithReaderSA()
+	cards := buildPerSubjectCapabilities(snap, nil)
+	// No findings at all: only the User bound to cluster-admin should produce a
+	// card (the reader SA's grants don't include any cluster-admin-equivalent
+	// rules, so it gets filtered out when there's no finding either).
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card (the cluster-admin User), got %d: %+v", len(cards), cards)
+	}
+	if cards[0].SubjectKind != "User" || cards[0].SubjectName != "alice@example.com" {
+		t.Fatalf("expected cluster-admin User card, got %+v", cards[0])
+	}
+	if cards[0].ChainAmplified {
+		t.Fatalf("cluster-admin User has no finding-based chain, should not be amplified, got %+v", cards[0])
+	}
+}
+
+func TestBuildPerSubjectCapabilitiesFiltersUnboundSubjects(t *testing.T) {
+	// Snapshot with no bindings → no cards regardless of findings.
+	if cards := buildPerSubjectCapabilities(models.Snapshot{}, nil); cards != nil {
+		t.Fatalf("expected nil cards for empty snapshot, got %+v", cards)
+	}
+}
+
+func TestCollapseEffectiveRulesCollapsesByResource(t *testing.T) {
+	rules := []permissions.EffectiveRule{
+		{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+		{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"watch"}},
+		{APIGroups: []string{"apps"}, Resources: []string{"deployments"}, Verbs: []string{"create"}},
+	}
+	verbs, rows := collapseEffectiveRules(rules)
+	wantVerbs := []string{"create", "get", "list", "watch"}
+	if !equalStrings(verbs, wantVerbs) {
+		t.Fatalf("expected dedup verbs %v, got %v", wantVerbs, verbs)
+	}
+	want := []string{
+		"create on deployments@apps",
+		"get,list,watch on pods@core",
+	}
+	if !equalStrings(rows, want) {
+		t.Fatalf("expected collapsed rows %v, got %v", want, rows)
+	}
+}
+
+func TestSubjectHoldsClusterAdminViaBinding(t *testing.T) {
+	perms := &permissions.EffectivePermissions{}
+	bindings := []string{"ClusterRoleBinding/foo -> ClusterRole/cluster-admin"}
+	if !subjectHoldsClusterAdmin(perms, bindings) {
+		t.Fatalf("expected cluster-admin binding to match")
+	}
+}
+
+func TestSubjectHoldsClusterAdminViaWildcard(t *testing.T) {
+	perms := &permissions.EffectivePermissions{
+		Rules: []permissions.EffectiveRule{
+			{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+		},
+	}
+	if !subjectHoldsClusterAdmin(perms, nil) {
+		t.Fatalf("expected wildcard-on-everything to match")
+	}
+	// Narrowed rule must not match.
+	perms.Rules = []permissions.EffectiveRule{
+		{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+	}
+	if subjectHoldsClusterAdmin(perms, nil) {
+		t.Fatalf("expected non-wildcard rule to not match")
+	}
+}
+
+func TestSummarizePrivescPathSinkFallback(t *testing.T) {
+	f := models.Finding{
+		RuleID:   "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS",
+		Severity: models.SeverityHigh,
+		EscalationPath: []models.EscalationHop{
+			{
+				Action:      "read_secrets",
+				FromSubject: models.SubjectRef{Kind: "ServiceAccount", Namespace: "default", Name: "reader"},
+				ToSubject:   models.SubjectRef{}, // empty sink
+			},
+		},
+	}
+	got := summarizePrivescPath(f)
+	if !strings.Contains(got, "kube_system_secrets") {
+		t.Fatalf("expected sink name in summary, got %q", got)
+	}
+	if !strings.Contains(got, "ServiceAccount default/reader") {
+		t.Fatalf("expected source label in summary, got %q", got)
+	}
+	if !strings.Contains(got, "1 hop") {
+		t.Fatalf("expected hop count in summary, got %q", got)
+	}
+}
+
+// equalStrings reports whether two string slices are element-wise equal. Inline
+// because the tests file would otherwise depend on a third-party comparator and
+// the slices here are tiny.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -253,16 +253,6 @@ func buildTopFixes(_ []models.Finding) []TopFix {
 	return nil
 }
 
-// buildPerSubjectCapabilities is the Wave 0 stub for the per-ServiceAccount
-// "what can this principal actually do" capability cards
-// (STRATEGY.md:32, plan slot W1 #7). Wave 1 will read aggregated EffectiveRules
-// from internal/permissions/aggregate.go plus the privesc paths originating
-// from each subject. Returns nil for now so the {{ if .SubjectCapCards }}
-// template gate suppresses the section.
-func buildPerSubjectCapabilities(_ models.Snapshot, _ []models.Finding) []SubjectCapabilityCard {
-	return nil
-}
-
 // BuildScoringTooltip is the Wave 0 helper that converts a finding into the
 // ScoringBreakdown surfaced in the HTML score tooltip (STRATEGY.md:155, plan
 // slot W1 #6). When ScoreFactors is nil (the legacy hand-picked-score path),

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -416,9 +416,14 @@ type ScoringBreakdown struct {
 // aggregated EffectiveRules plus any privesc paths originating from that
 // subject (STRATEGY.md:32, plan slot W1 #7). The Cloudsplaining-equivalent
 // "what can this principal actually do" view, scoped to RBAC subjects rather
-// than IAM principals. Populated by buildPerSubjectCapabilities in summary.go;
-// Wave 0 stub returns nil so the {{ if .SubjectCapCards }} template gate keeps
-// the section absent.
+// than IAM principals. Populated by buildPerSubjectCapabilities in
+// leastprivilege_section.go.
+//
+// Bindings is the deduped list of (Cluster)Role names the subject is bound to
+// (rendered as "RoleBinding -> Role/<name>" / "ClusterRoleBinding -> ClusterRole/<name>").
+// ChainAmplified is true when at least one privesc path originates from this
+// subject; the template surfaces a badge so operators can prioritize subjects
+// with exploitable chains over those whose grants are merely broad.
 type SubjectCapabilityCard struct {
 	SubjectKind     string
 	SubjectName     string
@@ -426,7 +431,9 @@ type SubjectCapabilityCard struct {
 	SubjectLabel    string // pre-rendered display string e.g. "ServiceAccount/default/builder"
 	EffectiveVerbs  []string
 	EffectiveRules  []string // pre-rendered "verbs on resources@apiGroup" strings
+	Bindings        []string // pre-rendered "ClusterRoleBinding/<name> -> ClusterRole/<role>" strings
 	PrivescPaths    []string // chain summaries originating from this subject
+	ChainAmplified  bool     // true iff PrivescPaths is non-empty
 	HighestSeverity models.Severity
 }
 


### PR DESCRIPTION
## Summary

Plan slot #7 (Track B, plan file: `.claude/plans/use-plan-md-strategy-md-and-think-frolicking-waffle.md`; STRATEGY.md:32).

Fills the Wave 0 `buildPerSubjectCapabilities` stub in `internal/report/leastprivilege_section.go` so each RBAC subject gets a Cloudsplaining-style "what can this principal actually do AND where does it lead" card inside the existing Least Privilege tab.

Each card surfaces:
- Subject identity (Kind + namespace + name)
- `Bindings`: every (Cluster)RoleBinding that grants the subject its permissions
- `Effective verbs`: deduped verb set across all bound roles
- `Effective rules`: granular RBAC rules collapsed into one row per `(resource, apiGroup)` pair (so the card reads "get,list,watch on pods@core" rather than three separate rules)
- `Privesc paths originating here`: one-line summary per `KUBE-PRIVESC-PATH-*` finding from this subject, with the sink slug as the destination label when the analyzer's `ToSubject` is empty (synthetic sinks like `kube_system_secrets`)
- A `chain-amplified` badge when at least one privesc path originates from the subject

Filter: only subjects that fire at least one finding OR hold a cluster-admin-equivalent grant (wildcard verbs on wildcard resources, or direct binding to the built-in `cluster-admin` ClusterRole) get a card. Sort puts chain-amplified subjects first, then by highest severity, then by label.

Markup moves from the Wave 0 placeholder (which lived in the Overview tab area) into the `#tab-leastprivilege` block, below the three existing summary tables and above the per-subject `lp-group` cards.

## Files

- `internal/report/leastprivilege_section.go`: filled `buildPerSubjectCapabilities` + helpers (`summarizePrivescPath`, `collapseEffectiveRules`, `subjectHoldsClusterAdmin`, `pluralizeHops`, `zeroOrSelf`, `hasWildcard*`).
- `internal/report/leastprivilege_section_test.go`: added 7 tests covering finding-driven inclusion, cluster-admin-only inclusion, empty-snapshot filter, rule collapse, wildcard / binding cluster-admin detection, and sink-fallback summarization.
- `internal/report/types.go`: extended `SubjectCapabilityCard` with `Bindings []string` and `ChainAmplified bool`.
- `internal/report/summary.go`: removed the now-obsolete Wave 0 stub.
- `internal/report/assets/report.html.tmpl`: moved the cards section into `#tab-leastprivilege` and extended the markup with the new fields plus a `chain-amplified` badge.

## Test plan

- [x] `make build` clean
- [x] `make test` — all packages green, including the 7 new tests under `internal/report`
- [x] `make lint` — gofmt + go vet clean
- [x] `./bin/golangci-lint run ./...` — 0 issues
- [x] Visual: `./bin/kubesplaining scan --input-file testdata/snapshots/minimal-risky.json` renders 1 card (the `reader` SA with its 1-hop `KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS` chain, chain-amplified badge, 2 collapsed rules)
- [x] Visual: same run against `testdata/snapshots/leastprivilege-demo.json` renders 5 cards
- [ ] `make e2e`: environment-blocked in this worktree (the docker host is OOMing kubeadm init due to competing kind clusters from parallel slot runs). No e2e fixtures or scripts were touched; the test suite covers the new code path.