### PR TITLE
feat(release): krew-release-bot automation and krew install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,11 @@ jobs:
             ${{ steps.notes.outputs.notes-file && format('--release-notes {0}', steps.notes.outputs.notes-file) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Renders .krew.yaml against the assets GoReleaser just published and
+      # opens a version-bump PR on kubernetes-sigs/krew-index. Needs no
+      # secrets: the bot verifies the public release and PRs from its own
+      # fork. Fails (without blocking the release) if the plugin is not yet
+      # in the index.
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.51

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,102 @@
+# krew-release-bot template. On every v* release, the release workflow's
+# krew-release-bot step renders this with the new tag and opens a version-bump
+# PR against kubernetes-sigs/krew-index automatically.
+#
+# {{ .TagName }} is the git tag (v1.2.0); archive filenames use the bare
+# version (1.2.0), hence {{ slice .TagName 1 }} inside the asset URLs.
+#
+# Test-render locally:
+#   docker run -v $(pwd)/.krew.yaml:/tmp/template-file.yaml \
+#     ghcr.io/rajatjindal/krew-release-bot:v0.0.47 \
+#     krew-release-bot template --tag v1.2.0 --template-file /tmp/template-file.yaml
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: kubesplaining
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/0hardik1/kubesplaining
+  shortDescription: Scan for security risks and RBAC escalation paths
+  description: |
+    Kubesplaining scans a Kubernetes cluster (live, or offline from a
+    snapshot file) and emits scored security findings as HTML, JSON, CSV,
+    or SARIF.
+
+    Its differentiator is an RBAC privilege-escalation graph: it searches
+    from every subject toward sinks such as cluster-admin, kube-system
+    secrets, node escape, and token minting, and reports the full hop
+    chain for each route it finds, including whether the route survives
+    the recommended fix.
+
+    Additional analyzers cover overbroad RBAC grants, pod security
+    (privileged containers, host namespaces, hostPath), NetworkPolicy
+    coverage, admission webhook weaknesses, secret and ConfigMap
+    exposure, service-account token handling, certificate-signing abuse,
+    and EKS-specific IAM mappings. Raw Secret values are never read, and
+    ConfigMap values are redacted at collection time.
+  caveats: |
+    This plugin needs read (get/list) access to the RBAC, workload, and
+    policy APIs it inspects. Forbidden resources are skipped and recorded
+    as collection warnings, so partial scans of locked-down clusters
+    still work.
+
+    Quick start:
+      kubectl kubesplaining scan
+      kubectl kubesplaining download -o snapshot.json
+      kubectl kubesplaining scan --input-file snapshot.json
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/0hardik1/kubesplaining/releases/download/{{ .TagName }}/kubesplaining_{{ slice .TagName 1 }}_Darwin_arm64.tar.gz" .TagName }}
+    bin: kubesplaining
+    files:
+    - from: kubesplaining
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/0hardik1/kubesplaining/releases/download/{{ .TagName }}/kubesplaining_{{ slice .TagName 1 }}_Darwin_x86_64.tar.gz" .TagName }}
+    bin: kubesplaining
+    files:
+    - from: kubesplaining
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/0hardik1/kubesplaining/releases/download/{{ .TagName }}/kubesplaining_{{ slice .TagName 1 }}_Linux_arm64.tar.gz" .TagName }}
+    bin: kubesplaining
+    files:
+    - from: kubesplaining
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/0hardik1/kubesplaining/releases/download/{{ .TagName }}/kubesplaining_{{ slice .TagName 1 }}_Linux_x86_64.tar.gz" .TagName }}
+    bin: kubesplaining
+    files:
+    - from: kubesplaining
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/0hardik1/kubesplaining/releases/download/{{ .TagName }}/kubesplaining_{{ slice .TagName 1 }}_Windows_x86_64.zip" .TagName }}
+    bin: kubesplaining.exe
+    files:
+    - from: kubesplaining.exe
+      to: .
+    - from: LICENSE
+      to: .

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -39,11 +39,6 @@ spec:
     policy APIs it inspects. Forbidden resources are skipped and recorded
     as collection warnings, so partial scans of locked-down clusters
     still work.
-
-    Quick start:
-      kubectl kubesplaining scan
-      kubectl kubesplaining download -o snapshot.json
-      kubectl kubesplaining scan --input-file snapshot.json
   platforms:
   - selector:
       matchLabels:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ make scan
 
 `make scan` builds the binary (Hermit auto-downloads the pinned Go toolchain) and runs it against your current `kubectl` context in one step.
 
-See [Installation](#installation) below for `go install`, pre-built binaries, and checksums.
+See [Installation](#installation) below for krew, `go install`, pre-built binaries, and checksums.
 
 ## vs the alternatives
 
@@ -88,7 +88,18 @@ kubesplaining scan-resource --input-file deployment.yaml
 
 ## Installation
 
-Pick the path that fits. They all produce the same `kubesplaining` CLI. The top of this README covers the from-clone path; this section adds Go install, pre-built binaries, and Docker.
+Pick the path that fits. They all produce the same `kubesplaining` CLI. The top of this README covers the from-clone path; this section adds krew, Go install, pre-built binaries, and Docker.
+
+### kubectl krew
+
+Install as a `kubectl` plugin via [Krew](https://krew.sigs.k8s.io/):
+
+```bash
+kubectl krew install kubesplaining
+kubectl kubesplaining scan
+```
+
+Every command in this README works the same way behind `kubectl`, e.g. `kubectl kubesplaining scan --input-file snapshot.json`.
 
 ### Go install
 


### PR DESCRIPTION
Companion to the krew-index submission kubernetes-sigs/krew-index#6167. Three pieces:

- **`.krew.yaml`**: krew-release-bot template. Archive filenames use the bare version while the bot only exposes `{{ .TagName }}`, so the asset URLs strip the `v` with the text/template built-in `slice`. Validated by rendering the template with the bot's own `template` command against the real v1.2.0 release assets: the output matches the manifest submitted to krew-index exactly (URIs and sha256s).
- **`release.yml`**: a krew-release-bot step after GoReleaser, so every future `v*` tag automatically opens the version-bump PR on krew-index. No secrets needed; the bot verifies the public release and PRs from its own fork.
- **README**: restores the krew install snippet that was dropped pending submission.

Merge ordering: hold this until kubernetes-sigs/krew-index#6167 lands, otherwise the README advertises an install path that does not resolve yet (and the bot step fails on the next tag until the plugin exists in the index).

The submitted manifest was also verified end to end with a local `krew install --manifest`: archive downloads, sha256 verifies, and the installed binary passes `version` and an offline `scan-resource` on darwin/arm64.