### PR TITLE
docs(readme): add krew version badge, drop retired Go Report Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Kubesplaining
 
 [![Latest release](https://img.shields.io/github/v/release/0hardik1/kubesplaining?include_prereleases&sort=semver)](https://github.com/0hardik1/kubesplaining/releases)
+[![Krew](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkubernetes-sigs%2Fkrew-index%2Fmaster%2Fplugins%2Fkubesplaining.yaml&query=%24.spec.version&label=krew&logo=kubernetes&logoColor=white)](https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/kubesplaining.yaml)
 [![License](https://img.shields.io/github/license/0hardik1/kubesplaining)](LICENSE)
 [![CI](https://github.com/0hardik1/kubesplaining/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/0hardik1/kubesplaining/actions/workflows/lint.yml)
 [![Go version](https://img.shields.io/github/go-mod/go-version/0hardik1/kubesplaining)](go.mod)
-[![Go Report Card](https://goreportcard.com/badge/github.com/0hardik1/kubesplaining)](https://goreportcard.com/report/github.com/0hardik1/kubesplaining)
 
 Kubesplaining is an open-source Kubernetes security assessment CLI that reads a live cluster or a captured snapshot and tells you exactly how an attacker can move through it. Unlike scanners that stop at "this resource is misconfigured," it builds a multi-hop RBAC privilege-escalation graph from every non-system subject to four cluster-takeover sinks (`cluster-admin`, `system:masters`, `node-escape`, `kube-system-secrets`) and renders each chain with the actual verbs, evidence, and remediation. Outputs are risk-prioritized HTML, JSON, CSV, and SARIF reports for human review, GitHub code scanning, or CI delta gates.
 


### PR DESCRIPTION
## What

- Adds a krew badge to the README badge row. It is a shields.io dynamic YAML badge that reads `spec.version` from the krew-index manifest, so it updates automatically when krew-release-bot bumps the index. It currently renders `krew | v1.2.0`.
- Removes the Go Report Card badge. The goreportcard.com service is retired.

## Notes

- The badge links to the manifest in kubernetes-sigs/krew-index for now. The plugin page on krew.sigs.k8s.io still returns 404 (the site has not regenerated since the index PR merged). Swap the link to https://krew.sigs.k8s.io/plugins/kubesplaining/ once that page is live.
- A repo-wide search found no other goreportcard references.