### PR TITLE
feat(analyzer): apiGroup/resourceNames precision + causal correlation

### DIFF
--- a/docs/eks-demo.md
+++ b/docs/eks-demo.md
@@ -35,11 +35,11 @@ make eks-demo-down    # ~10 min: removes cluster, IAM role, S3 bucket, kubeconfi
  ── Chain B (KUBE-PRIVESC-PATH-AWS-IAM-ROLE + SYSTEM-MASTERS) ─────────
    ServiceAccount  prod-data/prod-data-pipeline-sa
       │  KUBE-CLOUD-IRSA-ADMIN-ROLE-001 fires (name contains "Admin")
-      │  KUBE-CLOUD-IRSA-001 (irsa_assume_role)
+      │  KUBE-CLOUD-IRSA (irsa_assume_role)
       ▼
    external:aws-iam:HolySplainProdDataPipelineAdministrator
       │  KUBE-CLOUD-AWSAUTH-SYSTEM-MASTERS-001 fires on aws-auth ConfigMap
-      │  KUBE-CLOUD-AWSAUTH-001 (aws_auth_admin)
+      │  KUBE-CLOUD-AWSAUTH (aws_auth_admin)
       ▼
    sink:system_masters
 ```

--- a/internal/analyzer/correlate.go
+++ b/internal/analyzer/correlate.go
@@ -35,21 +35,40 @@ func isLeastPrivilegeAdvisory(ruleID string) bool {
 	return false
 }
 
-// correlate applies chain-modifier bumps to non-privesc findings whose Subject appears as a source in a privilege-escalation path.
-// It picks the highest-severity sink reachable from the subject and adds scoring.ChainModifier(sinkSev) to the finding's Score,
-// clamped to [0, 10]. A "chain:amplified" tag is added so report consumers can explain the bump.
+// pathEdge is one escalation-graph edge a subject actively drives: the technique
+// that enabled a hop, plus the severity of the sink the whole chain reaches.
+type pathEdge struct {
+	technique string
+	sink      models.Severity
+}
+
+// correlate applies chain-modifier bumps, but only to the findings that are the
+// actual edges of an escalation chain - not to every finding that happens to share
+// a subject with one. For each hop of every privesc path finding it records
+// (hop.FromSubject → technique → chain sink severity); a non-privesc finding is then
+// amplified only when its own (Subject, RuleID) matches one of those edges. The bump
+// is scoring.ChainModifier of the highest sink severity among the matching edges,
+// clamped to [0, 10], and a "chain:amplified" tag is added so report consumers can
+// explain it. This keeps a chain's weight on the specific weakness it exploits (the
+// impersonate grant, the privileged pod) instead of inflating an unrelated
+// misconfiguration on the same ServiceAccount.
 func correlate(findings []models.Finding) []models.Finding {
-	best := map[string]models.Severity{} // subject key → highest-severity sink reachable
+	pathEdges := map[string][]pathEdge{} // subject key → edges that subject drives
 	for _, finding := range findings {
-		if len(finding.EscalationPath) == 0 || finding.Subject == nil {
+		if len(finding.EscalationPath) == 0 {
 			continue
 		}
-		key := finding.Subject.Key()
-		if finding.Severity.Rank() > best[key].Rank() {
-			best[key] = finding.Severity
+		for _, hop := range finding.EscalationPath {
+			if hop.FromSubject.Name == "" || hop.Technique == "" {
+				// A hop with no source subject or no technique carries no causal
+				// signal we can attribute a specific finding to.
+				continue
+			}
+			from := hop.FromSubject.Key()
+			pathEdges[from] = append(pathEdges[from], pathEdge{technique: hop.Technique, sink: finding.Severity})
 		}
 	}
-	if len(best) == 0 {
+	if len(pathEdges) == 0 {
 		return findings
 	}
 
@@ -58,12 +77,19 @@ func correlate(findings []models.Finding) []models.Finding {
 			continue // privesc findings already reflect chain length in their own scoring
 		}
 		if findings[i].Subject == nil {
+			// Resource-anchored findings (e.g. the podsec pod-escape rules, which set
+			// Resource but no Subject) have no subject key to match against a path
+			// edge, so they are never amplified. This matches the pre-causal behavior.
 			continue
 		}
 		if isLeastPrivilegeAdvisory(findings[i].RuleID) {
 			continue // advisory recommendations skip the amplification bump
 		}
-		bump := scoring.ChainModifier(best[findings[i].Subject.Key()])
+		sink, ok := bestSinkForEdge(pathEdges[findings[i].Subject.Key()], findings[i].RuleID)
+		if !ok {
+			continue // this finding is not an edge of any chain from its subject
+		}
+		bump := scoring.ChainModifier(sink)
 		if bump == 0 {
 			continue
 		}
@@ -71,6 +97,37 @@ func correlate(findings []models.Finding) []models.Finding {
 		findings[i].Tags = append(findings[i].Tags, "chain:amplified")
 	}
 	return findings
+}
+
+// bestSinkForEdge returns the highest sink severity among the subject's escalation
+// edges whose technique matches ruleID, and whether any matched.
+func bestSinkForEdge(edges []pathEdge, ruleID string) (models.Severity, bool) {
+	var best models.Severity
+	found := false
+	for _, e := range edges {
+		if !techniqueMatchesRule(e.technique, ruleID) {
+			continue
+		}
+		if !found || e.sink.Rank() > best.Rank() {
+			best, found = e.sink, true
+		}
+	}
+	return best, found
+}
+
+// techniqueMatchesRule reports whether an edge technique identifies the same rule as
+// ruleID: an exact match, or a family prefix. The family-prefix form is what lets the
+// cloud edge technique "KUBE-CLOUD-IRSA" amplify the concrete, Subject-bearing eks
+// findings "KUBE-CLOUD-IRSA-ADMIN-ROLE-001" / "-MISSING-001" (and "KUBE-CLOUD-AWSAUTH"
+// its -SYSTEM-MASTERS-001 / -OVERBROAD-001 findings).
+//
+// The pod-escape edge is also tagged with a family prefix ("KUBE-ESCAPE") for hop
+// display, but that one never reaches this matcher: the KUBE-ESCAPE-* findings podsec
+// emits are resource-anchored (Subject == nil), so correlate skips them before the
+// technique match runs. See TestCorrelateSkipsResourceAnchoredFindings - amplifying
+// those would require podsec to carry a Subject, which is out of scope here.
+func techniqueMatchesRule(technique, ruleID string) bool {
+	return technique == ruleID || strings.HasPrefix(ruleID, technique+"-")
 }
 
 // dedupe collapses findings that describe the same (RuleID, Subject, Resource) combination across modules,

--- a/internal/analyzer/correlate_test.go
+++ b/internal/analyzer/correlate_test.go
@@ -11,11 +11,13 @@ func TestCorrelateBumpsSubjectOnCriticalPath(t *testing.T) {
 	subject := models.SubjectRef{Kind: "ServiceAccount", Namespace: "app", Name: "bad-sa"}
 	findings := []models.Finding{
 		{
-			RuleID:         "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
-			Severity:       models.SeverityCritical,
-			Score:          9.8,
-			Subject:        &subject,
-			EscalationPath: []models.EscalationHop{{Step: 1, Action: "wildcard"}},
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Score:    9.8,
+			Subject:  &subject,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "pod_create_token_theft", Technique: "KUBE-PRIVESC-001", FromSubject: subject},
+			},
 		},
 		{
 			RuleID:   "KUBE-PRIVESC-001",
@@ -32,6 +34,95 @@ func TestCorrelateBumpsSubjectOnCriticalPath(t *testing.T) {
 	}
 	if !slices.Contains(got[1].Tags, "chain:amplified") {
 		t.Errorf("chain:amplified tag missing: %v", got[1].Tags)
+	}
+}
+
+// TestCorrelateOnlyBumpsEdgeFindings is the core of the causal-correlation fix: two
+// findings share the path-source subject, but only the one whose rule is an actual
+// edge of the chain (the pod-create grant) is amplified; the unrelated root-container
+// weakness on the same ServiceAccount is left alone.
+func TestCorrelateOnlyBumpsEdgeFindings(t *testing.T) {
+	subject := models.SubjectRef{Kind: "ServiceAccount", Namespace: "app", Name: "bad-sa"}
+	findings := []models.Finding{
+		{
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Score:    9.8,
+			Subject:  &subject,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "impersonate", Technique: "KUBE-PRIVESC-008", FromSubject: subject},
+			},
+		},
+		{
+			RuleID: "KUBE-PRIVESC-008", Severity: models.SeverityCritical, Score: 7.0, Subject: &subject,
+		},
+		{
+			RuleID: "KUBE-PODSEC-ROOT-001", Severity: models.SeverityMedium, Score: 5.0, Subject: &subject,
+		},
+	}
+
+	got := correlate(findings)
+
+	if got[1].Score != 9.0 || !slices.Contains(got[1].Tags, "chain:amplified") {
+		t.Errorf("edge finding KUBE-PRIVESC-008 should be amplified 7.0 → 9.0, got %v tags=%v", got[1].Score, got[1].Tags)
+	}
+	if got[2].Score != 5.0 || slices.Contains(got[2].Tags, "chain:amplified") {
+		t.Errorf("bystander finding KUBE-PODSEC-ROOT-001 must not be amplified: got %v tags=%v", got[2].Score, got[2].Tags)
+	}
+}
+
+// TestCorrelateMatchesTechniqueFamily confirms a family-prefix edge technique
+// amplifies the concrete finding whose rule ID it prefixes. Uses the cloud IRSA
+// case (edge technique "KUBE-CLOUD-IRSA" → finding "KUBE-CLOUD-IRSA-ADMIN-ROLE-001"),
+// a real shape: the eks IRSA finding carries the SA as its Subject.
+func TestCorrelateMatchesTechniqueFamily(t *testing.T) {
+	subject := models.SubjectRef{Kind: "ServiceAccount", Namespace: "prod", Name: "pipeline"}
+	findings := []models.Finding{
+		{
+			RuleID:   "KUBE-PRIVESC-PATH-AWS-IAM-ROLE",
+			Severity: models.SeverityHigh,
+			Score:    8.0,
+			Subject:  &subject,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "irsa_assume_role", Technique: "KUBE-CLOUD-IRSA", FromSubject: subject},
+			},
+		},
+		{RuleID: "KUBE-CLOUD-IRSA-ADMIN-ROLE-001", Severity: models.SeverityHigh, Score: 7.0, Subject: &subject},
+	}
+
+	got := correlate(findings)
+
+	if !slices.Contains(got[1].Tags, "chain:amplified") {
+		t.Errorf("KUBE-CLOUD-IRSA-ADMIN-ROLE-001 should match the KUBE-CLOUD-IRSA edge family: got tags=%v", got[1].Tags)
+	}
+}
+
+// TestCorrelateSkipsResourceAnchoredFindings documents that a finding anchored to a
+// Resource rather than a Subject (Subject == nil) is never amplified, even when its
+// rule ID prefix-matches an escalation edge. Pod-escape findings (KUBE-ESCAPE-*,
+// KUBE-PODSEC-*) are resource-anchored today, so the "KUBE-ESCAPE" edge family does
+// not amplify them. This has always been the case (correlate has always skipped
+// Subject == nil); the test guards against a silent change in that contract.
+func TestCorrelateSkipsResourceAnchoredFindings(t *testing.T) {
+	sa := models.SubjectRef{Kind: "ServiceAccount", Namespace: "app", Name: "escaper"}
+	findings := []models.Finding{
+		{
+			RuleID:   "KUBE-PRIVESC-PATH-NODE-ESCAPE",
+			Severity: models.SeverityCritical,
+			Score:    9.4,
+			Subject:  &sa,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "pod_host_escape", Technique: "KUBE-ESCAPE", FromSubject: sa},
+			},
+		},
+		// Resource-anchored escape finding: no Subject, like real podsec findings.
+		{RuleID: "KUBE-ESCAPE-001", Severity: models.SeverityHigh, Score: 7.0, Resource: &models.ResourceRef{Kind: "Pod", Name: "p", Namespace: "app"}},
+	}
+
+	got := correlate(findings)
+
+	if slices.Contains(got[1].Tags, "chain:amplified") {
+		t.Errorf("resource-anchored finding (Subject == nil) must not be amplified: got tags=%v", got[1].Tags)
 	}
 }
 
@@ -79,16 +170,21 @@ func TestCorrelateUsesHighestSinkSeverity(t *testing.T) {
 	subject := models.SubjectRef{Kind: "ServiceAccount", Namespace: "app", Name: "leaker"}
 	findings := []models.Finding{
 		{
-			RuleID:         "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS",
-			Severity:       models.SeverityHigh,
-			Subject:        &subject,
-			EscalationPath: []models.EscalationHop{{Step: 1}},
+			RuleID:   "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS",
+			Severity: models.SeverityHigh,
+			Subject:  &subject,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Technique: "KUBE-PRIVESC-005", FromSubject: subject},
+			},
 		},
 		{
-			RuleID:         "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
-			Severity:       models.SeverityCritical,
-			Subject:        &subject,
-			EscalationPath: []models.EscalationHop{{Step: 1}, {Step: 2}},
+			RuleID:   "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
+			Severity: models.SeverityCritical,
+			Subject:  &subject,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Technique: "KUBE-PRIVESC-005", FromSubject: subject},
+				{Step: 2},
+			},
 		},
 		{
 			RuleID:   "KUBE-PRIVESC-005",

--- a/internal/analyzer/engine_test.go
+++ b/internal/analyzer/engine_test.go
@@ -217,10 +217,12 @@ func TestEngineCorrelatesPrivescChainsIntoOtherFindings(t *testing.T) {
 	privesc := &stubModule{name: "privesc", findings: []models.Finding{
 		{
 			ID: "p", RuleID: "KUBE-PRIVESC-PATH-CLUSTER-ADMIN",
-			Severity:       models.SeverityCritical,
-			Score:          9.5,
-			Subject:        subject,
-			EscalationPath: []models.EscalationHop{{Step: 1, Action: "wildcard"}},
+			Severity: models.SeverityCritical,
+			Score:    9.5,
+			Subject:  subject,
+			EscalationPath: []models.EscalationHop{
+				{Step: 1, Action: "bound_to_cluster_admin", Technique: "KUBE-RBAC-OVERBROAD-001", FromSubject: *subject},
+			},
 		},
 	}}
 	rbac := &stubModule{name: "rbac", findings: []models.Finding{

--- a/internal/analyzer/privesc/analyzer_test.go
+++ b/internal/analyzer/privesc/analyzer_test.go
@@ -15,6 +15,51 @@ func objectMeta(name, namespace string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{Name: name, Namespace: namespace}
 }
 
+// TestNameScopedSecretGetNoKubeSystemPath verifies that a cluster-wide `get secrets`
+// grant restricted to a specific resourceNames does NOT produce a
+// kube-system-secrets escalation path: the sink means "compromise the kube-system
+// secret store", which a get on one named secret cannot achieve. An unrestricted
+// grant of the same verb still does.
+func TestNameScopedSecretGetNoKubeSystemPath(t *testing.T) {
+	t.Parallel()
+
+	build := func(rule rbacv1.PolicyRule) models.Snapshot {
+		return models.Snapshot{
+			Resources: models.SnapshotResources{
+				Namespaces:   []corev1.Namespace{{ObjectMeta: objectMeta("default", "")}, {ObjectMeta: objectMeta("kube-system", "")}},
+				ClusterRoles: []rbacv1.ClusterRole{{ObjectMeta: objectMeta("reader-role", ""), Rules: []rbacv1.PolicyRule{rule}}},
+				ClusterRoleBindings: []rbacv1.ClusterRoleBinding{{
+					ObjectMeta: objectMeta("reader-role", ""),
+					RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "reader-role"},
+					Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "reader", Namespace: "default"}},
+				}},
+			},
+		}
+	}
+	hasSecretsPath := func(t *testing.T, snap models.Snapshot) bool {
+		t.Helper()
+		findings, err := New().Analyze(context.Background(), snap)
+		if err != nil {
+			t.Fatalf("Analyze() error = %v", err)
+		}
+		for _, f := range findings {
+			if f.RuleID == "KUBE-PRIVESC-PATH-KUBE-SYSTEM-SECRETS" {
+				return true
+			}
+		}
+		return false
+	}
+
+	scoped := rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}, ResourceNames: []string{"tls-cert"}}
+	if hasSecretsPath(t, build(scoped)) {
+		t.Error("name-scoped get secrets must not produce a kube-system-secrets path")
+	}
+	unrestricted := rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}}
+	if !hasSecretsPath(t, build(unrestricted)) {
+		t.Error("unrestricted get secrets should still produce a kube-system-secrets path")
+	}
+}
+
 func TestAnalyzerFindsClusterAdminAndSecretsPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analyzer/privesc/cloud_edges.go
+++ b/internal/analyzer/privesc/cloud_edges.go
@@ -142,7 +142,10 @@ func addIRSAEdge(graph *models.EscalationGraph, identity models.CloudIdentity) {
 	ensureSubjectNode(graph, saRef)
 	externalID := ensureExternalAWSIAMNode(graph, identity.ARN, true)
 	addEdge(graph, nodeID(saRef), externalID, &models.EscalationEdge{
-		Technique:   "KUBE-CLOUD-IRSA-001",
+		// Family prefix (not a full rule ID) so the correlation pass amplifies the
+		// concrete IRSA findings the eks analyzer emits (KUBE-CLOUD-IRSA-ADMIN-ROLE-001,
+		// KUBE-CLOUD-IRSA-MISSING-001) via techniqueMatchesRule's prefix rule.
+		Technique:   "KUBE-CLOUD-IRSA",
 		Action:      "irsa_assume_role",
 		Permission:  identity.ARN,
 		Description: "ServiceAccount can assume " + identity.ARN + " via IRSA",
@@ -165,7 +168,7 @@ func addAWSAuthEdges(graph *models.EscalationGraph, snapshot models.Snapshot, id
 		}
 		if group == "system:masters" {
 			addEdge(graph, externalID, sinkSystemMasters, &models.EscalationEdge{
-				Technique:   "KUBE-CLOUD-AWSAUTH-001",
+				Technique:   "KUBE-CLOUD-AWSAUTH",
 				Action:      "aws_auth_admin",
 				Permission:  "system:masters via aws-auth",
 				Description: "external IAM principal " + identity.ARN + " is mapped to system:masters via aws-auth",
@@ -177,7 +180,7 @@ func addAWSAuthEdges(graph *models.EscalationGraph, snapshot models.Snapshot, id
 			continue
 		}
 		addEdge(graph, externalID, sinkClusterAdmin, &models.EscalationEdge{
-			Technique:   "KUBE-CLOUD-AWSAUTH-001",
+			Technique:   "KUBE-CLOUD-AWSAUTH",
 			Action:      "aws_auth_admin",
 			Permission:  fmt.Sprintf("mapped to group %s bound to ClusterRole %s", group, roleName),
 			Description: fmt.Sprintf("external IAM principal %s is mapped to group %s, which is bound to ClusterRole %s (admin-equivalent) via a ClusterRoleBinding", identity.ARN, group, roleName),

--- a/internal/analyzer/privesc/cloud_edges_test.go
+++ b/internal/analyzer/privesc/cloud_edges_test.go
@@ -76,8 +76,8 @@ func TestAddCloudEdgesIRSAOnly(t *testing.T) {
 	if edge == nil {
 		t.Fatalf("expected irsa_assume_role edge from %s to %s; edges=%+v", saNodeID, externalID, graph.Edges)
 	}
-	if edge.Technique != "KUBE-CLOUD-IRSA-001" {
-		t.Errorf("IRSA edge Technique = %q, want %q", edge.Technique, "KUBE-CLOUD-IRSA-001")
+	if edge.Technique != "KUBE-CLOUD-IRSA" {
+		t.Errorf("IRSA edge Technique = %q, want %q", edge.Technique, "KUBE-CLOUD-IRSA")
 	}
 }
 
@@ -114,8 +114,8 @@ func TestAddCloudEdgesAWSAuthSystemMasters(t *testing.T) {
 	if edge == nil {
 		t.Fatalf("expected aws_auth_admin edge from %s to %s; edges=%+v", externalID, sinkSystemMasters, graph.Edges)
 	}
-	if edge.Technique != "KUBE-CLOUD-AWSAUTH-001" {
-		t.Errorf("aws-auth edge Technique = %q, want %q", edge.Technique, "KUBE-CLOUD-AWSAUTH-001")
+	if edge.Technique != "KUBE-CLOUD-AWSAUTH" {
+		t.Errorf("aws-auth edge Technique = %q, want %q", edge.Technique, "KUBE-CLOUD-AWSAUTH")
 	}
 }
 
@@ -158,8 +158,8 @@ func TestAddCloudEdgesAWSAuthCustomGroupBoundToClusterAdmin(t *testing.T) {
 	if edge == nil {
 		t.Fatalf("expected aws_auth_admin edge from %s to %s; edges=%+v", externalID, sinkClusterAdmin, graph.Edges)
 	}
-	if edge.Technique != "KUBE-CLOUD-AWSAUTH-001" {
-		t.Errorf("aws-auth edge Technique = %q, want %q", edge.Technique, "KUBE-CLOUD-AWSAUTH-001")
+	if edge.Technique != "KUBE-CLOUD-AWSAUTH" {
+		t.Errorf("aws-auth edge Technique = %q, want %q", edge.Technique, "KUBE-CLOUD-AWSAUTH")
 	}
 }
 

--- a/internal/analyzer/privesc/graph.go
+++ b/internal/analyzer/privesc/graph.go
@@ -258,10 +258,26 @@ func addEdgesForRule(
 		}
 	}
 
-	if matchesResourceVerb(rule, []string{"secrets"}, []string{"get", "list", "watch"}) {
+	// read_secrets reaches the kube_system_secrets sink only from an unrestricted
+	// grant: the sink means "compromise the kube-system secret store", which a
+	// resourceNames-scoped grant (a get on a fixed set of named secrets) cannot
+	// achieve. list/watch are already dropped for a name-scoped rule by the matcher;
+	// this guard additionally suppresses the surviving name-scoped `get` so a
+	// least-privilege "get one specific secret" grant no longer produces a spurious
+	// kube-system-secrets escalation path. (Inspecting whether a named secret is
+	// itself sensitive is the resourceName-aware enhancement tracked in the research
+	// doc; until then we prefer no false positive here.)
+	if !rule.NameScoped() && matchesResourceVerb(rule, []string{"secrets"}, []string{"get", "list", "watch"}) {
 		if clusterScope || rule.Namespace == "kube-system" {
+			// Label the edge with the technique of the strongest verb held so the
+			// correlation pass amplifies the matching rbac finding: list/watch
+			// (enumerate everything) is KUBE-PRIVESC-005, a get-only grant is -006.
+			technique := "KUBE-PRIVESC-006"
+			if matchesResourceVerb(rule, []string{"secrets"}, []string{"list", "watch"}) {
+				technique = "KUBE-PRIVESC-005"
+			}
 			addEdge(graph, from, sinkKubeSystemSecrets, &models.EscalationEdge{
-				Technique:   "KUBE-PRIVESC-005",
+				Technique:   technique,
 				Action:      "read_secrets",
 				Permission:  verbResource(rule, "secrets"),
 				Description: "can read secrets in kube-system or cluster-wide",
@@ -668,22 +684,45 @@ func containsSubject(refs []models.SubjectRef, name string) bool {
 	return false
 }
 
-// matchesResourceVerb reports whether a rule covers any of the given resources and any of the given verbs (wildcards match all).
-func matchesResourceVerb(rule permissions.EffectiveRule, resources, verbs []string) bool {
-	return hasAnyValue(rule.Resources, resources) && hasAnyValue(rule.Verbs, verbs)
+// resourceAPIGroup maps a bare resource (or subresource) name to the API group it
+// belongs to, so the graph's edge matchers can enforce the correct (apiGroup,
+// resource) pair without every call site spelling the group out. Every resource the
+// edge builders test is listed here; an unlisted resource defaults to the core group.
+var resourceAPIGroup = map[string]string{
+	// core group ("")
+	"pods":                     "",
+	"pods/exec":                "",
+	"pods/attach":              "",
+	"pods/ephemeralcontainers": "",
+	"pods/portforward":         "",
+	"secrets":                  "",
+	"serviceaccounts":          "",
+	"serviceaccounts/token":    "",
+	"nodes":                    "",
+	"nodes/proxy":              "",
+	"nodes/status":             "",
+	"users":                    "",
+	"groups":                   "",
+	// rbac.authorization.k8s.io
+	"roles":               "rbac.authorization.k8s.io",
+	"clusterroles":        "rbac.authorization.k8s.io",
+	"rolebindings":        "rbac.authorization.k8s.io",
+	"clusterrolebindings": "rbac.authorization.k8s.io",
+	// certificates.k8s.io
+	"certificatesigningrequests":          "certificates.k8s.io",
+	"certificatesigningrequests/approval": "certificates.k8s.io",
 }
 
-// hasAnyValue reports whether values contains any of the wanted tokens, treating "*" in values as a match-all wildcard.
-func hasAnyValue(values []string, wanted []string) bool {
-	if slices.Contains(values, "*") {
-		return true
+// matchesResourceVerb reports whether a rule authorizes any of the given verbs on
+// any of the given resources, honoring the resource's API group and the rule's
+// resourceNames (see permissions.Grants). Call sites keep passing bare resource
+// names; the group is resolved from resourceAPIGroup.
+func matchesResourceVerb(rule permissions.EffectiveRule, resources, verbs []string) bool {
+	targets := make([]permissions.ResourceTarget, 0, len(resources))
+	for _, r := range resources {
+		targets = append(targets, permissions.ResourceTarget{Group: resourceAPIGroup[r], Resource: r})
 	}
-	for _, w := range wanted {
-		if slices.Contains(values, w) {
-			return true
-		}
-	}
-	return false
+	return rule.Grants(targets, verbs...)
 }
 
 // hasAll reports whether every expected value is present in values (or values contains a wildcard).

--- a/internal/analyzer/privesc/pathfinder.go
+++ b/internal/analyzer/privesc/pathfinder.go
@@ -151,6 +151,7 @@ func buildPath(graph *models.EscalationGraph, source models.SubjectRef, target m
 		hops = append(hops, models.EscalationHop{
 			Step:        i + 1,
 			Action:      step.edge.Action,
+			Technique:   step.edge.Technique,
 			FromSubject: current,
 			ToSubject:   next,
 			Permission:  step.edge.Permission,

--- a/internal/analyzer/rbac/analyzer.go
+++ b/internal/analyzer/rbac/analyzer.go
@@ -10,10 +10,49 @@ import (
 	"strings"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
 	"github.com/0hardik1/kubesplaining/internal/remediation"
 	"github.com/0hardik1/kubesplaining/internal/scoring"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
+
+// API groups for the resources the privilege-escalation checks inspect. Matching on
+// the group (not the bare resource name) is what keeps a custom resource that reuses
+// a core name - e.g. a CRD `secrets.example.com` - from tripping the core-`secrets`
+// checks.
+const (
+	groupRBAC  = "rbac.authorization.k8s.io"
+	groupCerts = "certificates.k8s.io"
+	groupApps  = "apps"
+	groupBatch = "batch"
+)
+
+// Target sets for the dangerous-permission checks below, each pinned to its API
+// group. Shared by the per-rule switch and the multi-rule correlations (CSR mint,
+// secret-token mint, node migration).
+var (
+	targetSecrets     = []permissions.ResourceTarget{permissions.Core("secrets")}
+	targetPods        = []permissions.ResourceTarget{permissions.Core("pods")}
+	targetPodExec     = []permissions.ResourceTarget{permissions.Core("pods/exec"), permissions.Core("pods/attach")}
+	targetEphemeral   = []permissions.ResourceTarget{permissions.Core("pods/ephemeralcontainers")}
+	targetPortForward = []permissions.ResourceTarget{permissions.Core("pods/portforward")}
+	targetSAToken     = []permissions.ResourceTarget{permissions.Core("serviceaccounts/token")}
+	targetNodesProxy  = []permissions.ResourceTarget{permissions.Core("nodes/proxy")}
+	targetNodesStatus = []permissions.ResourceTarget{permissions.Core("nodes/status")}
+	targetNodes       = []permissions.ResourceTarget{permissions.Core("nodes")}
+	targetImpersonate = []permissions.ResourceTarget{permissions.Core("users"), permissions.Core("groups"), permissions.Core("serviceaccounts")}
+	targetWorkloads   = []permissions.ResourceTarget{permissions.InGroup(groupApps, "deployments"), permissions.InGroup(groupApps, "daemonsets"), permissions.InGroup(groupApps, "statefulsets"), permissions.InGroup(groupBatch, "jobs"), permissions.InGroup(groupBatch, "cronjobs")}
+	targetRoles       = []permissions.ResourceTarget{permissions.InGroup(groupRBAC, "roles"), permissions.InGroup(groupRBAC, "clusterroles")}
+	targetBindings    = []permissions.ResourceTarget{permissions.InGroup(groupRBAC, "rolebindings"), permissions.InGroup(groupRBAC, "clusterrolebindings")}
+	targetCSR         = []permissions.ResourceTarget{permissions.InGroup(groupCerts, "certificatesigningrequests")}
+	targetCSRApproval = []permissions.ResourceTarget{permissions.InGroup(groupCerts, "certificatesigningrequests/approval")}
+)
+
+// grants reports whether this rule authorizes any of verbs on any of targets,
+// honoring the target API group and this rule's resourceNames (see permissions.Grants).
+func (r effectiveRule) grants(targets []permissions.ResourceTarget, verbs ...string) bool {
+	return permissions.Grants(r.APIGroups, r.Resources, r.Verbs, r.ResourceNames, targets, verbs)
+}
 
 // Analyzer produces RBAC-focused findings from a snapshot.
 type Analyzer struct{}
@@ -30,6 +69,7 @@ type effectiveRule struct {
 	APIGroups              []string
 	Resources              []string
 	Verbs                  []string
+	ResourceNames          []string
 	SourceRole             string
 	SourceRoleKind         string
 	SourceRoleNamespace    string
@@ -98,6 +138,7 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 					APIGroups:              append([]string(nil), rule.APIGroups...),
 					Resources:              append([]string(nil), rule.Resources...),
 					Verbs:                  append([]string(nil), rule.Verbs...),
+					ResourceNames:          append([]string(nil), rule.ResourceNames...),
 					SourceRole:             binding.RoleRef.Name,
 					SourceRoleKind:         binding.RoleRef.Kind,
 					SourceRoleNamespace:    roleNamespace,
@@ -120,6 +161,7 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 					APIGroups:         append([]string(nil), rule.APIGroups...),
 					Resources:         append([]string(nil), rule.Resources...),
 					Verbs:             append([]string(nil), rule.Verbs...),
+					ResourceNames:     append([]string(nil), rule.ResourceNames...),
 					SourceRole:        binding.RoleRef.Name,
 					SourceRoleKind:    binding.RoleRef.Kind,
 					SourceBinding:     binding.Name,
@@ -150,6 +192,14 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 			if perms.Subject.Kind == "ServiceAccount" && usedServiceAccounts[perms.Subject.Key()] {
 				exploitability = 1.2
 			}
+			// A resourceNames-scoped grant reaches only a fixed set of named objects -
+			// a much smaller blast radius than the whole resource type - so attenuate
+			// it. The grant is still real (the checks below only match name-scopable
+			// verbs on a name-scoped rule), just narrower, so it ranks below an
+			// unrestricted grant of the same permission instead of disappearing.
+			if len(rule.ResourceNames) > 0 {
+				blastRadius *= 0.6
+			}
 			// scaledScore captures the per-rule multipliers above so each case below
 			// only has to declare its base score - the formula is named once instead of
 			// duplicated nine times.
@@ -175,66 +225,66 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 					"KUBE-PRIVESC-017", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.8),
 					contentPrivesc017(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "list", "watch"):
+			case rule.grants(targetSecrets, "list", "watch"):
 				// list/watch return every Secret's contents in one call (the
 				// enumerate-everything case). get-only is the narrower -006 below.
+				// A resourceNames-scoped rule never reaches this case: list/watch
+				// cannot enumerate a name-restricted collection.
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-005", models.SeverityHigh, models.CategoryDataExfiltration,
 					scaledScore(8.2),
 					contentPrivesc005(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get"):
+			case rule.grants(targetSecrets, "get"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-006", models.SeverityHigh, models.CategoryDataExfiltration,
 					scaledScore(7.6),
 					contentPrivesc006(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create"):
+			case rule.grants(targetPods, "create"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-001", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.4),
 					contentPrivesc001(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasAnyResource(rule.Resources, []string{"pods/exec", "pods/attach"}) && hasAnyVerb(rule.Verbs, "create", "get"):
+			case rule.grants(targetPodExec, "create", "get"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-004", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.0),
 					contentPrivesc004(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "pods/ephemeralcontainers") && hasAnyVerb(rule.Verbs, "update", "patch"):
+			case rule.grants(targetEphemeral, "update", "patch"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-013", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.0),
 					contentPrivesc013(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "pods/portforward") && hasAnyVerb(rule.Verbs, "create"):
+			case rule.grants(targetPortForward, "create"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-015", models.SeverityMedium, models.CategoryLateralMovement,
 					scaledScore(6.0),
 					contentPrivesc015(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasAnyResource(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) &&
-				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
+			case rule.grants(targetWorkloads, "create", "update", "patch"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-003", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.1),
 					contentPrivesc003(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasAnyResource(rule.Resources, []string{"users", "groups", "serviceaccounts"}) && hasAnyVerb(rule.Verbs, "impersonate"):
+			case rule.grants(targetImpersonate, "impersonate"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-008", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.4),
 					contentPrivesc008(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasAnyResource(rule.Resources, []string{"roles", "clusterroles"}) && hasAnyVerb(rule.Verbs, "bind", "escalate"):
+			case rule.grants(targetRoles, "bind", "escalate"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-009", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.2),
 					contentPrivesc009(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasAnyResource(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) &&
-				hasAnyVerb(rule.Verbs, "create", "update", "patch"):
+			case rule.grants(targetBindings, "create", "update", "patch"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-010", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.0),
 					contentPrivesc010(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "nodes/proxy") && hasAnyVerb(rule.Verbs, "get"):
+			case rule.grants(targetNodesProxy, "get"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-012", models.SeverityCritical, models.CategoryPrivilegeEscalation,
 					scaledScore(9.3),
 					contentPrivesc012(rule.Namespace, perms.Subject, bindingRef, roleRef)), snapshot))
-			case hasResource(rule.Resources, "serviceaccounts/token") && hasAnyVerb(rule.Verbs, "create"):
+			case rule.grants(targetSAToken, "create"):
 				findings = appendFinding(findings, seen, attachDangerousRemediation(findingFromContent(perms.Subject, rule,
 					"KUBE-PRIVESC-014", models.SeverityHigh, models.CategoryPrivilegeEscalation,
 					scaledScore(8.0),
@@ -246,7 +296,7 @@ func (a *Analyzer) Analyze(_ context.Context, snapshot models.Snapshot) ([]model
 			// target namespace does not enforce a PSA level that blocks privileged
 			// pods, the same pod-create grant also yields a host escape. Full
 			// wildcards are already -017, so skip them here to avoid noise.
-			isPodCreate := hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create")
+			isPodCreate := rule.grants(targetPods, "create")
 			isFullWildcard := hasWildcard(rule.Verbs) && hasWildcard(rule.Resources) && hasWildcard(rule.APIGroups)
 			if isPodCreate && !isFullWildcard {
 				if target, ok := podCreatePrivilegedTarget(rule.Namespace, privilegedNamespaces); ok {
@@ -639,10 +689,18 @@ func findingFromContent(subject models.SubjectRef, rule effectiveRule, ruleID st
 		"source_binding_kind": rule.SourceBindingKind,
 		"api_groups":          rule.APIGroups,
 		"resources":           rule.Resources,
+		"resource_names":      rule.ResourceNames,
 		"verbs":               rule.Verbs,
 		"namespace":           rule.Namespace,
 		"scope":               string(content.Scope.Level),
 	})
+
+	tags := []string{"module:rbac"}
+	if len(rule.ResourceNames) > 0 {
+		// Surface that this grant reaches only specific named objects, so report
+		// consumers can see the scope that attenuated the score.
+		tags = append(tags, "scope:resource-names")
+	}
 
 	resource := &models.ResourceRef{
 		Kind:      "RBACRule",
@@ -676,7 +734,7 @@ func findingFromContent(subject models.SubjectRef, rule effectiveRule, ruleID st
 		References:       references,
 		LearnMore:        content.LearnMore,
 		MitreTechniques:  content.MitreTechniques,
-		Tags:             []string{"module:rbac"},
+		Tags:             tags,
 	}
 }
 
@@ -717,46 +775,18 @@ func subjectRef(subject rbacv1.Subject, fallbackNamespace string) models.Subject
 	return ref
 }
 
+// hasWildcard reports whether values contains the "*" match-all token. Retained for
+// the triple-wildcard cluster-admin check (KUBE-PRIVESC-017); the resource/verb
+// primitive matching now goes through effectiveRule.grants / permissions.Grants.
 func hasWildcard(values []string) bool {
 	return slices.Contains(values, "*")
-}
-
-func hasAnyVerb(values []string, wanted ...string) bool {
-	if hasWildcard(values) {
-		return true
-	}
-	for _, value := range wanted {
-		if slices.Contains(values, value) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasResource(values []string, wanted string) bool {
-	if hasWildcard(values) {
-		return true
-	}
-	return slices.Contains(values, wanted)
-}
-
-func hasAnyResource(values []string, wanted []string) bool {
-	if hasWildcard(values) {
-		return true
-	}
-	for _, value := range wanted {
-		if slices.Contains(values, value) {
-			return true
-		}
-	}
-	return false
 }
 
 // matchesCSRCreate reports whether rule grants `create` on the cluster-scoped
 // `certificatesigningrequests` resource. Cluster scope is the caller's
 // responsibility (rule.Namespace == "").
 func matchesCSRCreate(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "certificatesigningrequests") && hasAnyVerb(rule.Verbs, "create")
+	return rule.grants(targetCSR, "create")
 }
 
 // matchesCSRApprove reports whether rule grants `update` or `patch` on the
@@ -765,32 +795,32 @@ func matchesCSRCreate(rule effectiveRule) bool {
 // does not allow approval — so this check is narrow on resource and broad on
 // the two verbs `kubectl certificate approve` could use.
 func matchesCSRApprove(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "certificatesigningrequests/approval") && hasAnyVerb(rule.Verbs, "update", "patch")
+	return rule.grants(targetCSRApproval, "update", "patch")
 }
 
 // matchesSecretCreate / matchesSecretGet are the two halves of the
 // KUBE-PRIVESC-007 secret-creation token-theft primitive.
 func matchesSecretCreate(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "create")
+	return rule.grants(targetSecrets, "create")
 }
 
 func matchesSecretGet(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get")
+	return rule.grants(targetSecrets, "get")
 }
 
 // matchesPodDelete, matchesNodeStatusWrite, and matchesNodeDelete are the
 // halves of the KUBE-PRIVESC-016 node-migration primitive. The node halves are
 // cluster-scoped resources, so the caller also requires rule.Namespace == "".
 func matchesPodDelete(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "delete")
+	return rule.grants(targetPods, "delete")
 }
 
 func matchesNodeStatusWrite(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "nodes/status") && hasAnyVerb(rule.Verbs, "update", "patch")
+	return rule.grants(targetNodesStatus, "update", "patch")
 }
 
 func matchesNodeDelete(rule effectiveRule) bool {
-	return hasResource(rule.Resources, "nodes") && hasAnyVerb(rule.Verbs, "delete")
+	return rule.grants(targetNodes, "delete")
 }
 
 // scopesCompose reports whether a create-secrets grant in createNs and a

--- a/internal/analyzer/rbac/analyzer_test.go
+++ b/internal/analyzer/rbac/analyzer_test.go
@@ -502,6 +502,75 @@ func TestCSRMintPrimitiveNamespaceScopeIgnored(t *testing.T) {
 	}
 }
 
+// TestResourceNamesAndAPIGroupPrecision covers the precision fixes: matching on
+// (apiGroup, resource, verb) rather than the bare resource name, and honoring a
+// rule's resourceNames so a name-scoped grant stops firing the "read/create the
+// whole resource type" primitives.
+func TestResourceNamesAndAPIGroupPrecision(t *testing.T) {
+	t.Parallel()
+
+	find := func(findings []models.Finding, ruleID string) *models.Finding {
+		for i := range findings {
+			if findings[i].RuleID == ruleID {
+				return &findings[i]
+			}
+		}
+		return nil
+	}
+	analyze := func(t *testing.T, rule rbacv1.PolicyRule) []models.Finding {
+		t.Helper()
+		findings, err := New().Analyze(context.Background(), clusterRoleSnapshot("role", "sa", rule))
+		if err != nil {
+			t.Fatalf("Analyze() error = %v", err)
+		}
+		return findings
+	}
+
+	t.Run("custom-group secrets does not match core secrets", func(t *testing.T) {
+		t.Parallel()
+		findings := analyze(t, rbacv1.PolicyRule{APIGroups: []string{"example.com"}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}})
+		assertRuleAbsent(t, findings, "KUBE-PRIVESC-005")
+		assertRuleAbsent(t, findings, "KUBE-PRIVESC-006")
+	})
+
+	t.Run("name-scoped list secrets cannot enumerate", func(t *testing.T) {
+		t.Parallel()
+		findings := analyze(t, rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"list", "watch"}, ResourceNames: []string{"tls-cert"}})
+		assertRuleAbsent(t, findings, "KUBE-PRIVESC-005")
+		assertRuleAbsent(t, findings, "KUBE-PRIVESC-006")
+	})
+
+	t.Run("name-scoped create pods is voided", func(t *testing.T) {
+		t.Parallel()
+		findings := analyze(t, rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"create"}, ResourceNames: []string{"only-this-pod"}})
+		assertRuleAbsent(t, findings, "KUBE-PRIVESC-001")
+	})
+
+	t.Run("name-scoped get secrets fires scoped and attenuated", func(t *testing.T) {
+		t.Parallel()
+		scoped := find(analyze(t, rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"}, ResourceNames: []string{"tls-cert"}}), "KUBE-PRIVESC-006")
+		if scoped == nil {
+			t.Fatal("name-scoped get secrets should still surface KUBE-PRIVESC-006 (a real, scoped read)")
+		}
+		if !strings.Contains(strings.Join(scoped.Tags, ","), "scope:resource-names") {
+			t.Errorf("expected scope:resource-names tag, got %v", scoped.Tags)
+		}
+		unrestricted := find(analyze(t, rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"}}), "KUBE-PRIVESC-006")
+		if unrestricted == nil {
+			t.Fatal("unrestricted get secrets should surface KUBE-PRIVESC-006")
+		}
+		if !(scoped.Score < unrestricted.Score) {
+			t.Errorf("name-scoped grant should score below unrestricted: scoped=%v unrestricted=%v", scoped.Score, unrestricted.Score)
+		}
+	})
+
+	t.Run("name-scoped impersonate still fires (named target still dangerous)", func(t *testing.T) {
+		t.Parallel()
+		findings := analyze(t, rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"groups"}, Verbs: []string{"impersonate"}, ResourceNames: []string{"system:masters"}})
+		assertRulePresent(t, findings, "KUBE-PRIVESC-008")
+	})
+}
+
 // clusterRoleSnapshot builds a snapshot with one ClusterRole (carrying rules)
 // bound cluster-wide to default/<saName>. Helper for the single-permission
 // technique tests below.

--- a/internal/analyzer/serviceaccount/analyzer.go
+++ b/internal/analyzer/serviceaccount/analyzer.go
@@ -19,6 +19,18 @@ import (
 // Analyzer produces service-account-focused findings from a snapshot.
 type Analyzer struct{}
 
+// Target sets for the dangerous-capability checks, each pinned to its API group so a
+// custom resource that reuses a core name does not trip a core-resource check.
+var (
+	targetSecrets     = []permissions.ResourceTarget{permissions.Core("secrets")}
+	targetPods        = []permissions.ResourceTarget{permissions.Core("pods")}
+	targetNodesProxy  = []permissions.ResourceTarget{permissions.Core("nodes/proxy")}
+	targetImpersonate = []permissions.ResourceTarget{permissions.Core("users"), permissions.Core("groups"), permissions.Core("serviceaccounts")}
+	targetWorkloads   = []permissions.ResourceTarget{permissions.InGroup("apps", "deployments"), permissions.InGroup("apps", "daemonsets"), permissions.InGroup("apps", "statefulsets"), permissions.InGroup("batch", "jobs"), permissions.InGroup("batch", "cronjobs")}
+	targetRoles       = []permissions.ResourceTarget{permissions.InGroup("rbac.authorization.k8s.io", "roles"), permissions.InGroup("rbac.authorization.k8s.io", "clusterroles")}
+	targetBindings    = []permissions.ResourceTarget{permissions.InGroup("rbac.authorization.k8s.io", "rolebindings"), permissions.InGroup("rbac.authorization.k8s.io", "clusterrolebindings")}
+)
+
 // workloadRef captures a pod-bearing workload that mounts a given ServiceAccount.
 type workloadRef struct {
 	Kind      string `json:"kind"`
@@ -181,7 +193,9 @@ func summarizeRules(rules []permissions.EffectiveRule) []map[string]any {
 	for _, rule := range rules {
 		summary = append(summary, map[string]any{
 			"namespace":      rule.Namespace,
+			"api_groups":     rule.APIGroups,
 			"resources":      rule.Resources,
+			"resource_names": rule.ResourceNames,
 			"verbs":          rule.Verbs,
 			"source_role":    rule.SourceRole,
 			"source_binding": rule.SourceBinding,
@@ -212,25 +226,25 @@ func hasClusterAdminStyleRule(rules []permissions.EffectiveRule) bool {
 func dangerousCapabilities(rules []permissions.EffectiveRule) []string {
 	found := make([]string, 0)
 	for _, rule := range rules {
-		if hasResource(rule.Resources, "secrets") && hasAnyVerb(rule.Verbs, "get", "list", "watch") {
+		if rule.Grants(targetSecrets, "get", "list", "watch") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "secrets"))
 		}
-		if hasResource(rule.Resources, "pods") && hasAnyVerb(rule.Verbs, "create") {
+		if rule.Grants(targetPods, "create") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "create pods"))
 		}
-		if hasAnyResource(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) && hasAnyVerb(rule.Verbs, "create", "update", "patch") {
+		if rule.Grants(targetWorkloads, "create", "update", "patch") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "mutate workloads"))
 		}
-		if hasAnyResource(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) && hasAnyVerb(rule.Verbs, "create", "update", "patch") {
+		if rule.Grants(targetBindings, "create", "update", "patch") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "bind roles"))
 		}
-		if hasAnyResource(rule.Resources, []string{"roles", "clusterroles"}) && hasAnyVerb(rule.Verbs, "bind", "escalate") {
+		if rule.Grants(targetRoles, "bind", "escalate") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "bind/escalate"))
 		}
-		if hasAnyResource(rule.Resources, []string{"users", "groups", "serviceaccounts"}) && hasAnyVerb(rule.Verbs, "impersonate") {
+		if rule.Grants(targetImpersonate, "impersonate") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "impersonate"))
 		}
-		if hasResource(rule.Resources, "nodes/proxy") && hasAnyVerb(rule.Verbs, "get") {
+		if rule.Grants(targetNodesProxy, "get") {
 			found = appendIfMissing(found, scopedCapability(rule.Namespace, "nodes/proxy"))
 		}
 	}
@@ -394,37 +408,8 @@ func hasDangerousCapability(values []string, fragments ...string) bool {
 	return false
 }
 
+// contains reports membership; retained for the wildcard cluster-admin-style check.
+// The resource/verb capability matching now goes through permissions.Grants.
 func contains(values []string, wanted string) bool {
 	return slices.Contains(values, wanted)
-}
-
-func hasAnyVerb(values []string, wanted ...string) bool {
-	if contains(values, "*") {
-		return true
-	}
-	for _, item := range wanted {
-		if contains(values, item) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasResource(values []string, wanted string) bool {
-	if contains(values, "*") {
-		return true
-	}
-	return contains(values, wanted)
-}
-
-func hasAnyResource(values []string, wanted []string) bool {
-	if contains(values, "*") {
-		return true
-	}
-	for _, item := range wanted {
-		if contains(values, item) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/models/finding.go
+++ b/internal/models/finding.go
@@ -295,8 +295,13 @@ func (r ResourceRef) Key() string {
 
 // EscalationHop is one step in a privilege-escalation chain: who moved to whom, which permission enabled it, and why.
 type EscalationHop struct {
-	Step        int        `json:"step"`   // 1-indexed position in the chain
-	Action      string     `json:"action"` // technique identifier, e.g. "pod_exec", "impersonate"
+	Step   int    `json:"step"`   // 1-indexed position in the chain
+	Action string `json:"action"` // short action label, e.g. "pod_exec", "impersonate"
+	// Technique is the stable rule identifier of the edge that enabled this hop
+	// (e.g. "KUBE-PRIVESC-008", or the "KUBE-ESCAPE" family for pod host escapes).
+	// It lets the correlation pass amplify only the findings that are the actual
+	// edges of a chain, rather than every finding that merely shares the subject.
+	Technique   string     `json:"technique,omitempty"`
 	FromSubject SubjectRef `json:"from_subject"`
 	ToSubject   SubjectRef `json:"to_subject"`
 	Permission  string     `json:"permission"` // RBAC permission or condition that enables the hop

--- a/internal/permissions/aggregate.go
+++ b/internal/permissions/aggregate.go
@@ -12,10 +12,16 @@ import (
 
 // EffectiveRule is one PolicyRule copy tagged with where it came from (namespace, originating Role/ClusterRole, binding).
 type EffectiveRule struct {
-	Namespace     string // binding namespace, or empty for cluster-scoped rules
-	APIGroups     []string
-	Resources     []string
-	Verbs         []string
+	Namespace string // binding namespace, or empty for cluster-scoped rules
+	APIGroups []string
+	Resources []string
+	Verbs     []string
+	// ResourceNames is the PolicyRule's optional whitelist of object names the rule
+	// applies to. Empty means the rule reaches every object of its resource type; a
+	// non-empty list scopes the grant to those named objects, which the shared
+	// matcher (matcher.go) honors so name-scoped grants stop firing the broad
+	// "read/enumerate/create the whole resource type" checks.
+	ResourceNames []string
 	SourceRole    string
 	SourceBinding string
 }
@@ -52,6 +58,7 @@ func Aggregate(snapshot models.Snapshot) map[string]*EffectivePermissions {
 					APIGroups:     append([]string(nil), rule.APIGroups...),
 					Resources:     append([]string(nil), rule.Resources...),
 					Verbs:         append([]string(nil), rule.Verbs...),
+					ResourceNames: append([]string(nil), rule.ResourceNames...),
 					SourceRole:    binding.RoleRef.Name,
 					SourceBinding: binding.Name,
 				})
@@ -70,6 +77,7 @@ func Aggregate(snapshot models.Snapshot) map[string]*EffectivePermissions {
 					APIGroups:     append([]string(nil), rule.APIGroups...),
 					Resources:     append([]string(nil), rule.Resources...),
 					Verbs:         append([]string(nil), rule.Verbs...),
+					ResourceNames: append([]string(nil), rule.ResourceNames...),
 					SourceRole:    binding.RoleRef.Name,
 					SourceBinding: binding.Name,
 				})

--- a/internal/permissions/matcher.go
+++ b/internal/permissions/matcher.go
@@ -1,0 +1,108 @@
+// Package permissions - matcher.go: the shared RBAC capability matcher used by the
+// rbac, serviceaccount, and privesc analyzers. It answers one question - "does this
+// effective rule authorize <verb> on <(apiGroup, resource)>?" - with the three
+// pieces of RBAC precision the analyzers used to skip:
+//
+//  1. apiGroup awareness. A PolicyRule authorizes a request only when it covers the
+//     request's API group AND resource AND verb. Matching on the bare resource name
+//     (ignoring the group) mis-fires on custom resources that reuse a core name -
+//     e.g. a CRD `secrets.example.com` in group `example.com` is not the core
+//     `secrets`. Grants requires both the group and the resource to line up.
+//
+//  2. resourceNames awareness. A rule with a non-empty ResourceNames applies only to
+//     those named object instances. RBAC cannot scope a request that has no object
+//     name at authorization time - `list`, `watch`, `deletecollection`, and `create`
+//     on a top-level resource - so a name-scoped rule does NOT authorize those verbs
+//     (Kubernetes documents "you cannot restrict create or deletecollection requests
+//     by their resource name"). Verbs that act on a named object (`get`, `update`,
+//     `patch`, `delete`, `bind`, `escalate`, `impersonate`, and `create` on a
+//     subresource whose parent name rides in the URL, like `pods/exec`) still match,
+//     scoped to the named objects.
+//
+//  3. wildcard handling on every axis: "*" in the rule's groups, resources, or verbs
+//     matches anything on that axis.
+package permissions
+
+import "strings"
+
+// ResourceTarget is one (apiGroup, resource) pair a capability check looks for.
+// Group "" is the core API group; Resource may name a subresource such as "pods/exec".
+type ResourceTarget struct {
+	Group    string
+	Resource string
+}
+
+// Core builds a ResourceTarget in the core ("") API group.
+func Core(resource string) ResourceTarget {
+	return ResourceTarget{Group: "", Resource: resource}
+}
+
+// InGroup builds a ResourceTarget in the named API group.
+func InGroup(group, resource string) ResourceTarget {
+	return ResourceTarget{Group: group, Resource: resource}
+}
+
+// NameScoped reports whether this rule is restricted to specific named objects via
+// resourceNames. Callers use it to annotate findings (evidence, tags, attenuated
+// blast radius) when a matched grant only reaches a fixed set of named objects.
+func (r EffectiveRule) NameScoped() bool {
+	return len(r.ResourceNames) > 0
+}
+
+// Grants reports whether this effective rule authorizes any of the wanted verbs on
+// any of the given targets. It is the method form of the package-level Grants, so
+// analyzers holding a permissions.EffectiveRule can write rule.Grants(targets, verbs...).
+func (r EffectiveRule) Grants(targets []ResourceTarget, verbs ...string) bool {
+	return Grants(r.APIGroups, r.Resources, r.Verbs, r.ResourceNames, targets, verbs)
+}
+
+// Grants reports whether an RBAC rule described by (apiGroups, resources, verbs,
+// resourceNames) authorizes any of wantedVerbs on any of targets. See the package
+// doc for the apiGroup / resourceNames / wildcard semantics it enforces.
+func Grants(apiGroups, resources, verbs, resourceNames []string, targets []ResourceTarget, wantedVerbs []string) bool {
+	nameScoped := len(resourceNames) > 0
+	for _, target := range targets {
+		if !covers(apiGroups, target.Group) || !covers(resources, target.Resource) {
+			continue
+		}
+		for _, verb := range wantedVerbs {
+			if nameScoped && collectionVerb(verb, target.Resource) {
+				// A name-scoped rule cannot authorize a request that carries no object
+				// name at authorization time, so this verb drops out of the match.
+				continue
+			}
+			if covers(verbs, verb) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// covers reports whether an RBAC axis (a rule's groups, resources, or verbs) includes
+// want, treating "*" as a match-all wildcard. Core-group membership works naturally:
+// the core group is the empty string, so covers([""], "") is true.
+func covers(values []string, want string) bool {
+	for _, v := range values {
+		if v == "*" || v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// collectionVerb reports whether verb operates on a collection (or creates a new
+// object) with no object name available at authorization time, so a resourceNames
+// restriction cannot authorize it. `create` is collection-like only for top-level
+// resources: on a subresource (resource contains "/") the parent object's name rides
+// in the request URL, so resourceNames scopes it and it is NOT collection-like.
+func collectionVerb(verb, resource string) bool {
+	switch verb {
+	case "list", "watch", "deletecollection":
+		return true
+	case "create":
+		return !strings.Contains(resource, "/")
+	default:
+		return false
+	}
+}

--- a/internal/permissions/matcher_test.go
+++ b/internal/permissions/matcher_test.go
@@ -1,0 +1,156 @@
+package permissions
+
+import "testing"
+
+func TestGrantsAPIGroupAwareness(t *testing.T) {
+	tests := []struct {
+		name      string
+		apiGroups []string
+		resources []string
+		verbs     []string
+		targets   []ResourceTarget
+		want      []string
+		expect    bool
+	}{
+		{
+			name:      "core secrets matches core target",
+			apiGroups: []string{""}, resources: []string{"secrets"}, verbs: []string{"get"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: true,
+		},
+		{
+			name:      "custom-group secrets does not match core secrets",
+			apiGroups: []string{"example.com"}, resources: []string{"secrets"}, verbs: []string{"get"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: false,
+		},
+		{
+			name:      "wildcard apiGroup matches core target",
+			apiGroups: []string{"*"}, resources: []string{"secrets"}, verbs: []string{"get"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: true,
+		},
+		{
+			name:      "rbac group required for rolebindings",
+			apiGroups: []string{""}, resources: []string{"rolebindings"}, verbs: []string{"create"},
+			targets: []ResourceTarget{InGroup("rbac.authorization.k8s.io", "rolebindings")}, want: []string{"create"}, expect: false,
+		},
+		{
+			name:      "rbac group matches rolebindings",
+			apiGroups: []string{"rbac.authorization.k8s.io"}, resources: []string{"rolebindings"}, verbs: []string{"patch"},
+			targets: []ResourceTarget{InGroup("rbac.authorization.k8s.io", "rolebindings")}, want: []string{"create", "update", "patch"}, expect: true,
+		},
+		{
+			name:      "wildcard resource matches any target in the group",
+			apiGroups: []string{""}, resources: []string{"*"}, verbs: []string{"get"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: true,
+		},
+		{
+			name:      "verb must also match",
+			apiGroups: []string{""}, resources: []string{"secrets"}, verbs: []string{"list"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Grants(tt.apiGroups, tt.resources, tt.verbs, nil, tt.targets, tt.want)
+			if got != tt.expect {
+				t.Errorf("Grants() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestGrantsResourceNamesSemantics(t *testing.T) {
+	names := []string{"my-object"}
+	tests := []struct {
+		name      string
+		resources []string
+		verbs     []string
+		targets   []ResourceTarget
+		want      []string
+		expect    bool
+	}{
+		{
+			name:      "list on named collection is voided (cannot enumerate)",
+			resources: []string{"secrets"}, verbs: []string{"list"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"list"}, expect: false,
+		},
+		{
+			name:      "watch on named collection is voided",
+			resources: []string{"secrets"}, verbs: []string{"watch"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"watch"}, expect: false,
+		},
+		{
+			name:      "create on top-level resource is voided (no name at authz time)",
+			resources: []string{"pods"}, verbs: []string{"create"},
+			targets: []ResourceTarget{Core("pods")}, want: []string{"create"}, expect: false,
+		},
+		{
+			name:      "deletecollection is voided",
+			resources: []string{"secrets"}, verbs: []string{"deletecollection"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"deletecollection"}, expect: false,
+		},
+		{
+			name:      "get on named object still matches (scoped read)",
+			resources: []string{"secrets"}, verbs: []string{"get"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: true,
+		},
+		{
+			name:      "update/patch on named object still matches",
+			resources: []string{"secrets"}, verbs: []string{"patch"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"update", "patch"}, expect: true,
+		},
+		{
+			name:      "impersonate scoped to named identity still matches (still dangerous)",
+			resources: []string{"groups"}, verbs: []string{"impersonate"},
+			targets: []ResourceTarget{Core("groups")}, want: []string{"impersonate"}, expect: true,
+		},
+		{
+			name:      "create on a subresource is name-scopable (parent name in URL)",
+			resources: []string{"serviceaccounts/token"}, verbs: []string{"create"},
+			targets: []ResourceTarget{Core("serviceaccounts/token")}, want: []string{"create"}, expect: true,
+		},
+		{
+			name:      "exec (create on pods/exec) is name-scopable",
+			resources: []string{"pods/exec"}, verbs: []string{"create"},
+			targets: []ResourceTarget{Core("pods/exec")}, want: []string{"create", "get"}, expect: true,
+		},
+		{
+			name:      "wildcard verb does not resurrect a voided list",
+			resources: []string{"secrets"}, verbs: []string{"*"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"list"}, expect: false,
+		},
+		{
+			name:      "wildcard verb still authorizes a name-scopable get",
+			resources: []string{"secrets"}, verbs: []string{"*"},
+			targets: []ResourceTarget{Core("secrets")}, want: []string{"get"}, expect: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Grants([]string{""}, tt.resources, tt.verbs, names, tt.targets, tt.want)
+			if got != tt.expect {
+				t.Errorf("Grants(resourceNames=%v) = %v, want %v", names, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestEffectiveRuleGrantsAndNameScoped(t *testing.T) {
+	unrestricted := EffectiveRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"list"}}
+	if unrestricted.NameScoped() {
+		t.Error("rule without resourceNames should not report NameScoped")
+	}
+	if !unrestricted.Grants([]ResourceTarget{Core("secrets")}, "list") {
+		t.Error("unrestricted list secrets should grant")
+	}
+
+	scoped := EffectiveRule{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"list", "get"}, ResourceNames: []string{"tls"}}
+	if !scoped.NameScoped() {
+		t.Error("rule with resourceNames should report NameScoped")
+	}
+	if scoped.Grants([]ResourceTarget{Core("secrets")}, "list") {
+		t.Error("name-scoped list secrets must not grant enumeration")
+	}
+	if !scoped.Grants([]ResourceTarget{Core("secrets")}, "get") {
+		t.Error("name-scoped get secrets should still grant a scoped read")
+	}
+}

--- a/internal/remediation/serviceaccount.go
+++ b/internal/remediation/serviceaccount.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 
 	"github.com/0hardik1/kubesplaining/internal/models"
+	"github.com/0hardik1/kubesplaining/internal/permissions"
 )
 
 // ForServiceAccount returns the structured remediation for a ServiceAccount-
@@ -59,10 +60,14 @@ func ForServiceAccount(ruleID string, finding models.Finding, _ models.Snapshot)
 
 // saEvidenceRule mirrors the inner shape of evidence.rules[] emitted by the SA
 // analyzer's summarizeRules helper. JSON tags match analyzer.go's evidence
-// builder exactly so the unmarshal is direct.
+// builder exactly so the unmarshal is direct. APIGroups and ResourceNames are
+// required for isDangerousSARule to stay in lockstep with the analyzer's
+// apiGroup- and resourceNames-aware matching.
 type saEvidenceRule struct {
 	Namespace     string   `json:"namespace"`
+	APIGroups     []string `json:"api_groups"`
 	Resources     []string `json:"resources"`
+	ResourceNames []string `json:"resource_names"`
 	Verbs         []string `json:"verbs"`
 	SourceRole    string   `json:"source_role"`
 	SourceBinding string   `json:"source_binding"`
@@ -129,64 +134,31 @@ func pickDangerousRule(rules []saEvidenceRule) (saEvidenceRule, bool) {
 	return saEvidenceRule{}, false
 }
 
-// isDangerousSARule mirrors the patterns in the SA analyzer's
-// dangerousCapabilities helper so the remediation diff highlights the same
-// rule the analyzer flagged. Returns true on the first match: the rule is
-// "dangerous" if it grants any of the high-risk verb/resource pairs the
-// analyzer cares about.
+// saDangerousTargets are the (apiGroup, resource) + verb checks the SA analyzer's
+// dangerousCapabilities helper flags. Kept here as a table so isDangerousSARule
+// runs through the exact same permissions.Grants matcher the analyzer uses -
+// apiGroup-aware and resourceNames-aware - instead of a diverging bare-name copy.
+var saDangerousTargets = []struct {
+	targets []permissions.ResourceTarget
+	verbs   []string
+}{
+	{[]permissions.ResourceTarget{permissions.Core("secrets")}, []string{"get", "list", "watch"}},
+	{[]permissions.ResourceTarget{permissions.Core("pods")}, []string{"create"}},
+	{[]permissions.ResourceTarget{permissions.InGroup("apps", "deployments"), permissions.InGroup("apps", "daemonsets"), permissions.InGroup("apps", "statefulsets"), permissions.InGroup("batch", "jobs"), permissions.InGroup("batch", "cronjobs")}, []string{"create", "update", "patch"}},
+	{[]permissions.ResourceTarget{permissions.InGroup("rbac.authorization.k8s.io", "rolebindings"), permissions.InGroup("rbac.authorization.k8s.io", "clusterrolebindings")}, []string{"create", "update", "patch"}},
+	{[]permissions.ResourceTarget{permissions.InGroup("rbac.authorization.k8s.io", "roles"), permissions.InGroup("rbac.authorization.k8s.io", "clusterroles")}, []string{"bind", "escalate"}},
+	{[]permissions.ResourceTarget{permissions.Core("users"), permissions.Core("groups"), permissions.Core("serviceaccounts")}, []string{"impersonate"}},
+	{[]permissions.ResourceTarget{permissions.Core("nodes/proxy")}, []string{"get"}},
+}
+
+// isDangerousSARule reports whether an evidence rule grants one of the high-risk
+// capabilities the SA analyzer's dangerousCapabilities helper flags, using the
+// same permissions.Grants matcher (apiGroup- and resourceNames-aware) so the
+// remediation diff highlights exactly the rule the analyzer counted - never a
+// name-scoped or wrong-apiGroup rule the analyzer discounted.
 func isDangerousSARule(rule saEvidenceRule) bool {
-	if hasAny(rule.Resources, "secrets") && hasAny(rule.Verbs, "get", "list", "watch") {
-		return true
-	}
-	if hasAny(rule.Resources, "pods") && hasAny(rule.Verbs, "create") {
-		return true
-	}
-	if hasAnySlice(rule.Resources, []string{"deployments", "daemonsets", "statefulsets", "jobs", "cronjobs"}) &&
-		hasAny(rule.Verbs, "create", "update", "patch") {
-		return true
-	}
-	if hasAnySlice(rule.Resources, []string{"rolebindings", "clusterrolebindings"}) &&
-		hasAny(rule.Verbs, "create", "update", "patch") {
-		return true
-	}
-	if hasAnySlice(rule.Resources, []string{"roles", "clusterroles"}) &&
-		hasAny(rule.Verbs, "bind", "escalate") {
-		return true
-	}
-	if hasAnySlice(rule.Resources, []string{"users", "groups", "serviceaccounts"}) &&
-		hasAny(rule.Verbs, "impersonate") {
-		return true
-	}
-	if hasAny(rule.Resources, "nodes/proxy") && hasAny(rule.Verbs, "get") {
-		return true
-	}
-	return false
-}
-
-// hasAny reports whether values contains either "*" (RBAC wildcard) or any of
-// the explicitly listed needles. Mirrors the analyzer's hasResource / hasAnyVerb
-// helpers so the remediation logic stays in sync.
-func hasAny(values []string, needles ...string) bool {
-	if saContainsString(values, "*") {
-		return true
-	}
-	for _, needle := range needles {
-		if saContainsString(values, needle) {
-			return true
-		}
-	}
-	return false
-}
-
-// hasAnySlice is hasAny but for the case where the needles list is itself a
-// slice variable (avoids the awkward `hasAny(v, slice...)` spread in callers
-// that already have a built slice).
-func hasAnySlice(values []string, needles []string) bool {
-	if saContainsString(values, "*") {
-		return true
-	}
-	for _, needle := range needles {
-		if saContainsString(values, needle) {
+	for _, check := range saDangerousTargets {
+		if permissions.Grants(rule.APIGroups, rule.Resources, rule.Verbs, rule.ResourceNames, check.targets, check.verbs) {
 			return true
 		}
 	}
@@ -242,10 +214,7 @@ func serviceAccountRoleEditHint(rule saEvidenceRule) *models.RemediationHint {
 		// operator still sees the kubectl edit recipe.
 		return commandOnlyHint(target, buildKubectlEditCommand(target))
 	}
-	// SA evidence does not currently carry the rule's apiGroups, so the diff
-	// renders with `apiGroups: []`. That is honest about what we know rather
-	// than guessing at "" (the core group) and steering the operator wrong.
-	diff := removeRuleDiff(kind, name, namespace, nil, rule.Resources, rule.Verbs)
+	diff := removeRuleDiff(kind, name, namespace, rule.APIGroups, rule.Resources, rule.Verbs)
 	cmd := buildKubectlEditCommand(target)
 	return &models.RemediationHint{
 		Patch: &models.KubectlPatch{

--- a/internal/remediation/serviceaccount_test.go
+++ b/internal/remediation/serviceaccount_test.go
@@ -45,6 +45,7 @@ func TestForServiceAccountPrivileged001(t *testing.T) {
 		"rules": []map[string]any{
 			{
 				"namespace":      "",
+				"api_groups":     []string{"*"},
 				"resources":      []string{"*"},
 				"verbs":          []string{"*"},
 				"source_role":    "cluster-admin",
@@ -93,6 +94,7 @@ func TestForServiceAccountPrivileged002(t *testing.T) {
 		"rules": []map[string]any{
 			{
 				"namespace":      "app",
+				"api_groups":     []string{""},
 				"resources":      []string{"secrets"},
 				"verbs":          []string{"get", "list"},
 				"source_role":    "app-reader",
@@ -138,6 +140,7 @@ func TestForServiceAccountDefault002(t *testing.T) {
 		"rules": []map[string]any{
 			{
 				"namespace":      "",
+				"api_groups":     []string{""},
 				"resources":      []string{"pods"},
 				"verbs":          []string{"create"},
 				"source_role":    "pod-creator",


### PR DESCRIPTION
## What

Three precision fixes to RBAC matching and privesc-chain correlation that reduce false positives across the `rbac`, `secrets`, `serviceaccount`, and `privesc` modules. They share a new matcher, `internal/permissions/matcher.go`, that all three analyzers route through.

### 1. Model `resourceNames`

`ResourceNames` is added to `permissions.EffectiveRule` (populated in both binding loops of `aggregate.go` and the rbac analyzer's local rule) and honored in the shared matcher. A name-scoped rule cannot authorize a request that carries no object name at authorization time, so `list` / `watch` / `deletecollection` and `create` on a top-level resource drop out of the match; name-scopable verbs (`get` / `update` / `patch` / `delete` / `bind` / `escalate` / `impersonate`, and `create` on a subresource whose parent name rides in the URL) still match.

RBAC findings on a name-scoped grant gain a `scope:resource-names` tag and 0.6x blast-radius attenuation, so they rank below an unrestricted grant of the same permission instead of vanishing.

### 2. Match on `(apiGroup, resource, verb)`, not the bare resource

`permissions.Grants` requires the API group, resource, and verb to all line up (with wildcards on each axis). The `rbac`, `serviceaccount`, and `privesc` analyzers route their dangerous-capability checks through group-pinned target tables, so a CRD that reuses a core name (e.g. `secrets.example.com` in group `example.com`) no longer trips the core-`secrets` checks.

### 3. Make `correlate` causal

`EscalationHop` now carries the `Technique` of the edge that enabled it. `correlate` builds per-subject path edges `(FromSubject → technique → sink severity)` and amplifies a finding only when its own `(Subject, RuleID)` is an actual edge of a chain, instead of bumping every finding that merely shares a subject with a privesc path.

## Consumers kept in lockstep

- The SA remediation matcher (`isDangerousSARule`) is routed through the same `permissions.Grants` table the analyzer uses, so the remediation diff highlights exactly the rule the analyzer counted, never a name-scoped or wrong-apiGroup rule it discounted.
- Cloud escalation-edge techniques use family prefixes (`KUBE-CLOUD-IRSA`, `KUBE-CLOUD-AWSAUTH`) that prefix-match the emitted rule IDs, so those edge findings amplify correctly under the new causal `correlate`.

## Testing

- `go test ./...` (all green), `gofmt -l` clean, `go vet` clean, `golangci-lint run ./...` (0 issues)
- `make e2e`: all 76 expected rule IDs present, no namespace-scoped cluster-admin false positive, PSA/admission/remediation assertions green
- New unit coverage: `permissions/matcher_test.go` (apiGroup awareness, resourceNames verb semantics), `rbac` resourceNames + apiGroup precision, `privesc` name-scoped secret-get produces no kube-system path, and causal-correlation edge/bystander/family-prefix/resource-anchored cases

https://claude.ai/code/session_01SH9DjVimnWc5CX2KVyRGua
