### PR TITLE
feat(network): cross-ns map + IMDS-endpoint egress detection

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -58,8 +58,8 @@ Legend: `[x]` done · `[~]` partial · `[ ]` not started. Partial items list wha
 
 ### Network Policy — [internal/analyzer/network/](internal/analyzer/network/analyzer.go)
 - [x] Coverage & weakness (default-allow, namespace-wide allow)
-- [ ] Cross-namespace communication map
-- [ ] Egress-to-metadata-endpoint (`169.254.169.254`) detection
+- [x] Cross-namespace communication map (KUBE-NETPOL-CROSSNS-001)
+- [x] Egress-to-metadata-endpoint (`169.254.169.254`) detection (KUBE-NETPOL-IMDS-001)
 
 ### Secrets & ConfigMaps — [internal/analyzer/secrets/](internal/analyzer/secrets/analyzer.go)
 - [x] Long-lived SA token secrets, excessive secret access

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -65,9 +65,11 @@ These rules compare granted RBAC permissions against observed usage from a kube-
 | --- | --- | --- | --- | --- |
 | KUBE-NETPOL-COVERAGE-001 | HIGH | Namespace has no NetworkPolicies | Non-system namespace with zero policies | Add a default-deny, then allow explicitly |
 | KUBE-NETPOL-WEAKNESS-002 | HIGH | NetworkPolicy permits internet egress | Egress rule targets `0.0.0.0/0` or `::/0` | Restrict to required CIDRs or services |
+| KUBE-NETPOL-IMDS-001 | HIGH | Workload egress can reach cloud IMDS `169.254.169.254` | No egress policy applies OR an explicit ipBlock admits the IMDS endpoint without an `except:` carve-out | Apply a default-deny-egress policy and carve out IMDS with `except: [169.254.169.254/32]`; pair with IMDSv2 hop-limit = 1 |
 | KUBE-NETPOL-COVERAGE-002 | MEDIUM | Workload is not selected by any NetworkPolicy | Pod in a policy-bearing namespace but no policy matches it | Add a selector or apply a baseline policy |
 | KUBE-NETPOL-COVERAGE-003 | MEDIUM | Ingress policies present but egress remains open | Namespace has ingress rules but no egress | Add explicit egress rules or a default-deny egress |
 | KUBE-NETPOL-WEAKNESS-001 | MEDIUM | NetworkPolicy allows ingress from all namespaces | Empty namespace selector in ingress | Use explicit namespace labels |
+| KUBE-NETPOL-CROSSNS-001 | MEDIUM | NetworkPolicy bridges a sensitive namespace | Ingress or egress peer's `namespaceSelector` matches a sensitive namespace (`kube-system`, `kube-public`, `kube-node-lease`, `default`, `gatekeeper-system`) other than the policy's own, or is empty (matches all) | Replace the cross-namespace peer with a narrow `matchLabels` + `podSelector` pair |
 
 ### Admission Webhooks ([internal/analyzer/admission/analyzer.go](../internal/analyzer/admission/analyzer.go))
 

--- a/internal/analyzer/network/analyzer.go
+++ b/internal/analyzer/network/analyzer.go
@@ -107,6 +107,20 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		}
 	}
 
+	// KUBE-NETPOL-CROSSNS-001 — cross-namespace peers involving a sensitive namespace.
+	// Lives in crossns.go so it can grow without bloating the main Analyze method.
+	for _, finding := range emitCrossNSFindings(findCrossNamespacePairs(snapshot)) {
+		findings = appendUnique(findings, seen, finding)
+	}
+
+	// KUBE-NETPOL-IMDS-001 — workload egress can reach 169.254.169.254. The check
+	// reuses the same workload list assembled above so the same exclusion semantics
+	// apply (controller-owned pods are dropped in favor of their workload). Lives
+	// in imds_egress.go for the same hygiene reason as crossns.
+	for _, finding := range emitImdsFindings(findImdsReachable(snapshot, workloads)) {
+		findings = appendUnique(findings, seen, finding)
+	}
+
 	return findings, nil
 }
 

--- a/internal/analyzer/network/content.go
+++ b/internal/analyzer/network/content.go
@@ -41,6 +41,8 @@ var (
 	refNetworkPolicies = models.Reference{Title: "Kubernetes — Network Policies", URL: "https://kubernetes.io/docs/concepts/services-networking/network-policies/"}
 	refCISBenchmark532 = models.Reference{Title: "CIS Kubernetes Benchmark 5.3.2 — All namespaces should have NetworkPolicies", URL: "https://www.cisecurity.org/benchmark/kubernetes"}
 	refNSAHardening    = models.Reference{Title: "NSA/CISA Kubernetes Hardening Guidance v1.2 (PDF)", URL: "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"}
+	refIMDSv2          = models.Reference{Title: "AWS — Use IMDSv2 and the metadata hop-limit", URL: "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-existing-instances.html"}
+	refEKSIMDSPrivesc  = models.Reference{Title: "Christophe Tafani-Dereeper — EKS privilege escalation via worker node IAM", URL: "https://blog.christophetd.fr/privilege-escalation-in-aws-elastic-kubernetes-service-eks-by-compromising-the-instance-role-of-worker-nodes/"}
 )
 
 func contentNetpolCoverage001(namespace string) ruleContent {
@@ -221,5 +223,130 @@ func contentNetpolWeakness001(namespace, policyName string) ruleContent {
 			{Title: "vCluster — NetworkPolicies for multi-tenant isolation", URL: "https://www.vcluster.com/blog/kubernetes-network-policies-for-isolating-namespaces"},
 		},
 		MitreTechniques: []models.MitreTechnique{mitreT1046, mitreT1018, mitreT1090, mitreT1078_004},
+	}
+}
+
+// contentNetpolCrossNS001 is the rule prose for KUBE-NETPOL-CROSSNS-001 (Cross-namespace
+// communication map). One entry per (sourceNS, targetNS, direction) tuple where at least
+// one endpoint is a sensitive namespace (kube-system / kube-public / kube-node-lease /
+// default / gatekeeper-system) or where the peer's namespaceSelector is empty.
+func contentNetpolCrossNS001(pair crossNSPair) ruleContent {
+	sourceLabel := pair.SourceNS
+	if sourceLabel == "*" {
+		sourceLabel = "every namespace in the cluster"
+	}
+	directionLabel := "ingress from"
+	if pair.Direction == directionEgress {
+		directionLabel = "egress to"
+	}
+
+	return ruleContent{
+		Title: fmt.Sprintf("NetworkPolicy `%s/%s` opens cross-namespace %s `%s` (target `%s`)", pair.PolicyNamespace, pair.PolicyName, pair.Direction, sourceLabel, pair.TargetNS),
+		Scope: models.Scope{
+			Level:  models.ScopeObject,
+			Detail: fmt.Sprintf("NetworkPolicy `%s/%s`: cross-namespace %s `%s`", pair.PolicyNamespace, pair.PolicyName, directionLabel, sourceLabel),
+		},
+		Description: fmt.Sprintf("NetworkPolicy `%s/%s` declares a peer that crosses a namespace boundary. The %s rule references `%s`, which is a different namespace from the policy's own `%s` and either the source or the target is a *sensitive* namespace (a control-plane namespace such as `kube-system`, `kube-public`, or `kube-node-lease`, the implicit `default` namespace, or `gatekeeper-system`).\n\n"+
+			"Namespace boundaries are the cheapest soft-tenancy primitive Kubernetes offers. A cross-namespace allow rule that pierces one of the sensitive namespaces is structurally suspicious because those namespaces tend to host either the cluster control plane (kube-system DaemonSets, the kubelet's apiserver client) or the catch-all destination for workloads that omit `metadata.namespace`. Tenancy-aware operators want explicit, narrowly-labeled selectors for these edges, not a broad cross-NS allow.\n\n"+
+			"In particular, an *ingress* rule that admits `kube-system` (or `*` / every namespace) gives every control-plane pod a path into the selected workload. An *egress* rule that admits traffic back into `kube-system` lets a compromised pod talk to control-plane services (CoreDNS, kube-proxy sidecars) that may run with elevated privilege or expose admin-only endpoints. The wildcard form (`namespaceSelector: {}`) is the worst variant: it matches every present and future namespace, so future tenants are silently bridged the moment they are created.",
+			pair.PolicyNamespace, pair.PolicyName, pair.Direction, sourceLabel, pair.PolicyNamespace),
+		Impact: fmt.Sprintf("Workloads selected by `%s` participate in cross-namespace traffic with `%s`, bypassing namespace-level isolation between tenants. The blast radius grows when the bridged namespace is a control-plane namespace because the bridge crosses a privilege boundary as well as a tenancy boundary.", pair.PolicyName, sourceLabel),
+		AttackScenario: []string{
+			fmt.Sprintf("Attacker compromises any pod in `%s` (or any namespace, when the source is `*`).", sourceLabel),
+			fmt.Sprintf("They open a TCP connection to the pods selected by `%s.spec.podSelector` in `%s`. The cross-namespace allow rule matches, so the connection succeeds when other tenant pods would be denied.", pair.PolicyName, pair.TargetNS),
+			fmt.Sprintf("They exploit an application-layer issue on the now-reachable port (auth bypass, weak credential, RCE) and gain a foothold in `%s`.", pair.TargetNS),
+			fmt.Sprintf("From `%s`, they pivot using mounted ServiceAccount tokens, in-namespace secrets, and any further allow rules that originate from this newly-owned pod.", pair.TargetNS),
+			"If the bridged namespace was a control-plane namespace, the attacker now has a usable position adjacent to control-plane services and can attempt to enumerate or impersonate the more privileged identities those services run as.",
+		},
+		Remediation: "Replace the cross-namespace peer with an explicit, narrowly-labeled `namespaceSelector` and a sibling `podSelector` that names the small set of pods that legitimately need this traffic, and confirm with the platform team whether the bridge is required at all.",
+		RemediationSteps: []string{
+			fmt.Sprintf("Audit `%s/%s` and confirm whether the cross-namespace allow rule is intentional. Most cross-NS rules touching `kube-system` / `default` are leftovers from a debug session.", pair.PolicyNamespace, pair.PolicyName),
+			"If the bridge is not intentional, delete the offending peer (`kubectl edit netpol`).",
+			"If the bridge is intentional, label the source namespace with a stable, policy-meaningful key (e.g., `tenancy.example.com/role: shared-egress`) and switch the peer to `matchLabels` for that key paired with a `podSelector`.",
+			fmt.Sprintf("Validate from a netshoot pod in `%s`: confirm allowed connections succeed and unrelated namespaces are still denied.", pair.TargetNS),
+			"Add a Kyverno or Gatekeeper rule that warns on any new NetworkPolicy whose `namespaceSelector` matches `kube-system` / `kube-public` / `default` or is empty.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			{Title: "Kubernetes — Pod-to-Pod Communication semantics", URL: "https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors"},
+			{Title: "vCluster — NetworkPolicies for multi-tenant isolation", URL: "https://www.vcluster.com/blog/kubernetes-network-policies-for-isolating-namespaces"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1046, mitreT1018, mitreT1090, mitreT1078_004},
+	}
+}
+
+// contentNetpolIMDS001 is the rule prose for KUBE-NETPOL-IMDS-001 (workload egress can
+// reach 169.254.169.254). One entry per workload; renders slightly differently depending
+// on whether the cause is "no egress policy applies" or "an explicit allow rule includes
+// the IMDS endpoint".
+func contentNetpolIMDS001(item imdsFinding) ruleContent {
+	wl := item.Workload
+	rid := fmt.Sprintf("%s/%s/%s", wl.Kind, wl.Namespace, wl.Name)
+
+	var (
+		title       string
+		description string
+		impact      string
+		scenario    []string
+	)
+
+	switch item.Reason {
+	case imdsReasonNoEgressPolicy:
+		title = fmt.Sprintf("Workload `%s` has no egress NetworkPolicy, so 169.254.169.254 (cloud IMDS) is reachable", rid)
+		description = fmt.Sprintf("Workload `%s` runs in namespace `%s` and is not selected by any NetworkPolicy with `policyTypes: [Egress]`. Kubernetes' default for non-isolated pods is allow-all egress, so this pod can open TCP/UDP connections to any destination, including the link-local cloud Instance Metadata Service at `169.254.169.254`.\n\n"+
+			"IMDS is the single most attacked egress destination in cloud Kubernetes. On AWS, a pod that can reach `169.254.169.254/latest/meta-data/iam/security-credentials/` can mint the node's IAM role credentials and pivot from container RCE to full cloud-account compromise. The same primitive exists on Azure (`169.254.169.254/metadata/instance`) and GCP (`metadata.google.internal`, served from the same link-local IP). IMDSv2 with `hop-limit = 1` (AWS) is the node-level defense, but a NetworkPolicy egress deny is the cluster-level defense and the only one a Kubernetes operator controls directly.\n\n"+
+			"The fix is to put the workload under an egress NetworkPolicy that, at a minimum, denies the IMDS range. The strongest pattern is a namespace-wide default-deny-egress baseline plus narrow per-workload allow rules; the more incremental pattern is a single namespace-wide NetworkPolicy that selects `podSelector: {}` and lists every allowed peer except an `ipBlock 0.0.0.0/0` with `except: [169.254.169.254/32]`.",
+			rid, wl.Namespace)
+		impact = "A compromised pod (RCE, leaked credential, sidecar SSRF) can scrape node IAM credentials from IMDS within seconds, escalating from container compromise to cloud-account compromise."
+		scenario = []string{
+			fmt.Sprintf("Attacker gains RCE in `%s` via an application vulnerability (e.g., SSRF, dependency exploit).", rid),
+			"They send an IMDSv1 request: `curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/`. The request is not blocked because no egress policy applies.",
+			"They use the returned IAM credentials with `aws sts get-caller-identity` to confirm the role, then enumerate the cloud account (S3 buckets, RDS, IAM users).",
+			"They exfiltrate secrets and pivot inside the cloud account using the worker node's role permissions.",
+			"They optionally open an outbound C2 channel to attacker infrastructure; the same lack of egress restriction allows the outbound TLS connection.",
+		}
+	case imdsReasonExplicitAllow:
+		offender := item.OffenderCIDR
+		offenderPolicy := fmt.Sprintf("%s/%s", item.OffenderPolicyNamespace, item.OffenderPolicyName)
+		title = fmt.Sprintf("Workload `%s` has an egress policy whose `ipBlock: %s` admits cloud IMDS (`169.254.169.254`)", rid, offender)
+		description = fmt.Sprintf("Workload `%s` is selected by NetworkPolicy `%s`, which contains an egress `to:` peer with `ipBlock.cidr: %s`. That CIDR includes `169.254.169.254` and the policy's `except:` list does not carve it out, so the cloud Instance Metadata Service is reachable from the selected pods.\n\n"+
+			"This is the most common foot-gun in egress policies. Operators often add `ipBlock: 0.0.0.0/0` (or `169.254.0.0/16`, the full link-local range) to allow \"general internet\" or \"any AWS API\" reach, not realizing that the link-local IMDS endpoint is included in the same range. The defense is to add an `except: [169.254.169.254/32]` carve-out (or to use a narrower allow ipBlock that does not include link-local at all).\n\n"+
+			"On AWS the second-layer defense is IMDSv2 with hop-limit = 1, which blocks pods on the host network from reaching IMDS via the node's address. But hop-limit only helps when the cluster-level NetworkPolicy is also in place; a pod with explicit egress to `0.0.0.0/0` can still construct an IMDSv2 request when the hop-limit allows it.",
+			rid, offenderPolicy, offender)
+		impact = "Despite having an egress NetworkPolicy in place, the workload retains a usable path to cloud IMDS. Container RCE -> cloud-account compromise stays one curl away."
+		scenario = []string{
+			fmt.Sprintf("Attacker compromises a pod selected by `%s.spec.podSelector` (the policy that admits IMDS).", offenderPolicy),
+			fmt.Sprintf("They reach IMDS at `http://169.254.169.254/latest/meta-data/iam/security-credentials/` because the `ipBlock: %s` allow rule includes the IMDS IP.", offender),
+			"They exfiltrate the worker node's IAM credentials and pivot into the cloud account.",
+			"The NetworkPolicy gives operators a false sense of \"egress is restricted\" while the most dangerous destination is still reachable.",
+			"On AWS specifically, IMDSv2 hop-limit = 1 may have been deployed at the node level, but the NetworkPolicy's broad ipBlock means the pod can still issue an IMDSv2 token request that the hop-limit permits.",
+		}
+	}
+
+	return ruleContent{
+		Title: title,
+		Scope: models.Scope{
+			Level:  models.ScopeWorkload,
+			Detail: fmt.Sprintf("Workload `%s`: egress to `%s` is reachable.", rid, imdsIP),
+		},
+		Description:    description,
+		Impact:         impact,
+		AttackScenario: scenario,
+		Remediation:    "Apply or tighten an egress NetworkPolicy in the workload's namespace that denies `169.254.169.254/32` explicitly, and pair it with IMDSv2 hop-limit = 1 at the node layer.",
+		RemediationSteps: []string{
+			fmt.Sprintf("Apply a default-deny-egress policy in `%s` (`podSelector: {}`, `policyTypes: [Egress]`).", wl.Namespace),
+			"Add an explicit DNS allow policy (UDP/TCP 53 to kube-system) so application hostname resolution still works.",
+			"For each workload that requires legitimate outbound, add a tight `to:` clause. Prefer `namespaceSelector + podSelector` for in-cluster destinations and an `ipBlock` with `except: [169.254.169.254/32]` for genuine internet reach.",
+			fmt.Sprintf("Validate from inside the pod: `kubectl exec %s -n %s -- curl --max-time 3 http://169.254.169.254/` must time out.", wl.Name, wl.Namespace),
+			"On AWS, set the launch-template `HttpPutResponseHopLimit = 1` so IMDSv2 token requests from pods routed via the node's network namespace are denied at the hypervisor.",
+			"Add a Kyverno or Gatekeeper policy that rejects any new NetworkPolicy whose egress ipBlock contains `169.254.169.254` without an `except:` carve-out.",
+		},
+		LearnMore: []models.Reference{
+			refNetworkPolicies,
+			refIMDSv2,
+			refEKSIMDSPrivesc,
+			{Title: "Calico GlobalNetworkPolicy reference", URL: "https://docs.tigera.io/calico/latest/reference/resources/globalnetworkpolicy"},
+		},
+		MitreTechniques: []models.MitreTechnique{mitreT1552_005, mitreT1078_004, mitreT1041, mitreT1071},
 	}
 }

--- a/internal/analyzer/network/crossns.go
+++ b/internal/analyzer/network/crossns.go
@@ -1,0 +1,273 @@
+// Cross-namespace NetworkPolicy analysis. Looks at every NetworkPolicy and reports
+// when its peer rules explicitly grant ingress or egress that crosses a namespace
+// boundary involving a sensitive namespace (kube-system, kube-public, kube-node-lease,
+// default). The intent is to surface the soft-tenancy violations that look fine in
+// "kubectl get netpol" — a policy in `team-a` that allows traffic from `kube-system`
+// is structurally suspicious because it pierces the cluster's strongest cheap
+// isolation boundary.
+//
+// Detection model. For each NetworkPolicy P in namespace `polNS`:
+//   - For each ingress.from peer:
+//   - If peer.namespaceSelector matches a namespace `peerNS` other than `polNS`,
+//     the pair is (peerNS -> polNS) ingress.
+//   - If peer.namespaceSelector is empty (`{}`), it matches every namespace, so
+//     the pair is (any -> polNS) ingress (we surface this as `*` in the source).
+//   - For each egress.to peer:
+//   - Symmetric: matched namespace becomes the destination, polNS the source.
+//
+// We emit a finding only when at least one of `polNS` or the peer namespace is
+// sensitive. The shared isSystemNamespace helper in analyzer.go enumerates the
+// system set; we add `default` here because user-created workloads land there
+// when no explicit namespace is set, so any rule that bridges `default` to a
+// tenant namespace deserves a note.
+//
+// Severity: MEDIUM. Cross-namespace allow rules are sometimes legitimate
+// (a logging sidecar in kube-system scraping app namespaces) but they are
+// almost always worth a second look in a multi-tenant cluster, so we lean
+// toward surfacing rather than suppressing.
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/scoring"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// crossNSDirection enumerates ingress vs egress so the finding ID and prose
+// can both render the direction crisply.
+type crossNSDirection string
+
+const (
+	directionIngress crossNSDirection = "ingress"
+	directionEgress  crossNSDirection = "egress"
+)
+
+// crossNSPair is one (sourceNS, targetNS, direction) tuple emitted as a finding.
+// SourceNS may be "*" when the peer's namespaceSelector is empty (matches all).
+type crossNSPair struct {
+	PolicyNamespace string
+	PolicyName      string
+	SourceNS        string
+	TargetNS        string
+	Direction       crossNSDirection
+}
+
+// findCrossNamespacePairs walks every NetworkPolicy and returns the deduplicated
+// (sourceNS, targetNS, direction) tuples whose endpoints involve a sensitive
+// namespace. The returned slice is sorted for determinism so finding IDs are
+// stable across runs.
+func findCrossNamespacePairs(snapshot models.Snapshot) []crossNSPair {
+	namespacesByLabels := indexNamespaces(snapshot.Resources.Namespaces)
+	seen := map[string]struct{}{}
+	out := make([]crossNSPair, 0)
+
+	for _, policy := range snapshot.Resources.NetworkPolicies {
+		polNS := policy.Namespace
+
+		for _, ingress := range policy.Spec.Ingress {
+			for _, peer := range ingress.From {
+				for _, ns := range peerNamespaces(peer, namespacesByLabels) {
+					if !isCrossNamespace(ns, polNS) {
+						continue
+					}
+					if !pairTouchesSensitive(ns, polNS) {
+						continue
+					}
+					pair := crossNSPair{
+						PolicyNamespace: polNS,
+						PolicyName:      policy.Name,
+						SourceNS:        ns,
+						TargetNS:        polNS,
+						Direction:       directionIngress,
+					}
+					key := pairKey(pair)
+					if _, ok := seen[key]; ok {
+						continue
+					}
+					seen[key] = struct{}{}
+					out = append(out, pair)
+				}
+			}
+		}
+
+		for _, egress := range policy.Spec.Egress {
+			for _, peer := range egress.To {
+				for _, ns := range peerNamespaces(peer, namespacesByLabels) {
+					if !isCrossNamespace(ns, polNS) {
+						continue
+					}
+					if !pairTouchesSensitive(ns, polNS) {
+						continue
+					}
+					pair := crossNSPair{
+						PolicyNamespace: polNS,
+						PolicyName:      policy.Name,
+						SourceNS:        polNS,
+						TargetNS:        ns,
+						Direction:       directionEgress,
+					}
+					key := pairKey(pair)
+					if _, ok := seen[key]; ok {
+						continue
+					}
+					seen[key] = struct{}{}
+					out = append(out, pair)
+				}
+			}
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].PolicyNamespace != out[j].PolicyNamespace {
+			return out[i].PolicyNamespace < out[j].PolicyNamespace
+		}
+		if out[i].PolicyName != out[j].PolicyName {
+			return out[i].PolicyName < out[j].PolicyName
+		}
+		if out[i].Direction != out[j].Direction {
+			return out[i].Direction < out[j].Direction
+		}
+		if out[i].SourceNS != out[j].SourceNS {
+			return out[i].SourceNS < out[j].SourceNS
+		}
+		return out[i].TargetNS < out[j].TargetNS
+	})
+
+	return out
+}
+
+// peerNamespaces returns the namespace name(s) that peer.namespaceSelector
+// resolves to. The returned slice contains:
+//   - "*" when the namespaceSelector is non-nil but empty (matches every namespace
+//     in the cluster, the documented "all namespaces" form).
+//   - One entry per namespace whose labels match a populated namespaceSelector.
+//   - An empty slice when peer.namespaceSelector is nil (peer is "same namespace
+//     plus optional podSelector"; not a cross-NS edge by definition).
+//
+// IPBlock peers do not move us across a namespace boundary at the L7 NetworkPolicy
+// level (they escape to L3) so they are intentionally not considered here. The
+// IMDS check in imds_egress.go handles the cloud-metadata IPBlock case.
+func peerNamespaces(peer networkingv1.NetworkPolicyPeer, namespacesByLabels []corev1.Namespace) []string {
+	if peer.NamespaceSelector == nil {
+		return nil
+	}
+	if isAllNamespaces(peer.NamespaceSelector) {
+		return []string{"*"}
+	}
+	selector, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+	if err != nil {
+		return nil
+	}
+	matches := make([]string, 0)
+	for _, ns := range namespacesByLabels {
+		if selector.Matches(labels.Set(ns.Labels)) {
+			matches = append(matches, ns.Name)
+		}
+	}
+	return matches
+}
+
+// indexNamespaces returns a deterministic slice of namespaces (sorted by name)
+// so callers get stable iteration order.
+func indexNamespaces(namespaces []corev1.Namespace) []corev1.Namespace {
+	out := make([]corev1.Namespace, len(namespaces))
+	copy(out, namespaces)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// isCrossNamespace reports whether the source namespace differs from the policy
+// namespace (i.e., the rule reaches across a namespace boundary). The "*" sentinel
+// (any namespace) is always considered cross-NS.
+func isCrossNamespace(sourceNS, policyNS string) bool {
+	if sourceNS == "*" {
+		return true
+	}
+	return sourceNS != policyNS
+}
+
+// sensitiveCrossNSNamespaces lists namespaces whose involvement in any cross-NS
+// allow rule warrants surfacing the rule. kube-system / kube-public / kube-node-lease
+// are the standard control-plane namespaces; `default` is included because workloads
+// frequently land there when no explicit namespace is set, so allow rules bridging
+// `default` are nearly always misconfigurations rather than intent.
+var sensitiveCrossNSNamespaces = map[string]struct{}{
+	"kube-system":       {},
+	"kube-public":       {},
+	"kube-node-lease":   {},
+	"default":           {},
+	"gatekeeper-system": {},
+}
+
+// pairTouchesSensitive reports whether either endpoint of the (source, target)
+// pair is in the sensitive set. The wildcard "*" is treated as sensitive because
+// it crosses into every namespace, including the sensitive ones.
+func pairTouchesSensitive(a, b string) bool {
+	if a == "*" || b == "*" {
+		return true
+	}
+	if _, ok := sensitiveCrossNSNamespaces[a]; ok {
+		return true
+	}
+	_, ok := sensitiveCrossNSNamespaces[b]
+	return ok
+}
+
+// pairKey returns a stable map key for deduplicating identical findings emitted
+// from distinct policies in the same namespace.
+func pairKey(p crossNSPair) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s", p.PolicyNamespace, p.PolicyName, p.Direction, p.SourceNS, p.TargetNS)
+}
+
+// emitCrossNSFindings materializes one finding per cross-NS pair returned by
+// findCrossNamespacePairs.
+func emitCrossNSFindings(pairs []crossNSPair) []models.Finding {
+	out := make([]models.Finding, 0, len(pairs))
+	for _, pair := range pairs {
+		evidence := map[string]any{
+			"policy_namespace": pair.PolicyNamespace,
+			"policy_name":      pair.PolicyName,
+			"source_namespace": pair.SourceNS,
+			"target_namespace": pair.TargetNS,
+			"direction":        string(pair.Direction),
+		}
+		evidenceBytes, _ := json.Marshal(evidence)
+
+		content := contentNetpolCrossNS001(pair)
+
+		out = append(out, models.Finding{
+			ID:          fmt.Sprintf("KUBE-NETPOL-CROSSNS-001:%s:%s:%s:%s:%s", pair.PolicyNamespace, pair.PolicyName, pair.Direction, pair.SourceNS, pair.TargetNS),
+			RuleID:      "KUBE-NETPOL-CROSSNS-001",
+			Severity:    models.SeverityMedium,
+			Score:       scoring.Clamp(5.4),
+			Category:    models.CategoryLateralMovement,
+			Title:       content.Title,
+			Description: content.Description,
+			Namespace:   pair.PolicyNamespace,
+			Resource: &models.ResourceRef{
+				Kind:      "NetworkPolicy",
+				Name:      pair.PolicyName,
+				Namespace: pair.PolicyNamespace,
+				APIGroup:  networkingv1.GroupName,
+			},
+			Scope:            content.Scope,
+			Impact:           content.Impact,
+			AttackScenario:   content.AttackScenario,
+			Evidence:         evidenceBytes,
+			Remediation:      content.Remediation,
+			RemediationSteps: content.RemediationSteps,
+			References:       referencesFromContent(content),
+			LearnMore:        content.LearnMore,
+			MitreTechniques:  content.MitreTechniques,
+			Tags:             []string{"module:network_policy", "check:crossNamespaceAllow", "direction:" + string(pair.Direction)},
+		})
+	}
+	return out
+}

--- a/internal/analyzer/network/crossns_test.go
+++ b/internal/analyzer/network/crossns_test.go
@@ -1,0 +1,254 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestCrossNSEmitsForSensitiveIngress verifies that a NetworkPolicy in a tenant
+// namespace that admits ingress from kube-system surfaces a KUBE-NETPOL-CROSSNS-001
+// finding pointing at the (kube-system -> tenant) pair.
+func TestCrossNSEmitsForSensitiveIngress(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"kubernetes.io/metadata.name": "kube-system"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "team-a", Labels: map[string]string{"kubernetes.io/metadata.name": "team-a"}}},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-from-kube-system", Namespace: "team-a"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						Ingress: []networkingv1.NetworkPolicyIngressRule{
+							{
+								From: []networkingv1.NetworkPolicyPeer{
+									{NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	if !hasRule(findings, "KUBE-NETPOL-CROSSNS-001") {
+		t.Fatalf("expected KUBE-NETPOL-CROSSNS-001 to fire when policy admits ingress from kube-system, got %v", ruleIDs(findings))
+	}
+
+	got := findRule(findings, "KUBE-NETPOL-CROSSNS-001")
+	if !strings.Contains(string(got.Evidence), `"source_namespace":"kube-system"`) {
+		t.Fatalf("expected source_namespace=kube-system in evidence, got %s", string(got.Evidence))
+	}
+	if !strings.Contains(string(got.Evidence), `"target_namespace":"team-a"`) {
+		t.Fatalf("expected target_namespace=team-a in evidence, got %s", string(got.Evidence))
+	}
+	if !strings.Contains(string(got.Evidence), `"direction":"ingress"`) {
+		t.Fatalf("expected direction=ingress in evidence, got %s", string(got.Evidence))
+	}
+}
+
+// TestCrossNSEmitsForWildcardSelector covers the namespaceSelector:{} wildcard
+// case (matches every namespace) which must always fire because the wildcard
+// pierces every namespace boundary including the sensitive ones.
+func TestCrossNSEmitsForWildcardSelector(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "open-ingress", Namespace: "team-a"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						Ingress: []networkingv1.NetworkPolicyIngressRule{
+							{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	if !hasRule(findings, "KUBE-NETPOL-CROSSNS-001") {
+		t.Fatalf("expected KUBE-NETPOL-CROSSNS-001 to fire on wildcard namespaceSelector, got %v", ruleIDs(findings))
+	}
+	got := findRule(findings, "KUBE-NETPOL-CROSSNS-001")
+	if !strings.Contains(string(got.Evidence), `"source_namespace":"*"`) {
+		t.Fatalf("expected source_namespace=* for wildcard, got %s", string(got.Evidence))
+	}
+}
+
+// TestCrossNSEmitsForEgress mirrors the ingress case for egress: a tenant policy
+// whose egress allows traffic into kube-system surfaces a finding with
+// direction=egress and source=tenant, target=kube-system.
+func TestCrossNSEmitsForEgress(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"kubernetes.io/metadata.name": "kube-system"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "team-a", Labels: map[string]string{"kubernetes.io/metadata.name": "team-a"}}},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "egress-to-kube-system", Namespace: "team-a"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{To: []networkingv1.NetworkPolicyPeer{
+								{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"}}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	got := findRule(findings, "KUBE-NETPOL-CROSSNS-001")
+	if got.RuleID == "" {
+		t.Fatalf("expected KUBE-NETPOL-CROSSNS-001 to fire on egress to kube-system, got %v", ruleIDs(findings))
+	}
+	if !strings.Contains(string(got.Evidence), `"direction":"egress"`) {
+		t.Fatalf("expected direction=egress for egress rule, got %s", string(got.Evidence))
+	}
+	if !strings.Contains(string(got.Evidence), `"source_namespace":"team-a"`) {
+		t.Fatalf("expected source_namespace=team-a (policy namespace) for egress rule, got %s", string(got.Evidence))
+	}
+	if !strings.Contains(string(got.Evidence), `"target_namespace":"kube-system"`) {
+		t.Fatalf("expected target_namespace=kube-system for egress rule, got %s", string(got.Evidence))
+	}
+}
+
+// TestCrossNSSuppressesInsensitivePair makes sure a cross-namespace allow rule
+// between two non-sensitive tenant namespaces does NOT fire (this is the noisy
+// false-positive case the rule is designed to avoid).
+func TestCrossNSSuppressesInsensitivePair(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "team-a", Labels: map[string]string{"tenancy": "a"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "team-b", Labels: map[string]string{"tenancy": "b"}}},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "team-a-to-team-b", Namespace: "team-a"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{To: []networkingv1.NetworkPolicyPeer{
+								{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"tenancy": "b"}}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if hasRule(findings, "KUBE-NETPOL-CROSSNS-001") {
+		t.Fatalf("expected KUBE-NETPOL-CROSSNS-001 to STAY SILENT for tenant<->tenant cross-NS rule, got %v", ruleIDs(findings))
+	}
+}
+
+// TestCrossNSIgnoresSameNamespace covers the negative case where a namespaceSelector
+// matches the policy's own namespace; that's not a cross-NS edge and must not fire.
+func TestCrossNSIgnoresSameNamespace(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"name": "kube-system"}}},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "self-ingress", Namespace: "kube-system"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						Ingress: []networkingv1.NetworkPolicyIngressRule{
+							{From: []networkingv1.NetworkPolicyPeer{
+								{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "kube-system"}}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if hasRule(findings, "KUBE-NETPOL-CROSSNS-001") {
+		t.Fatalf("expected KUBE-NETPOL-CROSSNS-001 NOT to fire for same-namespace selector, got %v", ruleIDs(findings))
+	}
+}
+
+// hasRule reports whether any finding has the given RuleID.
+func hasRule(findings []models.Finding, ruleID string) bool {
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+// findRule returns the first finding with the given RuleID, or zero value when absent.
+func findRule(findings []models.Finding, ruleID string) models.Finding {
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return f
+		}
+	}
+	return models.Finding{}
+}
+
+// ruleIDs is a small helper used in test failure messages.
+func ruleIDs(findings []models.Finding) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.RuleID)
+	}
+	return out
+}

--- a/internal/analyzer/network/imds_egress.go
+++ b/internal/analyzer/network/imds_egress.go
@@ -1,0 +1,252 @@
+// IMDS (Instance Metadata Service) egress reachability analysis.
+//
+// The link-local endpoint 169.254.169.254 (the AWS/Azure/GCP cloud Instance
+// Metadata Service) is the single most attacked egress destination in modern
+// cloud Kubernetes clusters. A pod that can reach it can mint cloud-provider
+// IAM credentials and pivot from container RCE to full cloud-account
+// compromise. Compare blog.christophetd.fr's EKS worker-node IAM walkthrough.
+//
+// This module asks one question per pod / workload: "can this pod's egress
+// reach 169.254.169.254/32?" We answer it by walking the pod's namespace's
+// NetworkPolicies in egress mode:
+//
+//  1. If no NetworkPolicy with policyTypes:[Egress] selects the pod, Kubernetes
+//     leaves the pod non-isolated for egress (allow-all), so IMDS is reachable.
+//     Fire KUBE-NETPOL-IMDS-001 with the "no-egress-policy" reason.
+//
+//  2. If at least one egress policy selects the pod, compute the union of its
+//     allowed peers. If any allowed peer is an ipBlock whose CIDR contains
+//     169.254.169.254 AND whose `except:` list does not carve out the IMDS IP,
+//     fire KUBE-NETPOL-IMDS-001 with the "explicit-allow" reason. Common
+//     offenders here: ipBlock 0.0.0.0/0 (the universal allow), 169.254.0.0/16
+//     (the entire link-local range), or 169.254.169.254/32 itself.
+//
+//  3. If every selecting policy either does not include IMDS in its ipBlock
+//     reach OR carves it out via `except:`, the pod is fine and no finding fires.
+//
+// The check is intentionally conservative on the "default-deny saves us" case:
+// if a pod has any egress policy at all whose peers do not include a
+// 169.254-containing ipBlock, we trust the deny-by-default semantic and stay
+// quiet. This avoids drowning operators who have done the right thing.
+//
+// Severity: HIGH. The SSRF -> cloud-creds chain is one of the highest-impact
+// real-world attack patterns in cloud Kubernetes; score 7.8.
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/scoring"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// imdsIP is the AWS/Azure/GCP link-local cloud metadata service endpoint. GCP
+// also surfaces it at the DNS name `metadata.google.internal`, but every cloud
+// uses 169.254.169.254 as the L3 address, so a pod that can reach the IP can
+// reach IMDS regardless of provider.
+const imdsIP = "169.254.169.254"
+
+// imdsReason captures why a particular pod / workload fired KUBE-NETPOL-IMDS-001.
+// Helps the report and tests distinguish the two structural causes.
+type imdsReason string
+
+const (
+	imdsReasonNoEgressPolicy imdsReason = "no-egress-policy"
+	imdsReasonExplicitAllow  imdsReason = "explicit-allow"
+)
+
+// imdsFinding is one workload-level IMDS-reachability finding before it is
+// materialized into a models.Finding. Keeping the intermediate struct makes
+// the analyzer testable without poking at the models.Finding JSON shape.
+type imdsFinding struct {
+	Workload                workload
+	Reason                  imdsReason
+	OffenderCIDR            string // populated when Reason == imdsReasonExplicitAllow; the CIDR that admits IMDS
+	OffenderPolicyNamespace string
+	OffenderPolicyName      string
+}
+
+// findImdsReachable returns one imdsFinding per workload whose effective egress
+// posture allows reaching 169.254.169.254. The result is deterministically
+// ordered by (namespace, kind, name) so finding IDs are stable.
+func findImdsReachable(snapshot models.Snapshot, workloads []workload) []imdsFinding {
+	policiesByNS := policiesByNamespace(snapshot.Resources.NetworkPolicies)
+	out := make([]imdsFinding, 0)
+
+	for _, wl := range workloads {
+		if isSystemNamespace(wl.Namespace) {
+			continue
+		}
+		policies := policiesByNS[wl.Namespace]
+		egressPolicies := egressPoliciesSelectingWorkload(policies, wl.Labels)
+
+		if len(egressPolicies) == 0 {
+			// No policy with policyTypes:[Egress] selects this pod, so Kubernetes
+			// applies the allow-all default. IMDS is reachable.
+			out = append(out, imdsFinding{
+				Workload: wl,
+				Reason:   imdsReasonNoEgressPolicy,
+			})
+			continue
+		}
+
+		// At least one egress policy selects this pod. Check whether the union
+		// of its allowed peers admits IMDS via any ipBlock that doesn't carve
+		// the IMDS IP out via `except:`.
+		offender, offenderPolicy := findIMDSAllow(egressPolicies)
+		if offender != "" {
+			out = append(out, imdsFinding{
+				Workload:                wl,
+				Reason:                  imdsReasonExplicitAllow,
+				OffenderCIDR:            offender,
+				OffenderPolicyNamespace: offenderPolicy.Namespace,
+				OffenderPolicyName:      offenderPolicy.Name,
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Workload.Namespace != out[j].Workload.Namespace {
+			return out[i].Workload.Namespace < out[j].Workload.Namespace
+		}
+		if out[i].Workload.Kind != out[j].Workload.Kind {
+			return out[i].Workload.Kind < out[j].Workload.Kind
+		}
+		return out[i].Workload.Name < out[j].Workload.Name
+	})
+	return out
+}
+
+// egressPoliciesSelectingWorkload returns the subset of policies whose podSelector
+// matches the workload's labels AND whose effective PolicyTypes include Egress.
+// A workload is egress-isolated only when at least one such policy exists.
+func egressPoliciesSelectingWorkload(policies []networkingv1.NetworkPolicy, workloadLabels map[string]string) []networkingv1.NetworkPolicy {
+	out := make([]networkingv1.NetworkPolicy, 0)
+	for _, policy := range policies {
+		if !policyTypesContains(effectivePolicyTypes(policy), networkingv1.PolicyTypeEgress) {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(&policy.Spec.PodSelector)
+		if err != nil {
+			continue
+		}
+		if selector.Matches(labels.Set(workloadLabels)) {
+			out = append(out, policy)
+		}
+	}
+	return out
+}
+
+// policyTypesContains reports whether the slice includes the given PolicyType.
+func policyTypesContains(types []networkingv1.PolicyType, target networkingv1.PolicyType) bool {
+	for _, t := range types {
+		if t == target {
+			return true
+		}
+	}
+	return false
+}
+
+// findIMDSAllow inspects the union of egress peers across the given policies and
+// returns the first ipBlock CIDR that admits 169.254.169.254 without carving it
+// out via `except:`. Returns ("", policy{}) when every policy correctly excludes
+// IMDS or simply does not mention any IMDS-containing CIDR.
+//
+// Note on the semantic: NetworkPolicy egress rules with PolicyTypes:[Egress] are
+// strictly additive. A policy that allows ipBlock:10.0.0.0/8 does not allow
+// 169.254.169.254 — the allow-list does not include IMDS. We only fire when an
+// ipBlock explicitly contains 169.254.169.254.
+func findIMDSAllow(policies []networkingv1.NetworkPolicy) (string, networkingv1.NetworkPolicy) {
+	imdsAddr := net.ParseIP(imdsIP)
+	for _, policy := range policies {
+		for _, egress := range policy.Spec.Egress {
+			for _, peer := range egress.To {
+				if peer.IPBlock == nil {
+					continue
+				}
+				_, cidrNet, err := net.ParseCIDR(peer.IPBlock.CIDR)
+				if err != nil {
+					continue
+				}
+				if !cidrNet.Contains(imdsAddr) {
+					continue
+				}
+				if exceptCoversIMDS(peer.IPBlock.Except, imdsAddr) {
+					continue
+				}
+				return peer.IPBlock.CIDR, policy
+			}
+		}
+	}
+	return "", networkingv1.NetworkPolicy{}
+}
+
+// exceptCoversIMDS reports whether any entry in the `except:` list of an ipBlock
+// contains the IMDS address (so the broad ipBlock is correctly carved out).
+func exceptCoversIMDS(except []string, addr net.IP) bool {
+	for _, e := range except {
+		_, exceptNet, err := net.ParseCIDR(e)
+		if err != nil {
+			continue
+		}
+		if exceptNet.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// emitImdsFindings materializes one models.Finding per imdsFinding returned by
+// findImdsReachable.
+func emitImdsFindings(items []imdsFinding) []models.Finding {
+	out := make([]models.Finding, 0, len(items))
+	for _, item := range items {
+		evidence := map[string]any{
+			"workload_kind":      item.Workload.Kind,
+			"workload_name":      item.Workload.Name,
+			"workload_namespace": item.Workload.Namespace,
+			"reason":             string(item.Reason),
+		}
+		if item.OffenderCIDR != "" {
+			evidence["offender_cidr"] = item.OffenderCIDR
+			evidence["offender_policy"] = fmt.Sprintf("%s/%s", item.OffenderPolicyNamespace, item.OffenderPolicyName)
+		}
+		evidenceBytes, _ := json.Marshal(evidence)
+
+		content := contentNetpolIMDS001(item)
+
+		out = append(out, models.Finding{
+			ID:          fmt.Sprintf("KUBE-NETPOL-IMDS-001:%s:%s:%s", item.Workload.Kind, item.Workload.Namespace, item.Workload.Name),
+			RuleID:      "KUBE-NETPOL-IMDS-001",
+			Severity:    models.SeverityHigh,
+			Score:       scoring.Clamp(7.8),
+			Category:    models.CategoryDataExfiltration,
+			Title:       content.Title,
+			Description: content.Description,
+			Namespace:   item.Workload.Namespace,
+			Resource: &models.ResourceRef{
+				Kind:      item.Workload.Kind,
+				Name:      item.Workload.Name,
+				Namespace: item.Workload.Namespace,
+				APIGroup:  workloadAPIGroup(item.Workload.Kind),
+			},
+			Scope:            content.Scope,
+			Impact:           content.Impact,
+			AttackScenario:   content.AttackScenario,
+			Evidence:         evidenceBytes,
+			Remediation:      content.Remediation,
+			RemediationSteps: content.RemediationSteps,
+			References:       referencesFromContent(content),
+			LearnMore:        content.LearnMore,
+			MitreTechniques:  content.MitreTechniques,
+			Tags:             []string{"module:network_policy", "check:imdsReachable", "reason:" + string(item.Reason)},
+		})
+	}
+	return out
+}

--- a/internal/analyzer/network/imds_egress_test.go
+++ b/internal/analyzer/network/imds_egress_test.go
@@ -1,0 +1,279 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestIMDSEmitsForNoEgressPolicy verifies the allow-all default fires the rule
+// with reason=no-egress-policy when a workload has no selecting egress policy.
+func TestIMDSEmitsForNoEgressPolicy(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+			},
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	got := findRule(findings, "KUBE-NETPOL-IMDS-001")
+	if got.RuleID == "" {
+		t.Fatalf("expected KUBE-NETPOL-IMDS-001 to fire when no egress policy applies, got %v", ruleIDs(findings))
+	}
+	if !strings.Contains(string(got.Evidence), `"reason":"no-egress-policy"`) {
+		t.Fatalf("expected reason=no-egress-policy, got %s", string(got.Evidence))
+	}
+	if got.Severity != models.SeverityHigh {
+		t.Fatalf("expected severity HIGH, got %s", got.Severity)
+	}
+}
+
+// TestIMDSEmitsForExplicitAllow asserts that an egress policy whose ipBlock contains
+// the IMDS endpoint (e.g., 0.0.0.0/0) fires the rule with reason=explicit-allow.
+func TestIMDSEmitsForExplicitAllow(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+			},
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+						},
+					},
+				},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-everywhere", Namespace: "apps"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{To: []networkingv1.NetworkPolicyPeer{
+								{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	got := findRule(findings, "KUBE-NETPOL-IMDS-001")
+	if got.RuleID == "" {
+		t.Fatalf("expected KUBE-NETPOL-IMDS-001 to fire when ipBlock 0.0.0.0/0 allows IMDS, got %v", ruleIDs(findings))
+	}
+	if !strings.Contains(string(got.Evidence), `"reason":"explicit-allow"`) {
+		t.Fatalf("expected reason=explicit-allow, got %s", string(got.Evidence))
+	}
+	if !strings.Contains(string(got.Evidence), `"offender_cidr":"0.0.0.0/0"`) {
+		t.Fatalf("expected offender_cidr=0.0.0.0/0, got %s", string(got.Evidence))
+	}
+}
+
+// TestIMDSSuppressesWhenExceptCarvesOutIMDS proves an operator who correctly adds
+// `except: [169.254.169.254/32]` to a broad ipBlock is no longer flagged. This is
+// the most important false-positive guard.
+func TestIMDSSuppressesWhenExceptCarvesOutIMDS(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+			},
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+						},
+					},
+				},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-internet-not-imds", Namespace: "apps"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{To: []networkingv1.NetworkPolicyPeer{
+								{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0", Except: []string{"169.254.169.254/32"}}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if hasRule(findings, "KUBE-NETPOL-IMDS-001") {
+		t.Fatalf("expected KUBE-NETPOL-IMDS-001 to STAY SILENT when ipBlock carves out IMDS, got %v", ruleIDs(findings))
+	}
+}
+
+// TestIMDSSuppressesWhenEgressPolicyOmitsIMDS verifies the conservative semantic:
+// a workload covered by an egress policy whose peers do not include IMDS is fine.
+// (No fire.)
+func TestIMDSSuppressesWhenEgressPolicyOmitsIMDS(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+			},
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+						},
+					},
+				},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-10-only", Namespace: "apps"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{To: []networkingv1.NetworkPolicyPeer{
+								{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/8"}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if hasRule(findings, "KUBE-NETPOL-IMDS-001") {
+		t.Fatalf("expected KUBE-NETPOL-IMDS-001 to STAY SILENT when egress policy does not include IMDS, got %v", ruleIDs(findings))
+	}
+}
+
+// TestIMDSEmitsForLinkLocalRange covers the 169.254.0.0/16 case: any ipBlock that
+// includes the link-local range admits IMDS and must fire.
+func TestIMDSEmitsForLinkLocalRange(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+			},
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+						},
+					},
+				},
+			},
+			NetworkPolicies: []networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "link-local", Namespace: "apps"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{To: []networkingv1.NetworkPolicyPeer{
+								{IPBlock: &networkingv1.IPBlock{CIDR: "169.254.0.0/16"}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if !hasRule(findings, "KUBE-NETPOL-IMDS-001") {
+		t.Fatalf("expected KUBE-NETPOL-IMDS-001 to fire on link-local 169.254.0.0/16, got %v", ruleIDs(findings))
+	}
+}
+
+// TestIMDSSkipsSystemNamespaces verifies that system namespaces (kube-system,
+// kube-public, kube-node-lease) are NOT scanned for IMDS reachability. Control
+// plane components routinely need IMDS access and would otherwise drown the
+// scan in noise.
+func TestIMDSSkipsSystemNamespaces(t *testing.T) {
+	t.Parallel()
+
+	snapshot := models.Snapshot{
+		Resources: models.SnapshotResources{
+			Namespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+			},
+			Deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "metrics-server", Namespace: "kube-system"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "metrics-server"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings, err := New().Analyze(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if hasRule(findings, "KUBE-NETPOL-IMDS-001") {
+		t.Fatalf("expected KUBE-NETPOL-IMDS-001 NOT to fire on kube-system workloads, got %v", ruleIDs(findings))
+	}
+}

--- a/internal/exclusions/config.go
+++ b/internal/exclusions/config.go
@@ -116,6 +116,10 @@ func Write(path string, cfg Config) error {
 // line in config.go.
 var wave1RulePrefixes = []string{
 	// "KUBE-CONTAINER-*",        // W1 #9 Container Security analyzer
+	// W1 #13 NetPol bundle: the rules are surfaced by default — operators
+	// who want them muted can re-add the patterns to their own exclusions
+	// file. The placeholder lines stay in this slice as documentation of
+	// what slots the standard preset reserves for future tuning.
 	// "KUBE-NETPOL-IMDS-*",      // W1 #13 NetPol IMDS egress
 	// "KUBE-NETPOL-CROSSNS-*",   // W1 #13 NetPol cross-namespace map
 	// "KUBE-SECRETS-STALE-*",    // W1 #12 Secrets bundle

--- a/testdata/e2e/expectations/netpol-bundle.expect
+++ b/testdata/e2e/expectations/netpol-bundle.expect
@@ -1,0 +1,5 @@
+# Wave 1 slot #13 — NetPol bundle (cross-ns map + IMDS-endpoint egress detection).
+# See testdata/e2e/vulnerable/13-netpol.yaml for the workloads + policies that
+# trigger these rules.
+KUBE-NETPOL-CROSSNS-001
+KUBE-NETPOL-IMDS-001

--- a/testdata/e2e/expectations/netpol-bundle.rollout
+++ b/testdata/e2e/expectations/netpol-bundle.rollout
@@ -1,0 +1,4 @@
+# Wave 1 slot #13 workloads — wait for these to roll out before scanning so
+# the snapshot reflects the policies + pods landing together.
+deploy/imds-open-app:netpol-imds
+deploy/imds-allow-app:netpol-imds

--- a/testdata/e2e/vulnerable/13-netpol.yaml
+++ b/testdata/e2e/vulnerable/13-netpol.yaml
@@ -1,0 +1,105 @@
+# Fixture for slot #13 (NetPol bundle: cross-ns map + IMDS-endpoint egress).
+#
+# Two scenarios exercised here:
+#
+# 1) NetworkPolicy in namespace netpol-bridge that allows ingress FROM kube-system
+#    via namespaceSelector matchLabels — should trigger KUBE-NETPOL-CROSSNS-001.
+#
+# 2) Deployment in namespace netpol-imds with NO egress policy at all — should
+#    trigger KUBE-NETPOL-IMDS-001 with reason=no-egress-policy. We also add a
+#    second Deployment in the same namespace that IS covered by an egress policy
+#    whose ipBlock 0.0.0.0/0 admits IMDS without an except: carve-out, so the
+#    rule fires with reason=explicit-allow as well.
+#
+# The kube-system namespace label keyed by kubernetes.io/metadata.name is set by
+# the kube-apiserver NamespaceDefaultLabelName admission plugin in every modern
+# Kubernetes (and kind) cluster, so the namespaceSelector below resolves at scan
+# time without us touching kube-system labels here.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netpol-bridge
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-system-ingress
+  namespace: netpol-bridge
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netpol-imds
+---
+# Workload with NO egress NetworkPolicy applying to it — fires KUBE-NETPOL-IMDS-001
+# with reason=no-egress-policy. We use a stable nginx image (the same baseline
+# uses for other lp/risky pods) so kind can pull and roll it out quickly.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imds-open-app
+  namespace: netpol-imds
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: imds-open-app
+  template:
+    metadata:
+      labels:
+        app: imds-open-app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27.5
+          ports:
+            - containerPort: 80
+---
+# Workload covered by an egress policy whose ipBlock 0.0.0.0/0 includes the IMDS
+# endpoint. Fires KUBE-NETPOL-IMDS-001 with reason=explicit-allow. The policy
+# does not include an except: [169.254.169.254/32] carve-out which is the
+# typical real-world misconfiguration the rule catches.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imds-allow-app
+  namespace: netpol-imds
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: imds-allow-app
+  template:
+    metadata:
+      labels:
+        app: imds-allow-app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27.5
+          ports:
+            - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-everywhere
+  namespace: netpol-imds
+spec:
+  podSelector:
+    matchLabels:
+      app: imds-allow-app
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0


### PR DESCRIPTION
## Summary

Wave 1 slot #13 from the parallel-agent fan-out plan (Track C, NetPol bundle). Closes the two open items under PLAN.md:61-62.

Two new rules in `internal/analyzer/network/`:

- **KUBE-NETPOL-CROSSNS-001** (MEDIUM): walks every NetworkPolicy and surfaces ingress / egress peer rules whose `namespaceSelector` reaches across a namespace boundary into (or out of) a sensitive namespace (`kube-system`, `kube-public`, `kube-node-lease`, `default`, `gatekeeper-system`). The wildcard `namespaceSelector: {}` form (matches every namespace) always fires. Each finding identifies the policy plus the (sourceNS, targetNS, direction) tuple in evidence so report consumers can rebuild a cross-namespace communication map.
- **KUBE-NETPOL-IMDS-001** (HIGH): per workload, fires when the effective egress posture lets the pod reach `169.254.169.254` (the cloud Instance Metadata Service). Two structural causes are distinguished via the `reason` tag and evidence field:
  - `no-egress-policy` — no NetworkPolicy with `policyTypes:[Egress]` selects the pod, so the Kubernetes allow-all default applies.
  - `explicit-allow` — at least one selecting egress policy includes an `ipBlock` whose CIDR contains the IMDS IP (e.g. `0.0.0.0/0`, `169.254.0.0/16`, `169.254.169.254/32`) without an `except:` carve-out for `169.254.169.254/32`. Operators who carve IMDS out correctly are NOT flagged.

This is the SSRF -> cloud-credentials chain that one curl turns into a full cloud-account compromise on AWS/Azure/GCP.

## Files

- New: `internal/analyzer/network/crossns.go`, `internal/analyzer/network/imds_egress.go`
- New tests: `internal/analyzer/network/crossns_test.go`, `internal/analyzer/network/imds_egress_test.go`
- Modified: `internal/analyzer/network/analyzer.go` (wires the two new sub-analyzers into `Analyze`), `internal/analyzer/network/content.go` (rule prose + new MITRE / reference entries)
- E2E: `testdata/e2e/vulnerable/13-netpol.yaml` (one cross-NS policy bridging `kube-system`, one workload with no egress policy, one workload covered by a `0.0.0.0/0` egress), `testdata/e2e/expectations/netpol-bundle.expect`, `testdata/e2e/expectations/netpol-bundle.rollout`
- Updated: `docs/findings.md` (rule catalog entries), `PLAN.md` (slot status), `internal/exclusions/config.go` (annotates the pre-reserved standard-preset slots so neither rule is muted by default)

## Test plan

- [x] `make build` clean
- [x] `make test` clean (every package green, including new tests)
- [x] `make lint` clean (`gofmt -l` + `go vet`)
- [x] `./bin/golangci-lint run ./...` clean (0 issues)
- [x] `make e2e` green with the two new rule IDs present in `findings.json` (uncapped report shows both `KUBE-NETPOL-CROSSNS-001` and `KUBE-NETPOL-IMDS-001`)