### PR TITLE
fix(report): escape analyzer strings in evidence rows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 require (
 	github.com/google/cel-go v0.29.2
 	github.com/spf13/cobra v1.10.2
-	golang.org/x/text v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -40,6 +39,7 @@ require (
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect

--- a/internal/report/evidence_glossary.go
+++ b/internal/report/evidence_glossary.go
@@ -118,7 +118,16 @@ var secretTypeLabels = map[string]string{
 	"bootstrap.kubernetes.io/token":       "Bootstrap token (joins new nodes to the cluster)",
 }
 
-// hostNamespaceHints explains what each pod-level "host*" boolean grants when set.
+// trueIsSafeBoolKeys names the boolean evidence fields whose *false* value is the
+// risky one, inverting the default true-is-bad polarity that every host*/privileged
+// flag follows. boolRow consults this to decide whether to apply the "danger" chip
+// styling and surface the hint, so a hardened `runAsNonRoot: true` is not painted red.
+// A key absent from this map is treated as true-is-bad.
+var trueIsSafeBoolKeys = map[string]bool{
+	"runAsNonRoot": true,
+}
+
+// hostNamespaceHints explains what each pod-level boolean means in its risky state.
 var hostNamespaceHints = map[string]string{
 	"hostNetwork":              "Shares the node's network namespace (sees every pod's traffic, binds to node IPs)",
 	"hostPID":                  "Shares the node's process namespace (can ptrace/kill node processes)",

--- a/internal/report/evidence_render.go
+++ b/internal/report/evidence_render.go
@@ -17,13 +17,8 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/0hardik1/kubesplaining/internal/models"
 )
-
-var titleCaser = cases.Title(language.English)
 
 // renderEvidence parses Evidence (an analyzer-emitted JSON object) and renders a
 // labeled grid with semantic formatting per known key. Returns "" when the payload
@@ -135,14 +130,18 @@ func renderEvidenceRow(key string, val any, obj map[string]any) string {
 	case "source_binding":
 		return kubectlRow("Source binding", asString(val), sourceBindingCmd(asString(val), obj))
 	case "scope":
-		return plainRow("Scope", titleCaser.String(asString(val)), "")
+		// The evidence payload carries the raw models.ScopeLevel string; render it
+		// through the same Label() helper the finding card uses (wired as the
+		// `scopeLabel` template func) so the two never disagree, including on the
+		// "Unknown" fallback for a level outside the four constants.
+		return textRow("Scope", models.ScopeLevel(asString(val)).Label(), "")
 	case "namespace":
 		return codeRow("Namespace", asString(val))
 	case "container":
 		return codeRow("Container", asString(val))
 	case "image":
 		img := asString(val)
-		return plainRow("Image", img, mutableImageHint(img))
+		return textRow("Image", img, mutableImageHint(img))
 	case "service_account":
 		return codeRow("ServiceAccount", asString(val))
 	case "hostNetwork", "hostPID", "hostIPC", "privileged",
@@ -444,6 +443,14 @@ func plainRow(label, valueHTML, hint string) string {
 	return b.String()
 }
 
+// textRow emits "Label: value" for a plain-text value. Use this, not plainRow, for
+// anything sourced from a Kubernetes object: a container image reference (or any
+// other analyzer-supplied string) can contain arbitrary characters, and plainRow
+// writes its value argument as raw HTML.
+func textRow(label, value, hint string) string {
+	return plainRow(label, template.HTMLEscapeString(value), hint)
+}
+
 // codeRow emits "Label: <code>value</code>" — the default for short identifiers.
 func codeRow(label, value string) string {
 	if value == "" {
@@ -479,14 +486,18 @@ func boolRow(key string, val any) string {
 	if !ok {
 		return jsonFallbackRow(key, val)
 	}
+	// The chip prints the literal value, but the danger styling and the explanatory
+	// hint follow the field's *risky* state, which is not always `true`. See
+	// trueIsSafeBoolKeys for the inverted fields (runAsNonRoot: false is the finding).
 	state := "false"
-	class := "ev-chip"
 	if bv {
 		state = "true"
-		class += " danger"
 	}
+	risky := bv != trueIsSafeBoolKeys[key]
+	class := "ev-chip"
 	hint := ""
-	if bv {
+	if risky {
+		class += " danger"
 		hint = hostNamespaceHint(key)
 	}
 	var b strings.Builder

--- a/internal/report/evidence_render_test.go
+++ b/internal/report/evidence_render_test.go
@@ -66,6 +66,75 @@ func TestRenderEvidencePodSecHostNetwork(t *testing.T) {
 	}
 }
 
+func TestRenderEvidencePodSecRunAsNonRootPolarity(t *testing.T) {
+	// runAsNonRoot inverts the host*/privileged polarity: false is the violation
+	// (KUBE-PODSEC-ROOT-001), true is the remediated state. The danger chip and the
+	// hint must follow the risky value, not the literal `true`.
+	risky := string(renderEvidence(mustEvidence(t, map[string]any{"runAsNonRoot": false})))
+	if !strings.Contains(risky, "ev-chip danger") {
+		t.Errorf("runAsNonRoot=false is the violation and should render a danger chip, got:\n%s", risky)
+	}
+	if !strings.Contains(risky, "the container can run as UID 0") {
+		t.Errorf("runAsNonRoot=false should surface the UID 0 hint, got:\n%s", risky)
+	}
+	if !strings.Contains(risky, `>false<`) {
+		t.Errorf("chip should still print the literal value, got:\n%s", risky)
+	}
+
+	safe := string(renderEvidence(mustEvidence(t, map[string]any{"runAsNonRoot": true})))
+	if strings.Contains(safe, "danger") {
+		t.Errorf("runAsNonRoot=true is the hardened state and must not render as danger, got:\n%s", safe)
+	}
+	if strings.Contains(safe, "UID 0") {
+		t.Errorf("runAsNonRoot=true should suppress the false-case hint, got:\n%s", safe)
+	}
+}
+
+func TestRenderEvidenceScopeUsesModelLabel(t *testing.T) {
+	// The evidence grid and the finding card must agree on how a ScopeLevel reads,
+	// so both go through models.ScopeLevel.Label() — including its "Unknown" arm.
+	cases := map[string]string{
+		string(models.ScopeCluster):   models.ScopeCluster.Label(),
+		string(models.ScopeNamespace): models.ScopeNamespace.Label(),
+		string(models.ScopeWorkload):  models.ScopeWorkload.Label(),
+		string(models.ScopeObject):    models.ScopeObject.Label(),
+		"workload-group":              "Unknown", // level outside the four constants
+	}
+	for level, want := range cases {
+		out := string(renderEvidence(mustEvidence(t, map[string]any{"scope": level})))
+		if !strings.Contains(out, ">"+want+"<") {
+			t.Errorf("scope %q should render as %q, got:\n%s", level, want, out)
+		}
+	}
+}
+
+func TestRenderEvidenceEscapesAnalyzerStrings(t *testing.T) {
+	// Container images (and every other analyzer-supplied string) are attacker-
+	// controlled: anyone who can create a pod picks the image reference. They must
+	// never reach the report as raw HTML, since renderEvidence returns template.HTML
+	// and nothing downstream re-escapes it.
+	const payload = `nginx<img src=x onerror=alert(1)>`
+	out := string(renderEvidence(mustEvidence(t, map[string]any{
+		"container": "app",
+		"image":     payload,
+	})))
+	if strings.Contains(out, "<img src=x") {
+		t.Errorf("hostile image string was injected as raw HTML:\n%s", out)
+	}
+	if !strings.Contains(out, "nginx&lt;img src=x onerror=alert(1)&gt;") {
+		t.Errorf("expected escaped image string, got:\n%s", out)
+	}
+}
+
+func mustEvidence(t *testing.T, obj map[string]any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal evidence: %v", err)
+	}
+	return raw
+}
+
 func TestRenderEvidencePodSecMutableImage(t *testing.T) {
 	raw, _ := json.Marshal(map[string]any{
 		"container": "app",


### PR DESCRIPTION
Three fixes in `internal/report/evidence_render.go`, all found while reviewing the recent `golang.org/x/text` bump (the bump itself is clean: the v0.37.0 -> v0.40.0 diff in `cases` is comment-only).

## 1. Analyzer-supplied strings reached the report as raw HTML

`plainRow` writes its value argument unescaped, and its doc comment says so: value is HTML, and *"callers must escape any analyzer-supplied content before passing it in."* Two of its nine call sites did not. The `Image` row passed the raw image reference; the `Scope` row passed a title-cased raw string. `renderEvidence` returns `template.HTML`, so `html/template` does not re-escape either one.

A container image reference is attacker-controlled. Anyone who can create a pod picks it, and the Kubernetes API applies no format validation beyond non-empty and no surrounding whitespace. An image such as `nginx<img src=x onerror=...>` is untagged, so it also fires `KUBE-IMAGE-LATEST-001` and is guaranteed to land in the report the operator opens to triage findings.

Before:

```html
<span class="ev-val">nginx<img src=x onerror=alert(1)></span>
```

After:

```html
<span class="ev-val">nginx&lt;img src=x onerror=alert(1)&gt;</span>
```

Fixed by adding `textRow`, which escapes and then delegates to `plainRow`, and routing both call sites through it. The remaining `plainRow` callers already wrap their values in `<code>` + `HTMLEscapeString`, so the escape-first path is now the obvious one for plain text too.

## 2. `boolRow` inverted the verdict for `runAsNonRoot`

`boolRow` applied a single polarity to all six boolean keys it handles: `true` gets the red `danger` chip and the explanatory hint. That is right for `hostNetwork`, `hostPID`, `hostIPC`, `privileged` and `allowPrivilegeEscalation`, but backwards for `runAsNonRoot`, where `false` is the violation (`KUBE-PODSEC-ROOT-001`). The hint text is already written for the false case: *"When false, the container can run as UID 0."*

So `runAsNonRoot: true`, the hardened state, rendered as a red danger chip captioned with the false-case warning, while `runAsNonRoot: false` rendered neutral grey with the hint suppressed.

The branch is wired live (`renderEvidenceRow` case, `orderedEvidenceKeys` priority list) but currently unfed, since no analyzer puts that key in `Evidence` yet. The first one to do so would have shipped an inverted verdict silently.

Fixed by splitting the printed value from the risk state: `risky := bv != trueIsSafeBoolKeys[key]`. Keys absent from the map keep the true-is-bad default, so adding an inverted field later (`readOnlyRootFilesystem`, say) is a one-line map entry.

## 3. Scope rendered two different ways in the same card

The evidence grid title-cased the raw `ScopeLevel` string with `x/text`; the finding card three lines up renders the same field through `models.ScopeLevel.Label()` (the `scopeLabel` template func). They agree on today's `cluster` and `namespace` values, but `Label()` has a `default: "Unknown"` arm and `cases.Title` has no notion of a known-value set, so any other level renders as `Scope · Unknown` on the card and `Scope: Workload-Group` in the grid below it.

Fixed by using `Label()` in both places. That was the only consumer of `golang.org/x/text` in the repo, so `go mod tidy` demotes it to `// indirect` (k8s libs still pull it in). `go.sum` is unchanged.

## Tests

`titleCaser` was the only `x/text` consumer and had no assertions on it anywhere: `scope` appeared in `internal/report/*_test.go` exactly once, as an input. There are no golden HTML files under `internal/report`, `make corpus` scores rule IDs in-process, and `scripts/kind-e2e.sh` asserts rule-ID sets from `findings.json`, so a `cases.Title` behavior change would have shipped green.

Three new cases close that gap: HTML escaping of a hostile image string, the `runAsNonRoot` polarity in both states, and every `ScopeLevel` plus the `Unknown` fallback. I stashed the fixes and reran them against the old code: all three fail, so they gate the actual behavior rather than restating it.

`make test`, `make lint`, `make corpus` and `./bin/golangci-lint run ./...` are clean. `make e2e` was not run locally (no Docker daemon); no rule IDs changed, so the `*.ruleset` goldens are unaffected.
