### PR TITLE
feat(remediation): rbac patch + minimal-binding-diff generator

### DIFF
--- a/internal/analyzer/privesc/analyzer.go
+++ b/internal/analyzer/privesc/analyzer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/remediation"
 )
 
 // DefaultMaxDepth is the fallback BFS depth used when no explicit MaxDepth is configured.
@@ -30,6 +31,12 @@ func (a *Analyzer) Name() string {
 }
 
 // Analyze builds the escalation graph, finds paths to any sensitive sink, and emits one Finding per unique source→target pair.
+//
+// Each finding is enriched with a structured RemediationHint (Wave 1 slot #17):
+// the per-path remediation generator picks the minimal binding edit that breaks
+// the chain (drop the subject from the first hop's binding) and emits a unified
+// diff + kubectl edit command. Synthetic-edge paths (pod escapes, token mints)
+// fall back to an advisory comment-only diff.
 func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]models.Finding, error) {
 	depth := a.MaxDepth
 	if depth <= 0 {
@@ -46,6 +53,7 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 		if _, ok := seen[finding.ID]; ok {
 			continue
 		}
+		finding.RemediationHint = remediation.ForPrivescPath(finding, snapshot)
 		seen[finding.ID] = struct{}{}
 		findings = append(findings, finding)
 	}

--- a/internal/analyzer/rbac/analyzer.go
+++ b/internal/analyzer/rbac/analyzer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/remediation"
 	"github.com/0hardik1/kubesplaining/internal/scoring"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -162,54 +163,59 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 			// finding. switch (not if/else chain) so a rule that matches several cases
 			// only fires the first - we prefer the most specific framing and let dedupe
 			// merge cross-module overlaps later.
+			//
+			// `attachDangerousRemediation` (defined below) populates the structured
+			// RemediationHint for the dangerous-verb findings. Wave 1 slot #17 added the
+			// per-rule remediation generator; the analyzer is the one place that has the
+			// snapshot in scope when these findings are constructed.
 			switch {
 			case hasWildcard(rule.Verbs) && hasWildcard(rule.Resources) && hasWildcard(rule.APIGroups):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-017", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.8),
-					contentPrivesc017(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc017(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get", "list", "watch"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-005", models.SeverityHigh, models.CategoryDataExfiltration,
 					scaledScore(8.2),
-					contentPrivesc005(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc005(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-001", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.4),
-					contentPrivesc001(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc001(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasAnyResource(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-003", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.1),
-					contentPrivesc003(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc003(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasAnyResource(rule.Resources, []string{"users", "groups", "serviceaccounts"}) && hasAnyVerb(rule.Verbs, "impersonate"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-008", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.4),
-					contentPrivesc008(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc008(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasAnyResource(rule.Resources, []string{"roles", "clusterroles"}) && hasAnyVerb(rule.Verbs, "bind", "escalate"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-009", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.2),
-					contentPrivesc009(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc009(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasAnyResource(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) &&
 				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-010", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.0),
-					contentPrivesc010(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc010(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasResource(rule.Resources, "nodes/proxy") && hasAnyVerb(rule.Verbs, "get"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-012", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.3),
-					contentPrivesc012(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc012(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			case hasResource(rule.Resources, "serviceaccounts/token") && hasAnyVerb(rule.Verbs, "create"):
-				findings = appendFinding(findings, seen, findingFromContent(perms.Subject, rule,
+				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-014", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.0),
-					contentPrivesc014(rule.Namespace, perms.Subject, bindingRef, roleRef)))
+					contentPrivesc014(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
 			}
 		}
 	}
@@ -221,7 +227,7 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 				if strings.HasPrefix(ref.Name, "system:") {
 					continue
 				}
-				findings = appendFinding(findings, seen, findingFromContent(
+				overbroadFinding := findingFromContent(
 					ref,
 					effectiveRule{
 						SourceBinding:     binding.Name,
@@ -230,7 +236,9 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 						SourceRoleKind:    binding.RoleRef.Kind,
 					},
 					"KUBE-RBAC-OVERBROAD-001", models.SeverityCritical, models.CategoryPrivilegeEscalation, 10,
-					contentRBACOverbroad001(ref, binding.Name)))
+					contentRBACOverbroad001(ref, binding.Name))
+				overbroadFinding.RemediationHint = remediation.ForRBACOverbroad(overbroadFinding, snapshot)
+				findings = appendFinding(findings, seen, overbroadFinding)
 			}
 		}
 	}
@@ -468,6 +476,18 @@ func appendFinding(findings []models.Finding, seen map[string]struct{}, finding 
 	return append(findings, finding)
 }
 
+// attachDangerousRemediation populates the structured RemediationHint for the
+// dangerous-verb (KUBE-PRIVESC-001 … -017) findings. Wired at each switch
+// branch above as a one-line wrapper around findingFromContent so the per-rule
+// remediation generator runs with the finding's evidence already populated.
+//
+// The remediation package guards on the rule ID and returns nil for anything
+// it doesn't know about, so the wrapper is safe to apply uniformly.
+func attachDangerousRemediation(f models.Finding, snap models.Snapshot) models.Finding {
+	f.RemediationHint = remediation.ForRBACDangerous(f.RuleID, f, snap)
+	return f
+}
+
 // findingFromContent materializes a models.Finding using the enriched ruleContent (Scope, Impact,
 // AttackScenario, RemediationSteps, LearnMore, MitreTechniques) plus the runtime context (subject,
 // originating rule, severity/score/category bucket). Evidence keeps the same shape as before so
@@ -475,6 +495,7 @@ func appendFinding(findings []models.Finding, seen map[string]struct{}, finding 
 func findingFromContent(subject models.SubjectRef, rule effectiveRule, ruleID string, severity models.Severity, category models.RiskCategory, score float64, content ruleContent) models.Finding {
 	evidenceBytes, _ := json.Marshal(map[string]any{
 		"source_role":         rule.SourceRole,
+		"source_role_kind":    rule.SourceRoleKind,
 		"source_binding":      rule.SourceBinding,
 		"source_binding_kind": rule.SourceBindingKind,
 		"api_groups":          rule.APIGroups,

--- a/internal/remediation/diff.go
+++ b/internal/remediation/diff.go
@@ -1,0 +1,143 @@
+// Package remediation generates structured fix payloads (kubectl patches, RBAC
+// diffs, Kyverno / Gatekeeper policy snippets) for findings. Each per-analyzer
+// generator lives in its own file (rbac.go, podsec.go, kyverno.go, gatekeeper.go)
+// and is invoked from the corresponding analyzer's Finding-construction site.
+//
+// The package never mutates a Finding directly. It returns a
+// *models.RemediationHint that the caller assigns to Finding.RemediationHint, so
+// the generators stay pure and trivially testable.
+package remediation
+
+import (
+	"fmt"
+	"strings"
+)
+
+// unifiedDiff renders a textbook unified-diff hunk for a single before / after
+// pair of YAML / text blobs. We hand-roll the format because (a) the only
+// alternative in the Go stdlib is `internal/diff` which is not importable, and
+// (b) we want the output deterministic across runs so test golden files are
+// stable. The result matches `diff -u` shape closely enough that GitHub /
+// editors render it as a syntax-highlighted patch.
+//
+// The header lines (`--- a/path`, `+++ b/path`) reference fromPath / toPath so
+// the consumer can produce a `git apply`-able blob if it wants to. The single
+// hunk covers the entire file (`@@ -1,L +1,M @@` where L and M are line counts)
+// because the inputs are short YAML snippets: multi-hunk minimisation buys
+// nothing for 20 line files.
+//
+// Lines that differ are rendered as `-old` / `+new` blocks; identical context
+// lines as ` line`. The implementation uses a simple longest-common-subsequence
+// (LCS) walk so removed and added blocks line up the way an operator expects
+// to read them.
+func unifiedDiff(fromPath, toPath, from, to string) string {
+	fromLines := splitLines(from)
+	toLines := splitLines(to)
+
+	header := fmt.Sprintf("--- a/%s\n+++ b/%s\n@@ -1,%d +1,%d @@\n",
+		fromPath, toPath, len(fromLines), len(toLines))
+
+	var body strings.Builder
+	ops := lcsDiff(fromLines, toLines)
+	for _, op := range ops {
+		switch op.kind {
+		case opEqual:
+			body.WriteString(" ")
+			body.WriteString(op.line)
+			body.WriteString("\n")
+		case opDelete:
+			body.WriteString("-")
+			body.WriteString(op.line)
+			body.WriteString("\n")
+		case opInsert:
+			body.WriteString("+")
+			body.WriteString(op.line)
+			body.WriteString("\n")
+		}
+	}
+	return header + body.String()
+}
+
+// splitLines is strings.Split with the empty trailing element stripped so that
+// `"a\n"` produces `["a"]` rather than `["a", ""]`. The diff routines assume
+// every element is a real line; trailing-newline noise breaks the LCS table.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// diffOp is one line in the rendered diff: equal context, a deletion, or an insertion.
+type diffOp struct {
+	kind diffKind
+	line string
+}
+
+type diffKind int
+
+const (
+	opEqual diffKind = iota
+	opDelete
+	opInsert
+)
+
+// lcsDiff computes the longest-common-subsequence between two line slices and
+// returns the diff operations needed to transform `a` into `b`. Time / space
+// is O(len(a) * len(b)); fine for the 20-100 line YAML snippets we feed it.
+//
+// The walk backtracks through the LCS table to produce diff ops in forward
+// order: equal lines surface as `opEqual`, removed-from-a lines as
+// `opDelete`, added-from-b lines as `opInsert`. When a deletion and an
+// insertion are adjacent, they form a "modified line" block in the rendered
+// diff; we deliberately do not collapse them into a single op because the
+// unified-diff format distinguishes the two anyway.
+func lcsDiff(a, b []string) []diffOp {
+	la, lb := len(a), len(b)
+	// table[i][j] = length of LCS of a[i:] and b[j:].
+	table := make([][]int, la+1)
+	for i := range table {
+		table[i] = make([]int, lb+1)
+	}
+	for i := la - 1; i >= 0; i-- {
+		for j := lb - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				table[i][j] = table[i+1][j+1] + 1
+			} else if table[i+1][j] >= table[i][j+1] {
+				table[i][j] = table[i+1][j]
+			} else {
+				table[i][j] = table[i][j+1]
+			}
+		}
+	}
+
+	var ops []diffOp
+	i, j := 0, 0
+	for i < la && j < lb {
+		switch {
+		case a[i] == b[j]:
+			ops = append(ops, diffOp{kind: opEqual, line: a[i]})
+			i++
+			j++
+		case table[i+1][j] >= table[i][j+1]:
+			ops = append(ops, diffOp{kind: opDelete, line: a[i]})
+			i++
+		default:
+			ops = append(ops, diffOp{kind: opInsert, line: b[j]})
+			j++
+		}
+	}
+	for i < la {
+		ops = append(ops, diffOp{kind: opDelete, line: a[i]})
+		i++
+	}
+	for j < lb {
+		ops = append(ops, diffOp{kind: opInsert, line: b[j]})
+		j++
+	}
+	return ops
+}

--- a/internal/remediation/rbac.go
+++ b/internal/remediation/rbac.go
@@ -1,0 +1,739 @@
+package remediation
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ForRBACOverbroad returns the structured remediation for KUBE-RBAC-OVERBROAD-001
+// (a wildcard `*:*:*` rule, or a cluster-admin binding equivalent). The fix is
+// not deletion of the binding outright (operators almost always have *some*
+// permission they actually need), but replacement of the wildcard rule with a
+// placeholder allowlist plus a clear comment that the user must populate the
+// real verbs / resources their workload needs.
+//
+// The Patch field is a strategic-merge patch against the (Cluster)Role; the
+// RBACDiff field is a hand-rolled unified diff of the same change so the HTML
+// report has something to render even when JSON consumers prefer the structured
+// patch.
+//
+// Returns nil when the finding is not a wildcard RBAC finding (RuleID mismatch)
+// or when there isn't enough evidence on the finding to identify the role :
+// the analyzer might emit a fallback shape and we'd rather degrade gracefully
+// than crash on unknown evidence keys.
+func ForRBACOverbroad(finding models.Finding, _ models.Snapshot) *models.RemediationHint {
+	if finding.RuleID != "KUBE-RBAC-OVERBROAD-001" {
+		return nil
+	}
+	roleKind, roleName, namespace := rbacTargetFromEvidence(finding)
+	if roleName == "" {
+		return nil
+	}
+	target := models.PatchTarget{
+		Kind:       roleKind,
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Name:       roleName,
+		Namespace:  namespace,
+	}
+	body, command := wildcardReplacementPatch(target)
+	hint := &models.RemediationHint{
+		Patch: &models.KubectlPatch{
+			Type:    "strategic",
+			Target:  target,
+			Body:    body,
+			Command: command,
+		},
+		RBACDiff: wildcardReplacementDiff(roleKind, roleName, namespace),
+	}
+	return hint
+}
+
+// wildcardReplacementPatch returns the JSON body and the pre-rendered kubectl
+// command for swapping a wildcard rule out for a placeholder least-privilege
+// allowlist. Callers fill in the actual verbs / resources their workload needs;
+// we emit `pods get,list` because almost every workload needs at least that
+// and it gives the patch a non-trivial worked example.
+//
+// Note: a strategic-merge patch against `rules:` is *replacive* for the array
+// (kubectl replaces the entire rules list rather than merging element-by-
+// element). That's what we want here: the goal is to wipe the wildcard, not
+// to add a peer rule alongside it.
+func wildcardReplacementPatch(_ models.PatchTarget) (json.RawMessage, string) {
+	payload := map[string]any{
+		"rules": []map[string]any{
+			{
+				"apiGroups": []string{""},
+				"resources": []string{"pods"},
+				"verbs":     []string{"get", "list"},
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	command := "# Replace the placeholder verbs / resources with the minimum your workload actually needs.\n" +
+		"kubectl patch clusterrole <role-name> --type=strategic --patch '" + string(body) + "'"
+	return body, command
+}
+
+// wildcardReplacementDiff renders the YAML-shaped unified diff a user would
+// see in `git diff` / `kubectl diff` if they swapped a wildcard rule for the
+// placeholder allowlist. The "before" block is the canonical `*:*:*` rule; the
+// "after" block is the placeholder plus a comment telling the user this is a
+// scaffold to fill in.
+//
+// We deliberately render this against a freshly-constructed minimal YAML
+// document rather than reconstructing the live (Cluster)Role from the
+// snapshot: the snapshot already groups all of a binding's effective rules
+// together, but the actual `kubectl get role` output may include other rules
+// the user wants to keep. The diff is therefore best read as "what your
+// wildcard rule should look like instead", not "exactly the change to apply".
+func wildcardReplacementDiff(roleKind, roleName, namespace string) string {
+	from := buildOverbroadBefore(roleKind, roleName, namespace)
+	to := buildOverbroadAfter(roleKind, roleName, namespace)
+	path := diffPathFor(roleKind, roleName, namespace)
+	return unifiedDiff(path, path, from, to)
+}
+
+func buildOverbroadBefore(roleKind, roleName, namespace string) string {
+	var b strings.Builder
+	b.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+	b.WriteString("kind: ")
+	b.WriteString(roleKind)
+	b.WriteString("\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  name: ")
+	b.WriteString(roleName)
+	b.WriteString("\n")
+	if namespace != "" {
+		b.WriteString("  namespace: ")
+		b.WriteString(namespace)
+		b.WriteString("\n")
+	}
+	b.WriteString("rules:\n")
+	b.WriteString("- apiGroups: [\"*\"]\n")
+	b.WriteString("  resources: [\"*\"]\n")
+	b.WriteString("  verbs: [\"*\"]\n")
+	return b.String()
+}
+
+func buildOverbroadAfter(roleKind, roleName, namespace string) string {
+	var b strings.Builder
+	b.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+	b.WriteString("kind: ")
+	b.WriteString(roleKind)
+	b.WriteString("\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  name: ")
+	b.WriteString(roleName)
+	b.WriteString("\n")
+	if namespace != "" {
+		b.WriteString("  namespace: ")
+		b.WriteString(namespace)
+		b.WriteString("\n")
+	}
+	b.WriteString("rules:\n")
+	b.WriteString("# TODO: replace the placeholder below with the minimum verbs / resources\n")
+	b.WriteString("# this principal actually needs. Run `kubectl auth can-i --list ...`\n")
+	b.WriteString("# against the workload SA to discover what to keep.\n")
+	b.WriteString("- apiGroups: [\"\"]\n")
+	b.WriteString("  resources: [\"pods\"]\n")
+	b.WriteString("  verbs: [\"get\", \"list\"]\n")
+	return b.String()
+}
+
+// ForRBACDangerous returns the structured remediation for the dangerous-verb
+// RBAC findings emitted by the rbac analyzer (KUBE-PRIVESC-001, -003, -005,
+// -008, -009, -010, -012, -014, -017). Each finding identifies a single
+// effective rule from a (Cluster)Role; the fix is to remove that one rule.
+//
+// The patch we emit is a JSON-patch operation that surgically removes the
+// matching rule by re-writing the entire rules array with the offending rule
+// dropped. We can't use a JSON-patch `remove` op with an indexed path because
+// the snapshot doesn't carry the rule's index inside the original role.
+// Instead, the unified diff shows the rule being removed so an operator can
+// hand-apply the change. The Patch.Command is wrapped with a comment that
+// tells the operator the diff is canonical and the patch JSON is a hint.
+//
+// Returns nil when the finding's evidence doesn't carry the source role / verbs
+// / resources (defensive: the analyzer always populates these today, but a
+// future refactor or a manual `findings.json` could miss them).
+func ForRBACDangerous(ruleID string, finding models.Finding, _ models.Snapshot) *models.RemediationHint {
+	if !isDangerousRBACRule(ruleID) {
+		return nil
+	}
+	roleKind, roleName, namespace := rbacTargetFromEvidence(finding)
+	if roleName == "" {
+		return nil
+	}
+	verbs, resources, apiGroups := rbacRuleFromEvidence(finding)
+	if len(verbs) == 0 && len(resources) == 0 {
+		return nil
+	}
+	target := models.PatchTarget{
+		Kind:       roleKind,
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Name:       roleName,
+		Namespace:  namespace,
+	}
+	body, command := removeRulePatch(target, apiGroups, resources, verbs)
+	diff := removeRuleDiff(roleKind, roleName, namespace, apiGroups, resources, verbs)
+	return &models.RemediationHint{
+		Patch: &models.KubectlPatch{
+			Type:    "json",
+			Target:  target,
+			Body:    body,
+			Command: command,
+		},
+		RBACDiff: diff,
+	}
+}
+
+// isDangerousRBACRule reports whether the given RuleID is one of the
+// dangerous-verb findings the rbac analyzer produces. Each of these maps to a
+// single rule inside a (Cluster)Role that the operator can remove without
+// dropping the (Cluster)Role wholesale (which would break workloads that
+// depend on the other rules in the same role).
+//
+// Kept as a small allowlist rather than a regex because (a) the set is
+// stable and small, and (b) it's the only place in the package that has to
+// stay in sync with the analyzer's rule-ID inventory: easier to spot the
+// drift in code review when it's a literal switch.
+func isDangerousRBACRule(ruleID string) bool {
+	switch ruleID {
+	case "KUBE-PRIVESC-001",
+		"KUBE-PRIVESC-003",
+		"KUBE-PRIVESC-005",
+		"KUBE-PRIVESC-008",
+		"KUBE-PRIVESC-009",
+		"KUBE-PRIVESC-010",
+		"KUBE-PRIVESC-012",
+		"KUBE-PRIVESC-014",
+		"KUBE-PRIVESC-017":
+		return true
+	}
+	return false
+}
+
+// removeRulePatch returns the JSON-patch body and pre-rendered kubectl command
+// for removing a single matching rule from a (Cluster)Role. The patch shape we
+// emit is a `kubectl patch --type=json` test+remove pair, which is the only
+// way to express "remove the rule that has these verbs / resources" via the
+// imperative kubectl API without round-tripping through `get -o yaml`.
+//
+// In practice the patch is a hint: a kubectl JSON patch path is index-based,
+// not query-based, so the operator usually runs `kubectl edit role X` and
+// removes the matching block by hand. The Command string carries both flows
+// so the report renders the structured patch as a copy paste fallback and the
+// edit command as the recommended path.
+func removeRulePatch(target models.PatchTarget, apiGroups, resources, verbs []string) (json.RawMessage, string) {
+	// We can't emit a JSON-patch `remove` with a query-based path: JSON pointer
+	// only supports numeric indexes. The hint we surface is a test-then-remove
+	// at index 0; the user will likely re-shape it after running `kubectl get
+	// <role> -o yaml` to find the real index. The Command therefore prioritises
+	// `kubectl edit` as the user-facing recipe.
+	rule := map[string]any{
+		"apiGroups": apiGroups,
+		"resources": resources,
+		"verbs":     verbs,
+	}
+	patch := []map[string]any{
+		{
+			"op":    "test",
+			"path":  "/rules/0",
+			"value": rule,
+		},
+		{
+			"op":   "remove",
+			"path": "/rules/0",
+		},
+	}
+	body, _ := json.Marshal(patch)
+	cmd := buildKubectlEditCommand(target)
+	cmd += "\n# Alternatively (only if the dangerous rule is index 0 in the rules array):\n"
+	cmd += "# kubectl patch " + strings.ToLower(target.Kind) + " " + target.Name
+	if target.Namespace != "" {
+		cmd += " -n " + target.Namespace
+	}
+	cmd += " --type=json --patch '" + string(body) + "'"
+	return body, cmd
+}
+
+// removeRuleDiff renders a unified-diff hunk showing the dangerous rule being
+// removed from the (Cluster)Role. The before block reconstructs the rule from
+// the finding's evidence; the after block has the same role with that single
+// rule stripped. As with the wildcard diff, this is a "what the change looks
+// like" hint, not a guaranteed-applyable patch: the live role may have other
+// rules we don't surface here.
+func removeRuleDiff(roleKind, roleName, namespace string, apiGroups, resources, verbs []string) string {
+	from := buildDangerousBefore(roleKind, roleName, namespace, apiGroups, resources, verbs)
+	to := buildDangerousAfter(roleKind, roleName, namespace)
+	path := diffPathFor(roleKind, roleName, namespace)
+	return unifiedDiff(path, path, from, to)
+}
+
+func buildDangerousBefore(roleKind, roleName, namespace string, apiGroups, resources, verbs []string) string {
+	var b strings.Builder
+	b.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+	b.WriteString("kind: ")
+	b.WriteString(roleKind)
+	b.WriteString("\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  name: ")
+	b.WriteString(roleName)
+	b.WriteString("\n")
+	if namespace != "" {
+		b.WriteString("  namespace: ")
+		b.WriteString(namespace)
+		b.WriteString("\n")
+	}
+	b.WriteString("rules:\n")
+	b.WriteString("- apiGroups: ")
+	b.WriteString(jsonList(apiGroups))
+	b.WriteString("\n")
+	b.WriteString("  resources: ")
+	b.WriteString(jsonList(resources))
+	b.WriteString("\n")
+	b.WriteString("  verbs: ")
+	b.WriteString(jsonList(verbs))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func buildDangerousAfter(roleKind, roleName, namespace string) string {
+	var b strings.Builder
+	b.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+	b.WriteString("kind: ")
+	b.WriteString(roleKind)
+	b.WriteString("\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  name: ")
+	b.WriteString(roleName)
+	b.WriteString("\n")
+	if namespace != "" {
+		b.WriteString("  namespace: ")
+		b.WriteString(namespace)
+		b.WriteString("\n")
+	}
+	b.WriteString("rules: []  # all dangerous rules removed: re-add only what the workload actually needs\n")
+	return b.String()
+}
+
+// ForPrivescPath returns the structured remediation for a KUBE-PRIVESC-PATH-*
+// finding. The fix is the *smallest* edit that breaks the escalation chain;
+// the algorithm picks the first hop (the closest one to the subject) because
+// it's the one the operator has the most control over: it lives in their
+// configuration, not the cluster's built-in identity layer.
+//
+// Two shapes of fix exist:
+//
+//  1. If the first hop names a binding we can identify (we look up the binding
+//     by the hop's Permission or by scanning the snapshot for a binding that
+//     carries the subject), we emit a unified diff of the binding with the
+//     subject removed from `subjects:`. This is the cheapest cut because the
+//     binding may still be useful for *other* subjects.
+//
+//  2. If we can't pin down the binding (synthetic edges like pod_host_escape
+//     don't trace back to a single binding), we fall back to a generic
+//     advisory diff: the subject is annotated with a comment explaining that
+//     the chain comes from a workload-level permission, not an RBAC grant.
+//
+// Either way the Command is a `kubectl edit` invocation against the
+// candidate object so the operator can hand-apply the change. Returns nil
+// when the finding's path is empty or the subject is missing: the analyzer
+// always populates both, but defensively we don't crash on a degenerate input.
+func ForPrivescPath(finding models.Finding, snap models.Snapshot) *models.RemediationHint {
+	if !strings.HasPrefix(finding.RuleID, "KUBE-PRIVESC-PATH-") {
+		return nil
+	}
+	if len(finding.EscalationPath) == 0 || finding.Subject == nil {
+		return nil
+	}
+	subject := *finding.Subject
+	firstHop := finding.EscalationPath[0]
+
+	if binding := findBindingForSubject(snap, subject); binding != nil {
+		return remediationDropSubjectFromBinding(*binding, subject, firstHop)
+	}
+
+	// Fallback when no enumerable binding carries the subject: emit a generic
+	// advisory diff that explains the chain stems from a pod-escape or
+	// synthetic edge that doesn't have a single binding to cut. We still set
+	// the Command so the report has something actionable.
+	return &models.RemediationHint{
+		RBACDiff: privescPathAdvisoryDiff(subject, firstHop),
+	}
+}
+
+// remediationDropSubjectFromBinding builds the RemediationHint for the
+// "remove this subject from this binding" branch of ForPrivescPath. We don't
+// emit a kubectl patch struct here because (Cluster)RoleBindings are
+// immutable on `roleRef` and partial subject-list edits are not strategic-
+// merge friendly: the right shape is either a JSON patch `remove` at the
+// subject's index (fragile against list-order changes) or `kubectl edit`.
+// We surface the edit command as the canonical action and leave the
+// structured patch nil so the JSON consumer doesn't get a half-correct hint.
+func remediationDropSubjectFromBinding(binding bindingRef, subject models.SubjectRef, _ models.EscalationHop) *models.RemediationHint {
+	from := buildBindingBefore(binding)
+	to := buildBindingAfter(binding, subject)
+	path := diffPathFor(binding.Kind, binding.Name, binding.Namespace)
+	diff := unifiedDiff(path, path, from, to)
+	cmd := buildBindingEditCommand(binding)
+	return &models.RemediationHint{
+		RBACDiff: diff,
+		Patch: &models.KubectlPatch{
+			Type: "json",
+			Target: models.PatchTarget{
+				Kind:       binding.Kind,
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Name:       binding.Name,
+				Namespace:  binding.Namespace,
+			},
+			Command: cmd,
+		},
+	}
+}
+
+// bindingRef is the narrow projection of an (Cluster)RoleBinding the diff
+// builders need. We don't pass the live rbacv1 objects around because they
+// carry a lot of metadata (ResourceVersion, ManagedFields) that we'd have to
+// strip before rendering YAML: and the diff is illustrative, not a literal
+// `kubectl diff` capture.
+type bindingRef struct {
+	Kind          string
+	Name          string
+	Namespace     string // empty for ClusterRoleBindings
+	RoleRefKind   string
+	RoleRefName   string
+	Subjects      []rbacv1.Subject
+	BindingObject any
+}
+
+// findBindingForSubject scans the snapshot for the (Cluster)RoleBinding whose
+// subject list includes the given subject. We don't try to use the hop's
+// Permission to disambiguate among multiple matching bindings: the user-visible
+// fix is "drop this subject from any binding that grants the dangerous verb",
+// and the first match is good enough for the hint.
+//
+// Returns nil when no binding lists the subject. That happens when the chain
+// is rooted at a synthetic edge (pod_host_escape, token_mint via SA token
+// API) rather than an explicit binding: the ForPrivescPath caller falls back
+// to the advisory diff in that case.
+func findBindingForSubject(snap models.Snapshot, subject models.SubjectRef) *bindingRef {
+	// Walk ClusterRoleBindings first: they're shorter (cluster-scoped subjects
+	// usually accumulate here) and the deterministic order keeps test goldens
+	// stable.
+	bindings := collectBindings(snap)
+	for _, b := range bindings {
+		for _, s := range b.Subjects {
+			if subjectsMatch(s, subject, b.Namespace) {
+				out := b
+				return &out
+			}
+		}
+	}
+	return nil
+}
+
+// collectBindings flattens the snapshot's RoleBindings and ClusterRoleBindings
+// into a single ordered slice of bindingRef. ClusterRoleBindings come first so
+// the test goldens and the path-fix algorithm consistently prefer the cluster-
+// scoped binding when both exist for the same subject (a not-uncommon shape
+// when a SA is bound at both scopes).
+func collectBindings(snap models.Snapshot) []bindingRef {
+	out := make([]bindingRef, 0, len(snap.Resources.ClusterRoleBindings)+len(snap.Resources.RoleBindings))
+	for _, b := range snap.Resources.ClusterRoleBindings {
+		out = append(out, bindingRef{
+			Kind:          "ClusterRoleBinding",
+			Name:          b.Name,
+			Namespace:     "",
+			RoleRefKind:   b.RoleRef.Kind,
+			RoleRefName:   b.RoleRef.Name,
+			Subjects:      b.Subjects,
+			BindingObject: b,
+		})
+	}
+	for _, b := range snap.Resources.RoleBindings {
+		out = append(out, bindingRef{
+			Kind:          "RoleBinding",
+			Name:          b.Name,
+			Namespace:     b.Namespace,
+			RoleRefKind:   b.RoleRef.Kind,
+			RoleRefName:   b.RoleRef.Name,
+			Subjects:      b.Subjects,
+			BindingObject: b,
+		})
+	}
+	// Stable sort by Kind, then namespace, then name so test goldens don't
+	// flap on map-iteration ordering shifts elsewhere.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// subjectsMatch reports whether an rbacv1.Subject from a binding's subject
+// list refers to the same identity as a models.SubjectRef. ServiceAccount
+// subjects need namespace handling (empty namespace on the binding means the
+// binding's own namespace); Users and Groups have no namespace.
+func subjectsMatch(s rbacv1.Subject, target models.SubjectRef, bindingNs string) bool {
+	if s.Kind != target.Kind {
+		return false
+	}
+	if s.Name != target.Name {
+		return false
+	}
+	if s.Kind == "ServiceAccount" {
+		ns := s.Namespace
+		if ns == "" {
+			ns = bindingNs
+		}
+		return ns == target.Namespace
+	}
+	return true
+}
+
+// buildBindingBefore renders the binding as YAML with all of its subjects
+// listed. The shape is the minimum needed for an operator to recognise the
+// binding in their cluster: we don't reproduce metadata.labels /
+// annotations / managedFields because the diff is about subjects, not
+// metadata, and including them would inflate the diff with noise.
+func buildBindingBefore(b bindingRef) string {
+	return renderBindingYAML(b, b.Subjects)
+}
+
+// buildBindingAfter renders the binding with the named subject removed. If
+// removing the subject leaves an empty subjects list, we surface the binding
+// with `subjects: []` so the operator can see the binding is now effectively
+// inert (a binding with no subjects grants nothing): they should usually
+// delete the binding outright in that case, and the diff makes that obvious.
+func buildBindingAfter(b bindingRef, subject models.SubjectRef) string {
+	kept := make([]rbacv1.Subject, 0, len(b.Subjects))
+	for _, s := range b.Subjects {
+		if subjectsMatch(s, subject, b.Namespace) {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return renderBindingYAML(b, kept)
+}
+
+// renderBindingYAML returns a YAML serialisation of the binding with the
+// supplied subject list substituted in. Kept hand-rolled (rather than
+// `sigs.k8s.io/yaml.Marshal`) so the output is deterministic: Kubernetes'
+// YAML marshaller orders map keys by struct-tag declaration order which is
+// fine, but it also splatters Status: {} and creationTimestamp: null on every
+// object, which would noise up the diff and confuse a reader who isn't
+// looking for those fields.
+func renderBindingYAML(b bindingRef, subjects []rbacv1.Subject) string {
+	var sb strings.Builder
+	sb.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+	sb.WriteString("kind: ")
+	sb.WriteString(b.Kind)
+	sb.WriteString("\n")
+	sb.WriteString("metadata:\n")
+	sb.WriteString("  name: ")
+	sb.WriteString(b.Name)
+	sb.WriteString("\n")
+	if b.Namespace != "" {
+		sb.WriteString("  namespace: ")
+		sb.WriteString(b.Namespace)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("roleRef:\n")
+	sb.WriteString("  apiGroup: rbac.authorization.k8s.io\n")
+	sb.WriteString("  kind: ")
+	sb.WriteString(b.RoleRefKind)
+	sb.WriteString("\n")
+	sb.WriteString("  name: ")
+	sb.WriteString(b.RoleRefName)
+	sb.WriteString("\n")
+	if len(subjects) == 0 {
+		sb.WriteString("subjects: []\n")
+		return sb.String()
+	}
+	sb.WriteString("subjects:\n")
+	for _, s := range subjects {
+		sb.WriteString("- kind: ")
+		sb.WriteString(s.Kind)
+		sb.WriteString("\n")
+		sb.WriteString("  name: ")
+		sb.WriteString(s.Name)
+		sb.WriteString("\n")
+		if s.Kind == "ServiceAccount" {
+			ns := s.Namespace
+			if ns == "" {
+				ns = b.Namespace
+			}
+			if ns != "" {
+				sb.WriteString("  namespace: ")
+				sb.WriteString(ns)
+				sb.WriteString("\n")
+			}
+		}
+	}
+	return sb.String()
+}
+
+// privescPathAdvisoryDiff is the fallback we emit when ForPrivescPath can't
+// pin the chain to a single binding. The "before" block is the subject as the
+// chain represents it; the "after" block is the same with an inline comment
+// saying the operator needs to look at workload security (pod hostPath, host
+// PID, SA-token mint) rather than RBAC because the chain doesn't terminate in
+// a binding. This is rare in practice: most chains pass through a binding
+// somewhere: but we'd rather emit an explanatory comment than nothing.
+func privescPathAdvisoryDiff(subject models.SubjectRef, firstHop models.EscalationHop) string {
+	from := fmt.Sprintf("# Subject\n# kind: %s\n# name: %s\n# namespace: %s\n# first-hop action: %s\n",
+		subject.Kind, subject.Name, subject.Namespace, firstHop.Action)
+	to := fmt.Sprintf("# Subject\n# kind: %s\n# name: %s\n# namespace: %s\n# first-hop action: %s\n# NOTE: this chain starts at a synthetic edge (pod escape, token mint,\n# or similar) that does not map to a single (Cluster)RoleBinding. Mitigation\n# is at the workload layer: remove hostPath / hostPID / hostNetwork on the\n# offending pod or revoke `serviceaccounts/token` create on the role that\n# enables the mint.\n",
+		subject.Kind, subject.Name, subject.Namespace, firstHop.Action)
+	path := "subject-" + sanitisePath(subject.Key())
+	return unifiedDiff(path, path, from, to)
+}
+
+// buildKubectlEditCommand returns the canonical `kubectl edit <role>` line so
+// the operator can hand-prune the dangerous rule. We lower-case the Kind
+// because kubectl accepts both `clusterrole` and `ClusterRole` but the
+// lower-case form is what every K8s tutorial shows.
+func buildKubectlEditCommand(target models.PatchTarget) string {
+	cmd := "# Recommended: edit the role and remove the dangerous rule by hand.\n"
+	cmd += "kubectl edit " + strings.ToLower(target.Kind) + " " + target.Name
+	if target.Namespace != "" {
+		cmd += " -n " + target.Namespace
+	}
+	return cmd
+}
+
+// buildBindingEditCommand returns the canonical `kubectl edit <binding>` line
+// for the drop-subject-from-binding remediation. Same lower-case convention
+// as buildKubectlEditCommand.
+func buildBindingEditCommand(b bindingRef) string {
+	cmd := "# Edit the binding and remove the offending subject from `subjects:`.\n"
+	cmd += "kubectl edit " + strings.ToLower(b.Kind) + " " + b.Name
+	if b.Namespace != "" {
+		cmd += " -n " + b.Namespace
+	}
+	return cmd
+}
+
+// diffPathFor returns the synthetic file-path embedded in the unified-diff
+// header. It exists only so the diff renders nicely in editors that
+// syntax-highlight by extension; we use `.yaml` and prefix with `rbac/` to
+// hint at the source. Namespace is included when non-empty so an operator
+// scanning multiple diffs in a PR can tell which namespace each comes from.
+func diffPathFor(kind, name, namespace string) string {
+	parts := []string{"rbac", strings.ToLower(kind)}
+	if namespace != "" {
+		parts = append(parts, namespace)
+	}
+	parts = append(parts, name+".yaml")
+	return strings.Join(parts, "/")
+}
+
+// sanitisePath rewrites a SubjectRef.Key() into a string safe for use inside
+// a unified-diff header path. Slashes are the path separator inside the diff
+// header so we replace them with dashes.
+func sanitisePath(s string) string {
+	return strings.ReplaceAll(s, "/", "-")
+}
+
+// rbacTargetFromEvidence extracts the (Cluster)Role kind, name, and namespace
+// from a Finding's evidence JSON. The rbac analyzer's findingFromContent
+// helper consistently emits `source_role`, `source_binding`, and (via
+// Finding.Resource) the Role kind, so we look at both Evidence and Resource
+// for the most accurate values. Returns ("", "", "") when neither carries the
+// info: callers degrade to "no remediation hint" in that case.
+func rbacTargetFromEvidence(finding models.Finding) (kind, name, namespace string) {
+	// Prefer Finding.Resource: the analyzer sets it to {Kind: "RBACRule", Name:
+	// <role-name>, Namespace: <ns>} for the dangerous-verb findings, and to
+	// {Kind: "RBACRule", ...} for OVERBROAD. We need to look at evidence to
+	// recover the actual Role/ClusterRole distinction.
+	if finding.Resource != nil {
+		name = finding.Resource.Name
+		namespace = finding.Resource.Namespace
+	}
+	if len(finding.Evidence) == 0 {
+		// No evidence to disambiguate; default to ClusterRole because the
+		// dangerous-rule findings overwhelmingly fire on cluster-scoped roles
+		// (a namespaced Role is rarely granted cluster-wide verbs). Operators
+		// applying a wrong-kind patch get a clear "not found" from kubectl and
+		// will swap to Role themselves.
+		kind = "ClusterRole"
+		return
+	}
+	var ev struct {
+		SourceRole      string `json:"source_role"`
+		SourceRoleKind  string `json:"source_role_kind"`
+		Namespace       string `json:"namespace"`
+		SourceBindingNs string `json:"binding_namespace"`
+	}
+	_ = json.Unmarshal(finding.Evidence, &ev)
+	if ev.SourceRole != "" {
+		name = ev.SourceRole
+	}
+	if ev.SourceRoleKind != "" {
+		kind = ev.SourceRoleKind
+	}
+	if kind == "" {
+		// The dangerous-verb findings' evidence carries `source_role` (the
+		// role's name) but not the kind explicitly. We can infer from
+		// namespace: a namespaced source_binding implies a Role, a cluster-
+		// scoped one implies a ClusterRole (binding kinds match their roleRef
+		// kind by RBAC invariant).
+		if ev.Namespace != "" || ev.SourceBindingNs != "" {
+			kind = "Role"
+		} else {
+			kind = "ClusterRole"
+		}
+	}
+	if namespace == "" && kind == "Role" {
+		// Carry through the binding namespace as the Role namespace: true
+		// because a RoleBinding can only reference a Role in the same namespace.
+		if ev.Namespace != "" {
+			namespace = ev.Namespace
+		} else if ev.SourceBindingNs != "" {
+			namespace = ev.SourceBindingNs
+		}
+	}
+	return
+}
+
+// rbacRuleFromEvidence extracts the (verbs, resources, apiGroups) triple from
+// a Finding's evidence. The rbac analyzer emits these as JSON arrays; we just
+// unmarshal. Empty / nil defaults are fine: the caller already checks for
+// zero-length verbs and resources before generating the patch.
+func rbacRuleFromEvidence(finding models.Finding) (verbs, resources, apiGroups []string) {
+	if len(finding.Evidence) == 0 {
+		return
+	}
+	var ev struct {
+		APIGroups []string `json:"api_groups"`
+		Resources []string `json:"resources"`
+		Verbs     []string `json:"verbs"`
+	}
+	_ = json.Unmarshal(finding.Evidence, &ev)
+	return ev.Verbs, ev.Resources, ev.APIGroups
+}
+
+// jsonList serialises a string slice as a flow-style YAML list, matching the
+// style our hand-rolled YAML uses elsewhere in this file. Nil / empty becomes
+// `[]` so the diff is still parseable.
+func jsonList(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+	quoted := make([]string, 0, len(values))
+	for _, v := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", v))
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}

--- a/internal/remediation/rbac_test.go
+++ b/internal/remediation/rbac_test.go
@@ -1,0 +1,280 @@
+package remediation
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/0hardik1/kubesplaining/internal/models"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestForRBACOverbroad covers the wildcard-rule remediation path. The
+// generator must produce both a strategic-merge patch body and a unified diff
+// that swap the wildcard for the placeholder least-privilege allowlist.
+func TestForRBACOverbroad(t *testing.T) {
+	t.Parallel()
+
+	finding := models.Finding{
+		RuleID: "KUBE-RBAC-OVERBROAD-001",
+		Resource: &models.ResourceRef{
+			Kind: "RBACRule",
+			Name: "admins",
+		},
+		Evidence: mustMarshal(map[string]any{
+			"source_role":      "cluster-admin",
+			"source_role_kind": "ClusterRole",
+		}),
+	}
+
+	hint := ForRBACOverbroad(finding, models.Snapshot{})
+	if hint == nil {
+		t.Fatal("ForRBACOverbroad returned nil")
+	}
+	if hint.Patch == nil {
+		t.Fatal("ForRBACOverbroad: Patch is nil")
+	}
+	if hint.Patch.Type != "strategic" {
+		t.Errorf("Patch.Type = %q, want strategic", hint.Patch.Type)
+	}
+	if hint.Patch.Target.Kind != "ClusterRole" {
+		t.Errorf("Patch.Target.Kind = %q, want ClusterRole", hint.Patch.Target.Kind)
+	}
+	if !strings.Contains(string(hint.Patch.Body), "\"verbs\":[\"get\",\"list\"]") {
+		t.Errorf("Patch.Body should contain placeholder verbs, got %s", string(hint.Patch.Body))
+	}
+	if hint.RBACDiff == "" {
+		t.Fatal("ForRBACOverbroad: RBACDiff is empty")
+	}
+	if !strings.Contains(hint.RBACDiff, "-  verbs: [\"*\"]") {
+		t.Errorf("RBACDiff should remove the wildcard verbs line, got:\n%s", hint.RBACDiff)
+	}
+	if !strings.Contains(hint.RBACDiff, "+- apiGroups: [\"\"]") {
+		t.Errorf("RBACDiff should add the placeholder rule, got:\n%s", hint.RBACDiff)
+	}
+	if !strings.Contains(hint.RBACDiff, "+# TODO:") {
+		t.Errorf("RBACDiff should include a TODO comment, got:\n%s", hint.RBACDiff)
+	}
+}
+
+// TestForRBACOverbroadRejectsWrongRule ensures the generator is a no-op for
+// rule IDs it doesn't know about. A future analyzer rename or copy-paste
+// mistake at the call site should silently get nil rather than a confusingly
+// shaped hint that points at the wrong rule.
+func TestForRBACOverbroadRejectsWrongRule(t *testing.T) {
+	t.Parallel()
+
+	finding := models.Finding{RuleID: "KUBE-PRIVESC-005"}
+	if hint := ForRBACOverbroad(finding, models.Snapshot{}); hint != nil {
+		t.Errorf("ForRBACOverbroad accepted non-wildcard rule, got %+v", hint)
+	}
+}
+
+// TestForRBACDangerous covers the per-dangerous-rule path. The generator must
+// emit a JSON patch whose body removes the offending rule, plus a unified diff
+// whose `-` block reconstructs the rule from the finding's evidence.
+func TestForRBACDangerous(t *testing.T) {
+	t.Parallel()
+
+	finding := models.Finding{
+		RuleID: "KUBE-PRIVESC-005",
+		Resource: &models.ResourceRef{
+			Kind:      "RBACRule",
+			Name:      "reader",
+			Namespace: "team-a",
+		},
+		Evidence: mustMarshal(map[string]any{
+			"source_role":      "reader",
+			"source_role_kind": "Role",
+			"namespace":        "team-a",
+			"api_groups":       []string{""},
+			"resources":        []string{"secrets"},
+			"verbs":            []string{"get", "list"},
+		}),
+	}
+
+	hint := ForRBACDangerous("KUBE-PRIVESC-005", finding, models.Snapshot{})
+	if hint == nil {
+		t.Fatal("ForRBACDangerous returned nil")
+	}
+	if hint.Patch == nil {
+		t.Fatal("ForRBACDangerous: Patch is nil")
+	}
+	if hint.Patch.Type != "json" {
+		t.Errorf("Patch.Type = %q, want json", hint.Patch.Type)
+	}
+	if hint.Patch.Target.Kind != "Role" {
+		t.Errorf("Patch.Target.Kind = %q, want Role", hint.Patch.Target.Kind)
+	}
+	if hint.Patch.Target.Namespace != "team-a" {
+		t.Errorf("Patch.Target.Namespace = %q, want team-a", hint.Patch.Target.Namespace)
+	}
+	if !strings.Contains(hint.Patch.Command, "kubectl edit role reader") {
+		t.Errorf("Patch.Command should include kubectl edit recipe, got:\n%s", hint.Patch.Command)
+	}
+	if !strings.Contains(hint.RBACDiff, "-  resources: [\"secrets\"]") {
+		t.Errorf("RBACDiff should show the dangerous resources being removed, got:\n%s", hint.RBACDiff)
+	}
+	if !strings.Contains(hint.RBACDiff, "+rules: []") {
+		t.Errorf("RBACDiff should reduce rules to []; got:\n%s", hint.RBACDiff)
+	}
+}
+
+// TestForRBACDangerousRejectsUnknownRule mirrors the wildcard-side guard:
+// callers passing an unrelated rule ID get nil so the call site stays
+// idempotent if the rule-ID inventory drifts.
+func TestForRBACDangerousRejectsUnknownRule(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"", "KUBE-RBAC-OVERBROAD-001", "KUBE-PODSEC-ROOT-001", "KUBE-PRIVESC-PATH-CLUSTER-ADMIN"}
+	for _, rule := range cases {
+		t.Run(rule, func(t *testing.T) {
+			finding := models.Finding{RuleID: rule}
+			if hint := ForRBACDangerous(rule, finding, models.Snapshot{}); hint != nil {
+				t.Errorf("ForRBACDangerous(%q) returned non-nil hint: %+v", rule, hint)
+			}
+		})
+	}
+}
+
+// TestForPrivescPathDropsSubject covers the binding-cut branch. When the
+// subject is reachable through a real (Cluster)RoleBinding, the remediation
+// diff must show that subject struck from the binding's subject list while
+// leaving the other subjects in place.
+func TestForPrivescPathDropsSubject(t *testing.T) {
+	t.Parallel()
+
+	subject := models.SubjectRef{Kind: "ServiceAccount", Name: "attacker", Namespace: "default"}
+	snap := models.Snapshot{
+		Resources: models.SnapshotResources{
+			ClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "crb-elevated"},
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "elevated-role"},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "attacker", Namespace: "default"},
+						{Kind: "ServiceAccount", Name: "innocent", Namespace: "default"},
+					},
+				},
+			},
+		},
+	}
+	finding := models.Finding{
+		RuleID:  "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+		Subject: &subject,
+		EscalationPath: []models.EscalationHop{
+			{
+				Step:        1,
+				Action:      "impersonate",
+				FromSubject: subject,
+				ToSubject:   models.SubjectRef{Kind: "User", Name: "admin"},
+				Permission:  "users:impersonate",
+			},
+		},
+	}
+
+	hint := ForPrivescPath(finding, snap)
+	if hint == nil {
+		t.Fatal("ForPrivescPath returned nil")
+	}
+	if hint.RBACDiff == "" {
+		t.Fatal("RBACDiff is empty")
+	}
+	if !strings.Contains(hint.RBACDiff, "-  name: attacker") {
+		t.Errorf("expected attacker subject to be removed (- line); got:\n%s", hint.RBACDiff)
+	}
+	if !strings.Contains(hint.RBACDiff, "   name: innocent") {
+		t.Errorf("expected innocent subject to remain in diff context; got:\n%s", hint.RBACDiff)
+	}
+	// The attacker's `-- kind` line collapses with the next subject's `- kind`
+	// in the LCS walk, but the attacker's name + namespace must always be in
+	// the deletion blocks.
+	if !strings.Contains(hint.RBACDiff, "-  namespace: default") {
+		t.Errorf("expected attacker's namespace line to be deleted; got:\n%s", hint.RBACDiff)
+	}
+	if hint.Patch == nil || hint.Patch.Command == "" {
+		t.Fatal("Patch.Command must be populated with kubectl edit recipe")
+	}
+	if !strings.Contains(hint.Patch.Command, "kubectl edit clusterrolebinding crb-elevated") {
+		t.Errorf("Patch.Command should reference the binding, got:\n%s", hint.Patch.Command)
+	}
+}
+
+// TestForPrivescPathFallback covers the advisory branch. When the chain
+// doesn't pass through any (Cluster)RoleBinding we can name (synthetic edges
+// like pod_host_escape), the generator emits a comment-only diff telling the
+// operator the chain is a workload-layer issue.
+func TestForPrivescPathFallback(t *testing.T) {
+	t.Parallel()
+
+	subject := models.SubjectRef{Kind: "ServiceAccount", Name: "lonely", Namespace: "default"}
+	finding := models.Finding{
+		RuleID:  "KUBE-PRIVESC-PATH-NODE-ESCAPE",
+		Subject: &subject,
+		EscalationPath: []models.EscalationHop{
+			{
+				Step:        1,
+				Action:      "pod_host_escape",
+				FromSubject: subject,
+				ToSubject:   models.SubjectRef{Kind: "Node", Name: "worker-1"},
+				Permission:  "hostPath:/",
+			},
+		},
+	}
+
+	hint := ForPrivescPath(finding, models.Snapshot{})
+	if hint == nil {
+		t.Fatal("ForPrivescPath returned nil even for synthetic-edge chain")
+	}
+	if hint.RBACDiff == "" {
+		t.Fatal("advisory RBACDiff is empty")
+	}
+	if !strings.Contains(hint.RBACDiff, "synthetic edge") {
+		t.Errorf("advisory diff should explain the chain is synthetic; got:\n%s", hint.RBACDiff)
+	}
+	if hint.Patch != nil {
+		t.Errorf("Patch should be nil for the advisory branch; got %+v", hint.Patch)
+	}
+}
+
+// TestForPrivescPathSkipsNonPathRule guards the call-site contract: callers
+// pass any privesc-analyzer finding through here, but the generator only
+// applies to KUBE-PRIVESC-PATH-* findings. Anything else must return nil so
+// the call site stays a one-liner that doesn't have to filter rule IDs.
+func TestForPrivescPathSkipsNonPathRule(t *testing.T) {
+	t.Parallel()
+
+	finding := models.Finding{
+		RuleID:  "KUBE-RBAC-OVERBROAD-001",
+		Subject: &models.SubjectRef{Kind: "User", Name: "alice"},
+		EscalationPath: []models.EscalationHop{
+			{Step: 1, Action: "impersonate"},
+		},
+	}
+	if hint := ForPrivescPath(finding, models.Snapshot{}); hint != nil {
+		t.Errorf("ForPrivescPath accepted non-PATH rule, got %+v", hint)
+	}
+}
+
+// TestUnifiedDiffShape is a regression guard for the unified-diff renderer:
+// it must produce a single hunk with a stable header and recognisable
+// equal / delete / insert markers. Test goldens for the higher-level
+// generators above implicitly depend on this shape.
+func TestUnifiedDiffShape(t *testing.T) {
+	t.Parallel()
+
+	got := unifiedDiff("a/foo", "b/foo", "one\ntwo\nthree\n", "one\nfour\nthree\n")
+	want := "--- a/a/foo\n+++ b/b/foo\n@@ -1,3 +1,3 @@\n one\n-two\n+four\n three\n"
+	if got != want {
+		t.Errorf("unifiedDiff mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func mustMarshal(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

Implements Wave 1 slot #17 from [`use-plan-md-strategy-md-and-think-frolicking-waffle.md`](.claude/plans/use-plan-md-strategy-md-and-think-frolicking-waffle.md) and STRATEGY.md:52-57. Introduces `internal/remediation/` (new package) that generates structured `RemediationHint` payloads for the rbac and privesc analyzers.

- New `internal/remediation/rbac.go`: three generators (`ForRBACOverbroad`, `ForRBACDangerous`, `ForPrivescPath`) emitting unified diffs + kubectl commands.
- New `internal/remediation/diff.go`: hand-rolled unified-diff helper backed by an LCS walk; deterministic across runs for stable test goldens.
- Wired one-line at each rbac analyzer switch branch (nine dangerous-verb rules + KUBE-RBAC-OVERBROAD-001) and at the privesc analyzer path-finding loop.

Coverage:

- **KUBE-RBAC-OVERBROAD-001**: strategic-merge `Patch` + `RBACDiff` swapping the wildcard rule for a placeholder allowlist with a TODO comment.
- **KUBE-PRIVESC-001/003/005/008/009/010/012/014/017** (9 rules): JSON-patch `test+remove` body + `RBACDiff` showing the dangerous rule struck. `kubectl edit` is the canonical recipe; the JSON patch is the fallback.
- **KUBE-PRIVESC-PATH-\***: walks the first hop, finds the binding carrying the subject in `snap.Resources.{Cluster,}RoleBindings`, emits a unified diff with that subject dropped. Falls back to a comment-only advisory diff for synthetic edges (`pod_host_escape`, `token_mint`).

## Test plan

- [x] `make build` clean
- [x] `make test` green (new `internal/remediation` package tests cover all three generators + reject paths + diff shape regression)
- [x] `make lint` green
- [x] `./bin/golangci-lint run ./...` clean
- [x] `make e2e` green: 50 expected rule IDs present, no regressions, and **43 findings now carry `remediation_hint` with populated `rbac_diff`** in the kind fixture
- [x] Manual smoke against `testdata/snapshots/minimal-risky.json`: all 3 wired rule IDs (`KUBE-PRIVESC-001`, `KUBE-PRIVESC-005`, `KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS`) produce useful diffs

Sample RBACDiff (from e2e):

```diff
--- a/rbac/clusterrolebinding/crb-bind-escalate.yaml
+++ b/rbac/clusterrolebinding/crb-bind-escalate.yaml
@@ -1,12 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: crb-bind-escalate
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cr-bind-escalate
-subjects:
-- kind: ServiceAccount
-  name: sa-bind-escalate
-  namespace: rbac-fixtures
+subjects: []
```